### PR TITLE
Asynchronous function invocation support

### DIFF
--- a/cel/BUILD.bazel
+++ b/cel/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//common/types/ref:go_default_library",
         "//common/types/traits:go_default_library",
         "//interpreter/functions:go_default_library",
+        "//test:go_default_library",
         "//test/proto2pb:go_default_library",
         "//test/proto3pb:go_default_library",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",

--- a/cel/env.go
+++ b/cel/env.go
@@ -307,14 +307,13 @@ func (e *Env) ParseSource(src common.Source) (*Ast, *Issues) {
 
 // Program generates an evaluable instance of the Ast within the environment (Env).
 func (e *Env) Program(ast *Ast, opts ...ProgramOption) (Program, error) {
-	optSet := e.progOpts
-	if len(opts) != 0 {
-		mergedOpts := []ProgramOption{}
-		mergedOpts = append(mergedOpts, e.progOpts...)
-		mergedOpts = append(mergedOpts, opts...)
-		optSet = mergedOpts
-	}
-	return newProgram(e, ast, optSet)
+	return e.newProgram(ast, opts /* async= */, false)
+}
+
+// AsyncProgram generates an evaluable instance of the Ast with support for asynchronous extension
+// functions.
+func (e *Env) AsyncProgram(ast *Ast, opts ...ProgramOption) (AsyncProgram, error) {
+	return e.newProgram(ast, opts /* async= */, true)
 }
 
 // SetFeature sets the given feature flag, as enumerated in options.go.
@@ -427,8 +426,8 @@ func (i *Issues) Err() error {
 	if i == nil {
 		return nil
 	}
-	if len(i.errs.GetErrors()) > 0 {
-		return errors.New(i.errs.ToDisplayString())
+	if len(i.Errors()) > 0 {
+		return errors.New(i.String())
 	}
 	return nil
 }

--- a/common/types/ref/provider.go
+++ b/common/types/ref/provider.go
@@ -101,3 +101,11 @@ type FieldTester func(target interface{}) bool
 
 // FieldGetter is used to get the field value from an input object, if set.
 type FieldGetter func(target interface{}) (interface{}, error)
+
+// Resolver abstracts variable and type identifier resolution behind a single interface
+// method.
+type Resolver interface {
+	// ResolveName returns the value associated with the given fully qualified name, if
+	// present.
+	ResolveName(name string) (interface{}, bool)
+}

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "activation.go",
+        "async.go",
         "attributes.go",
         "attribute_patterns.go",
         "decorators.go",
@@ -42,6 +43,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "activation_test.go",
+        "async_test.go",
         "attributes_test.go",
         "attribute_patterns_test.go",
         "interpreter_test.go",

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -37,9 +37,7 @@ type Activation interface {
 
 // EmptyActivation returns a variable free activation.
 func EmptyActivation() Activation {
-	// This call cannot fail.
-	a, _ := NewActivation(map[string]interface{}{})
-	return a
+	return emptyActivation
 }
 
 // NewActivation returns an activation based on a map-based binding where the map keys are
@@ -197,6 +195,9 @@ func (v *varActivation) ResolveName(name string) (interface{}, bool) {
 }
 
 var (
+	// emptyActivation is a singleton activation which provides no input
+	emptyActivation = &mapActivation{bindings: map[string]interface{}{}}
+
 	// pool of var activations to reduce allocations during folds.
 	varActivationPool = &sync.Pool{
 		New: func() interface{} {

--- a/interpreter/async.go
+++ b/interpreter/async.go
@@ -1,0 +1,244 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter/functions"
+)
+
+// AsyncInterpretable supports evaluation with async extension functions.
+type AsyncInterpretable interface {
+	// ID of the interpretable expression.
+	ID() int64
+
+	// AsyncEval drives the evaluation of an Interpretable program which may invoke asynchronous
+	// calls.
+	AsyncEval(context.Context, *AsyncActivation) ref.Val
+}
+
+// asyncEval is the default implementation of the AsyncInterpretable interface.
+type asyncEval struct {
+	Interpretable
+}
+
+// AsyncEval implements the AsyncInterpretable interface method and applies the following
+// algorithm:
+//
+// - Evaluate synchronously. If the result is not of types.Unkonwn, return the result.
+// - Otherwise for each unknown value determine if the expression id maps to the expression id
+//   of an async call.
+// - For each async call and unique argument set found, invoke the async implementation.
+// - Async call results are memoized with their corresponding argument sets.
+// - Revaluate synchronously. Repeat if unknowns are still present and progress (at least one
+//   async call invocation has been made).
+//
+// The process of incremental evaluation may be strictly more expensive than some alternative
+// approaches; however, the async call is expected to dominate the execution time by several
+// orders of magnitude.
+func (async *asyncEval) AsyncEval(ctx context.Context, vars *AsyncActivation) ref.Val {
+	res := async.Interpretable.Eval(vars)
+	for types.IsUnknown(res) {
+		progress := false
+		unk := res.(types.Unknown)
+		for _, id := range unk {
+			call, found := vars.findCall(id)
+			if !found {
+				continue
+			}
+			call.evals.Range(func(idx, rawArgs interface{}) bool {
+				asyncResult, hasResult := call.results.Load(idx)
+				if hasResult {
+					return true
+				}
+				progress = true
+				args := rawArgs.([]ref.Val)
+				asyncResult = call.impl(ctx, vars, args)
+				call.results.Store(idx, asyncResult)
+				return false
+			})
+		}
+		if !progress {
+			break
+		}
+		res = async.Interpretable.Eval(vars)
+	}
+	return res
+}
+
+// NewAsyncActivation returns an AsyncActivation capable of tracking async calls relevant to a
+// single evaluation pass through an AsyncInterpretable object.
+//
+func NewAsyncActivation(vars Activation) *AsyncActivation {
+	return &AsyncActivation{Activation: vars}
+}
+
+// AsyncActivation tracks calls by expression identifier and overload name for use in subsequent
+// async function invocations when the result cannot be computed without context provided by the
+// remote call.
+//
+// Note, this object is concurrency safe, but should not be reused across invocations.
+type AsyncActivation struct {
+	Activation
+	asyncCalls sync.Map // map[int64]*asyncCall
+}
+
+// findCall returns an async call matching the given expression id, if any.
+func (act *AsyncActivation) findCall(id int64) (*asyncCall, bool) {
+	call, found := act.asyncCalls.Load(id)
+	if found {
+		return call.(*asyncCall), true
+	}
+	return nil, false
+}
+
+// findCallbyOverload returns an async call matching the given overload identifer, if any.
+//
+// Note, the same overload may be referenced in multiple locations within the expression.
+// This call will return the first instance of the call evaluated for the purpose of aggregating
+// related arugments sets to the underlying function and deduping them.
+func (act *AsyncActivation) findCallByOverload(overload string) (*asyncCall, bool) {
+	var call *asyncCall
+	act.asyncCalls.Range(func(_, ac interface{}) bool {
+		asyncCall := ac.(*asyncCall)
+		if asyncCall.overload == overload {
+			call = asyncCall
+			return false
+		}
+		return true
+	})
+	if call != nil {
+		return call, true
+	}
+	return nil, false
+}
+
+// putCall stores the asyncCall by its expression id.
+func (act *AsyncActivation) putCall(id int64, call *asyncCall) {
+	act.asyncCalls.Store(id, call)
+}
+
+// newAsyncCall creates a new asyncCall instance capable of tracking argument sets to the call.
+func newAsyncCall(id int64, overload string, impl functions.AsyncOp) *asyncCall {
+	var idx int32
+	return &asyncCall{
+		id:          id,
+		overload:    overload,
+		impl:        impl,
+		nextCallIdx: &idx,
+	}
+}
+
+// asyncCall tracks argument sets and associated results for a given async call.
+type asyncCall struct {
+	id          int64
+	impl        functions.AsyncOp
+	overload    string
+	nextCallIdx *int32
+	evals       sync.Map // [][]ref.Val
+	results     sync.Map // []ref.Val
+}
+
+// Eval implements the Interpretable interface method, tracks argument sets, and returns memoized
+// results, if present.
+func (ac *asyncCall) Eval(args []ref.Val) ref.Val {
+	argsFound := false
+	idx := atomic.LoadInt32(ac.nextCallIdx)
+	ac.evals.Range(func(i, rawArgs interface{}) bool {
+		asyncArgs := rawArgs.([]ref.Val)
+		for j, arg := range args {
+			if arg.Equal(asyncArgs[j]) != types.True {
+				return true
+			}
+		}
+		idx = i.(int32)
+		argsFound = true
+		return false
+	})
+	val, resultFound := ac.results.Load(idx)
+	// args found and there's a result, return it.
+	if resultFound {
+		return val.(ref.Val)
+	}
+	// args found, but no result yet, return unknown.
+	if argsFound {
+		return types.Unknown{ac.id}
+	}
+	// Args not tracked, track them here.
+	swapped := false
+	for !swapped {
+		swapped = atomic.CompareAndSwapInt32(ac.nextCallIdx, idx, idx+1)
+		idx++
+	}
+	ac.evals.Store(idx, args)
+	return types.Unknown{ac.id}
+}
+
+// evalAsyncCall implements the InterpretableCall interface and is the entry point into async
+// function evaluation coordination.
+type evalAsyncCall struct {
+	id       int64
+	function string
+	overload string
+	args     []Interpretable
+	impl     functions.AsyncOp
+}
+
+// ID returns the expression identifier where the call is referenced.
+func (async *evalAsyncCall) ID() int64 {
+	return async.id
+}
+
+// Function implements the InterpretableCall interface method.
+func (async *evalAsyncCall) Function() string {
+	return async.function
+}
+
+// OverloadID implements the InterpretableCall interface method.
+func (async *evalAsyncCall) OverloadID() string {
+	return async.overload
+}
+
+// Args returns the argument to the unary function.
+func (async *evalAsyncCall) Args() []Interpretable {
+	return async.args
+}
+
+// Eval tracks the arguments provided to the underlying async invocation, deduping argument sets
+// if possible.
+func (async *evalAsyncCall) Eval(vars Activation) ref.Val {
+	argVals := make([]ref.Val, len(async.args), len(async.args))
+	// Early return if any argument to the function is unknown or error.
+	for i, arg := range async.args {
+		argVals[i] = arg.Eval(vars)
+		if types.IsUnknownOrError(argVals[i]) {
+			return argVals[i]
+		}
+	}
+	// Attempt to return the result if one exists. Note, this can be pretty expensive,
+	// but presumably cheaper than actually invoking the async call.
+	asyncVars := vars.(*AsyncActivation)
+	calls, found := asyncVars.findCallByOverload(async.overload)
+	if !found {
+		calls = newAsyncCall(async.id, async.overload, async.impl)
+	}
+	asyncVars.putCall(async.id, calls)
+	return calls.Eval(argVals)
+}

--- a/interpreter/async_test.go
+++ b/interpreter/async_test.go
@@ -1,0 +1,203 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/test"
+)
+
+func TestAsyncEval_CallTracking(t *testing.T) {
+	var tests = []struct {
+		lhs         ref.Val
+		lhsOverload string
+		lhsTimeout  time.Duration
+		rhs         ref.Val
+		rhsOverload string
+		rhsTimeout  time.Duration
+		in          map[string]interface{}
+		out         ref.Val
+	}{
+		{
+			lhs:         types.String("x success!"),
+			lhsTimeout:  50 * time.Millisecond,
+			lhsOverload: "same_async",
+			rhs:         types.String("y success!"),
+			rhsTimeout:  50 * time.Millisecond,
+			rhsOverload: "same_async",
+			in:          map[string]interface{}{"x": "x", "y": "y"},
+			out:         types.True,
+		},
+		{
+			lhs:         types.String("x success!"),
+			lhsTimeout:  50 * time.Millisecond,
+			lhsOverload: "same_async",
+			rhs:         types.String("y success!"),
+			rhsTimeout:  1 * time.Millisecond,
+			rhsOverload: "alt_async",
+			in:          map[string]interface{}{"x": "x", "y": "y"},
+			out:         types.True,
+		},
+		{
+			lhs:         types.String("x success!"),
+			lhsTimeout:  1 * time.Millisecond,
+			lhsOverload: "alt_async",
+			rhs:         types.String("y success!"),
+			rhsTimeout:  50 * time.Millisecond,
+			rhsOverload: "same_async",
+			in:          map[string]interface{}{"x": "x", "y": "y"},
+			out:         types.True,
+		},
+		{
+			lhs:         types.String("x success!"),
+			lhsTimeout:  1 * time.Millisecond,
+			lhsOverload: "alt_async",
+			rhs:         types.String("y success!"),
+			rhsTimeout:  50 * time.Millisecond,
+			rhsOverload: "same_async",
+			in:          map[string]interface{}{"x": "x", "y": "not y"},
+			out:         types.NewErr("context deadline exceeded"),
+		},
+		{
+			lhs:        types.String("x success!"),
+			rhs:        types.String("y success!"),
+			lhsTimeout: 1 * time.Millisecond,
+			rhsTimeout: 1 * time.Millisecond,
+			in:         map[string]interface{}{"x": "x", "y": "y"},
+			out:        types.NewErr("context deadline exceeded"),
+		},
+		{
+			lhs:        types.Unknown{42},
+			lhsTimeout: 50 * time.Millisecond,
+			rhs:        types.String("y success!"),
+			rhsTimeout: 50 * time.Millisecond,
+			in:         map[string]interface{}{"x": "x", "y": "y"},
+			out:        types.True,
+		},
+		{
+			lhs:        types.Unknown{42},
+			lhsTimeout: 50 * time.Millisecond,
+			rhs:        types.String("y success!"),
+			rhsTimeout: 50 * time.Millisecond,
+			in:         map[string]interface{}{"x": "x", "y": "z"},
+			out:        types.Unknown{42},
+		},
+		{
+			lhs:         types.String("x success!"),
+			lhsTimeout:  50 * time.Millisecond,
+			lhsOverload: "same_async",
+			rhs:         types.String("x success!"),
+			rhsTimeout:  50 * time.Millisecond,
+			rhsOverload: "same_async",
+			in:          map[string]interface{}{"x": "x", "y": "x"},
+			out:         types.True,
+		},
+		{
+			lhs:         types.String("x success!"),
+			lhsTimeout:  50 * time.Millisecond,
+			lhsOverload: "same_async",
+			rhs:         types.String(" success!"),
+			rhsTimeout:  50 * time.Millisecond,
+			rhsOverload: "same_async",
+			in: map[string]interface{}{
+				"x": types.Unknown{42},
+				"y": "not y",
+			},
+			out: types.Unknown{42},
+		},
+		{
+			lhs:         types.String("x success!"),
+			lhsTimeout:  50 * time.Millisecond,
+			lhsOverload: "same_async",
+			rhs:         types.String("y success!"),
+			rhsTimeout:  50 * time.Millisecond,
+			rhsOverload: "same_async",
+			in: map[string]interface{}{
+				"x": types.Unknown{42},
+				"y": "y",
+			},
+			out: types.True,
+		},
+	}
+	xVar := &absoluteAttribute{
+		id:             2,
+		namespaceNames: []string{"x"},
+	}
+	yVar := &absoluteAttribute{
+		id:             4,
+		namespaceNames: []string{"y"},
+	}
+
+	for i, tst := range tests {
+		tc := tst
+		t.Run(fmt.Sprintf("%d", i), func(tt *testing.T) {
+			testX := makeTestEq(6,
+				tc.lhsOverload, xVar, NewConstValue(8, tc.lhs), tc.lhsTimeout)
+			testY := makeTestEq(10,
+				tc.rhsOverload, yVar, NewConstValue(12, tc.rhs), tc.rhsTimeout)
+			logic := &evalOr{
+				id:  14,
+				lhs: testX,
+				rhs: testY,
+			}
+			async := &asyncEval{Interpretable: logic}
+			in, err := NewActivation(tc.in)
+			if err != nil {
+				tt.Fatal(err)
+			}
+			vars := NewAsyncActivation(in)
+			ctx := context.TODO()
+			out := async.AsyncEval(ctx, vars)
+			if !reflect.DeepEqual(out, tc.out) {
+				tt.Errorf("got %v, wanted %v", out, tc.out)
+			}
+			outCached := async.AsyncEval(ctx, vars)
+			if !reflect.DeepEqual(out, outCached) {
+				tt.Errorf("got %v, wanted %v", outCached, out)
+			}
+		})
+	}
+}
+
+func makeTestEq(id int64,
+	overload string,
+	arg Attribute,
+	value Interpretable,
+	timeout time.Duration) Interpretable {
+	test := &evalAsyncCall{
+		id:       id,
+		function: "asyncEcho",
+		overload: overload,
+		args: []Interpretable{
+			&evalAttr{
+				attr:    arg,
+				adapter: types.DefaultTypeAdapter,
+			},
+		},
+		impl: test.FakeRPC(timeout),
+	}
+	return &evalEq{
+		id:  id + 1,
+		lhs: test,
+		rhs: value,
+	}
+}

--- a/interpreter/functions/functions.go
+++ b/interpreter/functions/functions.go
@@ -16,7 +16,11 @@
 // interpreter and as declared within the checker#StandardDeclarations.
 package functions
 
-import "github.com/google/cel-go/common/types/ref"
+import (
+	"context"
+
+	"github.com/google/cel-go/common/types/ref"
+)
 
 // Overload defines a named overload of a function, indicating an operand trait
 // which must be present on the first argument to the overload as well as one
@@ -27,8 +31,7 @@ import "github.com/google/cel-go/common/types/ref"
 // types with operator overloads. Any added complexity is assumed to be handled
 // by the generic FunctionOp.
 type Overload struct {
-	// Operator name as written in an expression or defined within
-	// operators.go.
+	// Operator name as written in an expression or defined within operators.go.
 	Operator string
 
 	// Operand trait used to dispatch the call. The zero-value indicates a
@@ -42,17 +45,21 @@ type Overload struct {
 	// Binary defines the overload with a BinaryOp implementation. May be nil.
 	Binary BinaryOp
 
-	// Function defines the overload with a FunctionOp implementation. May be
-	// nil.
+	// Function defines the overload with a FunctionOp implementation. May be nil.
 	Function FunctionOp
+
+	// Async defines an overload with an AsyncOp implementation. May be nil.
+	Async AsyncOp
 }
 
-// UnaryOp is a function that takes a single value and produces an output.
-type UnaryOp func(value ref.Val) ref.Val
+// UnaryOp is a function that takes a single argument.
+type UnaryOp func(ref.Val) ref.Val
 
-// BinaryOp is a function that takes two values and produces an output.
-type BinaryOp func(lhs ref.Val, rhs ref.Val) ref.Val
+// BinaryOp is a function that takes two arguments.
+type BinaryOp func(ref.Val, ref.Val) ref.Val
 
-// FunctionOp is a function with accepts zero or more arguments and produces
-// an value (as interface{}) or error as a result.
-type FunctionOp func(values ...ref.Val) ref.Val
+// FunctionOp is a function with accepts zero or more arguments.
+type FunctionOp func(...ref.Val) ref.Val
+
+// AsyncOp is an asynchronous function which accepts a Context value and arguments.
+type AsyncOp func(context.Context, ref.Resolver, []ref.Val) ref.Val

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 package(
     default_visibility = [
+        "//cel:__subpackages__",
         "//checker:__subpackages__",
         "//common:__subpackages__",
         "//interpreter:__subpackages__",
@@ -14,12 +15,16 @@ package(
 go_library(
     name = "go_default_library",
     srcs = [
+        "async.go",
         "compare.go",
         "expr.go",
     ],
     importpath = "github.com/google/cel-go/test",
     deps = [
       "//common/operators:go_default_library",
+      "//common/types:go_default_library",
+      "//common/types/ref:go_default_library",
+      "//interpreter/functions:go_default_library",
       "@com_github_golang_protobuf//proto:go_default_library",
       "@io_bazel_rules_go//proto/wkt:struct_go_proto",
       "@org_golang_google_genproto//googleapis/api/expr/v1alpha1:go_default_library",

--- a/test/async.go
+++ b/test/async.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter/functions"
+)
+
+func FakeRPC(timeout time.Duration) functions.AsyncOp {
+	return func(ctx context.Context, vars ref.Resolver, args []ref.Val) ref.Val {
+		rpcCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		time.Sleep(20 * time.Millisecond)
+		select {
+		case <-rpcCtx.Done():
+			return types.NewErr(rpcCtx.Err().Error())
+		default:
+			in := args[0].(types.String)
+			return in.Add(types.String(" success!"))
+		}
+	}
+}


### PR DESCRIPTION
The PR introduces support for asynchronous functions as CEL extensions.

The general algorithm for evaluation relies on the `types.Unknown` value to indicate when
async calls relevant to the outcome of an expression. Async calls arguments are tracked,
deduped, and memoized based on the overload id associated with the implementation. 

It is possible to use partial state evaluation with async evaluation, though async calls will
be resolved before any unknown attribute patterns. Using both features together may be
inefficient; however, there is a general expectation that async function implementations may
implement their own caching logic in order to handle repeated invocations of the same
async function with the same arguments.