### PR TITLE
ext: Rename go_strings_library target to go_default_library

### DIFF
--- a/ext/BUILD.bazel
+++ b/ext/BUILD.bazel
@@ -5,7 +5,7 @@ package(
 )
 
 go_library(
-    name = "go_strings_library",
+    name = "go_default_library",
     srcs = [
         "encoders.go",
         "guards.go",
@@ -31,7 +31,7 @@ go_test(
         "strings_test.go",
     ],
     embed = [
-        ":go_strings_library",
+        ":go_default_library",
     ],
     deps = [
         "//cel:go_default_library",


### PR DESCRIPTION
Hi team, this PR renames the `//ext:go_strings_library` Bazel target to `//ext:go_default_library`. If we are concerned about backwards compatibility, we alternatively add an `alias` rule instead.

The `go_default_library` target name is the default name generated by Gazelle and is also the name used by all other `go_library` targets in this package. Other than being conventional, this custom named target makes using the `ext` package transitively by other packages ([example](https://github.com/caddyserver/caddy/blob/be5f77e84da941d32eb1b873d355bfc1a186304b/modules/caddyhttp/celmatcher.go#L34)) difficult. This is because Gazelle generates deps that assume the `go_default_library` target name, so to work around this we would need to supply a patch file for this repository that adds an alias in.
