### PR TITLE
Bug fixes for type-santization and abstract types.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -112,7 +112,8 @@ func (c *checker) check(e *exprpb.Expr) {
 	case *exprpb.Expr_ComprehensionExpr:
 		c.checkComprehension(e)
 	default:
-		panic(fmt.Sprintf("Unrecognized ast type: %v", reflect.TypeOf(e)))
+		c.errors.ReportError(
+			c.location(e), "Unrecognized ast type: %v", reflect.TypeOf(e))
 	}
 }
 
@@ -572,7 +573,9 @@ func (c *checker) lookupFieldType(l common.Location, messageType string, fieldNa
 
 func (c *checker) setType(e *exprpb.Expr, t *exprpb.Type) {
 	if old, found := c.types[e.Id]; found && !proto.Equal(old, t) {
-		panic(fmt.Sprintf("(Incompatible) Type already exists for expression: %v(%d) old:%v, new:%v", e, e.Id, old, t))
+		c.errors.ReportError(c.location(e),
+			"(Incompatible) Type already exists for expression: %v(%d) old:%v, new:%v", e, e.GetId(), old, t)
+		return
 	}
 	c.types[e.Id] = t
 }
@@ -583,7 +586,9 @@ func (c *checker) getType(e *exprpb.Expr) *exprpb.Type {
 
 func (c *checker) setReference(e *exprpb.Expr, r *exprpb.Reference) {
 	if old, found := c.references[e.Id]; found && !proto.Equal(old, r) {
-		panic(fmt.Sprintf("Reference already exists for expression: %v(%d) old:%v, new:%v", e, e.Id, old, r))
+		c.errors.ReportError(c.location(e),
+			"Reference already exists for expression: %v(%d) old:%v, new:%v", e, e.Id, old, r)
+		return
 	}
 	c.references[e.Id] = r
 }

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1564,6 +1564,114 @@ _&&_(_==_(list~type(list(dyn))^list,
 		)~string^base64_encode_string`,
 		Type: decls.String,
 	},
+	{
+		I:    `{}`,
+		R:    `{}~map(dyn, dyn)`,
+		Type: decls.NewMapType(decls.Dyn, decls.Dyn),
+	},
+	{
+		I: `set([1, 2, 3])`,
+		R: `
+		set(
+		  [
+		    1~int,
+		    2~int,
+		    3~int
+		  ]~list(int)
+		)~abstract_type:{name:"set" parameter_types:{primitive:INT64}}^set_list`,
+		Env: env{
+			functions: []*exprpb.Decl{
+				decls.NewFunction("set",
+					decls.NewParameterizedOverload(
+						"set_list", []*exprpb.Type{
+							decls.NewListType(decls.NewTypeParamType("T")),
+						}, decls.NewAbstractType("set", decls.NewTypeParamType("T")),
+						[]string{"T"})),
+			},
+		},
+		Type: decls.NewAbstractType("set", decls.Int),
+	},
+	{
+		I: `set([1, 2]) == set([2, 1])`,
+		R: `
+		_==_(
+		  set([1~int, 2~int]~list(int))~abstract_type:{name:"set" parameter_types:{primitive:INT64}}^set_list,
+		  set([2~int, 1~int]~list(int))~abstract_type:{name:"set" parameter_types:{primitive:INT64}}^set_list
+		)~bool^equals`,
+		Env: env{
+			functions: []*exprpb.Decl{
+				decls.NewFunction("set",
+					decls.NewParameterizedOverload(
+						"set_list", []*exprpb.Type{
+							decls.NewListType(decls.NewTypeParamType("T")),
+						}, decls.NewAbstractType("set", decls.NewTypeParamType("T")),
+						[]string{"T"})),
+			},
+		},
+		Type: decls.Bool,
+	},
+	{
+		I: `set([1, 2]) == x`,
+		R: `
+		_==_(
+		  set([1~int, 2~int]~list(int))~abstract_type:{name:"set" parameter_types:{primitive:INT64}}^set_list,
+		  x~abstract_type:{name:"set" parameter_types:{primitive:INT64}}^x
+		)~bool^equals`,
+		Env: env{
+			idents: []*exprpb.Decl{
+				decls.NewVar("x", decls.NewAbstractType("set", decls.NewTypeParamType("T"))),
+			},
+			functions: []*exprpb.Decl{
+				decls.NewFunction("set",
+					decls.NewParameterizedOverload(
+						"set_list", []*exprpb.Type{
+							decls.NewListType(decls.NewTypeParamType("T")),
+						}, decls.NewAbstractType("set", decls.NewTypeParamType("T")),
+						[]string{"T"})),
+			},
+		},
+		Type: decls.Bool,
+	},
+	{
+		I: `int{}`,
+		Error: `
+		ERROR: <input>:1:4: 'int' is not a message type
+		 | int{}
+		 | ...^
+		`,
+	},
+	{
+		I: `Msg{}`,
+		Error: `
+		ERROR: <input>:1:4: undeclared reference to 'Msg' (in container '')
+		 | Msg{}
+		 | ...^
+		`,
+	},
+	{
+		I: `fun()`,
+		Error: `
+		ERROR: <input>:1:4: undeclared reference to 'fun' (in container '')
+		 | fun()
+		 | ...^
+		`,
+	},
+	{
+		I: `'string'.fun()`,
+		Error: `
+		ERROR: <input>:1:13: undeclared reference to 'fun' (in container '')
+		 | 'string'.fun()
+		 | ............^
+		`,
+	},
+	{
+		I: `[].length`,
+		Error: `
+		ERROR: <input>:1:3: type 'list_type:{elem_type:{type_param:"_var0"}}' does not support field selection
+		 | [].length
+		 | ..^
+		`,
+	},
 }
 
 var testEnvs = map[string]env{

--- a/checker/env.go
+++ b/checker/env.go
@@ -231,34 +231,26 @@ func sanitizeFunction(decl *exprpb.Decl) *exprpb.Decl {
 	}
 
 	// Sanitize all of the overloads if any overload requires an update to its type references.
-	overloads := make([]*exprpb.Decl_FunctionDecl_Overload, 0, len(fn.GetOverloads()))
+	overloads := make([]*exprpb.Decl_FunctionDecl_Overload, len(fn.GetOverloads()))
 	for i, o := range fn.GetOverloads() {
-		var sanitized bool
 		rt := o.GetResultType()
 		if isObjectWellKnownType(rt) {
 			rt = getObjectWellKnownType(rt)
-			sanitized = true
 		}
-		params := make([]*exprpb.Type, 0, len(o.GetParams()))
+		params := make([]*exprpb.Type, len(o.GetParams()))
 		copy(params, o.GetParams())
 		for j, p := range params {
 			if isObjectWellKnownType(p) {
 				params[j] = getObjectWellKnownType(p)
-				sanitized = true
 			}
 		}
 		// If sanitized, replace the overload definition.
-		if sanitized {
-			if o.IsInstanceFunction {
-				overloads[i] =
-					decls.NewInstanceOverload(o.GetOverloadId(), params, rt)
-			} else {
-				overloads[i] =
-					decls.NewOverload(o.GetOverloadId(), params, rt)
-			}
+		if o.IsInstanceFunction {
+			overloads[i] =
+				decls.NewInstanceOverload(o.GetOverloadId(), params, rt)
 		} else {
-			// Otherwise, preserve the original overload.
-			overloads[i] = o
+			overloads[i] =
+				decls.NewOverload(o.GetOverloadId(), params, rt)
 		}
 	}
 	return decls.NewFunction(decl.GetName(), overloads...)

--- a/checker/env_test.go
+++ b/checker/env_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/containers"
+	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -61,6 +62,30 @@ func TestOverlappingOverload(t *testing.T) {
 		t.Error("Got nil, wanted error")
 	} else if !strings.Contains(err.Error(), "overlapping overload") {
 		t.Errorf("Got %v, wanted overlapping overload error", err)
+	}
+}
+
+func TestSanitizedOverload(t *testing.T) {
+	env := NewStandardEnv(containers.DefaultContainer, newTestRegistry(t))
+	err := env.Add(decls.NewFunction(operators.Add,
+		decls.NewOverload("timestamp_add_int",
+			[]*exprpb.Type{decls.NewObjectType("google.protobuf.Timestamp"), decls.Int},
+			decls.NewObjectType("google.protobuf.Timestamp"))))
+	if err != nil {
+		t.Errorf("env.Add('timestamp_add_int') failed: %v", err)
+	}
+}
+
+func TestSanitizedInstanceOverload(t *testing.T) {
+	env := NewStandardEnv(containers.DefaultContainer, newTestRegistry(t))
+	err := env.Add(decls.NewFunction("orDefault",
+		decls.NewInstanceOverload("int_ordefault_int",
+			[]*exprpb.Type{
+				decls.NewObjectType("google.protobuf.Int32Value"),
+				decls.NewObjectType("google.protobuf.Int32Value")},
+			decls.Int)))
+	if err != nil {
+		t.Errorf("env.Add('int_ordefault_int') failed: %v", err)
 	}
 }
 

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -41,32 +41,9 @@ func (e *typeErrors) undefinedField(l common.Location, field string) {
 	e.ReportError(l, "undefined field '%s'", field)
 }
 
-func (e *typeErrors) fieldDoesNotSupportPresenceCheck(l common.Location, field string) {
-	e.ReportError(l, "field '%s' does not support presence check", field)
-}
-
-func (e *typeErrors) overlappingOverload(l common.Location, name string, overloadID1 string, f1 *exprpb.Type,
-	overloadID2 string, f2 *exprpb.Type) {
-	e.ReportError(l, "overlapping overload for name '%s' (type '%s' with overloadId: '%s' cannot be distinguished from '%s' with "+
-		"overloadId: '%s')", name, FormatCheckedType(f1), overloadID1, FormatCheckedType(f2), overloadID2)
-}
-
-func (e *typeErrors) overlappingMacro(l common.Location, name string, args int) {
-	e.ReportError(l, "overload for name '%s' with %d argument(s) overlaps with predefined macro",
-		name, args)
-}
-
 func (e *typeErrors) noMatchingOverload(l common.Location, name string, args []*exprpb.Type, isInstance bool) {
 	signature := formatFunction(nil, args, isInstance)
 	e.ReportError(l, "found no matching overload for '%s' applied to '%s'", name, signature)
-}
-
-func (e *typeErrors) aggregateTypeMismatch(l common.Location, aggregate *exprpb.Type, member *exprpb.Type) {
-	e.ReportError(
-		l,
-		"type '%s' does not match previous type '%s' in aggregate. Use 'dyn(x)' to make the aggregate dynamic.",
-		FormatCheckedType(member),
-		FormatCheckedType(aggregate))
 }
 
 func (e *typeErrors) notAType(l common.Location, t *exprpb.Type) {

--- a/checker/mapping.go
+++ b/checker/mapping.go
@@ -15,8 +15,6 @@
 package checker
 
 import (
-	"fmt"
-
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
@@ -48,15 +46,4 @@ func (m *mapping) copy() *mapping {
 		c.mapping[k] = v
 	}
 	return c
-}
-
-func (m *mapping) String() string {
-	result := "{"
-
-	for k, v := range m.mapping {
-		result += fmt.Sprintf("%v => %v   ", k, v)
-	}
-
-	result += "}"
-	return result
 }

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -28,15 +28,3 @@ type parseErrors struct {
 func (e *parseErrors) syntaxError(l common.Location, message string) {
 	e.ReportError(l, fmt.Sprintf("Syntax error: %s", message))
 }
-
-func (e *parseErrors) invalidHasArgument(l common.Location) {
-	e.ReportError(l, "Argument to the function 'has' must be a field selection")
-}
-
-func (e *parseErrors) argumentIsNotIdent(l common.Location) {
-	e.ReportError(l, "Argument must be a simple name")
-}
-
-func (e *parseErrors) notAQualifiedName(l common.Location) {
-	e.ReportError(l, "Expected a qualified name")
-}


### PR DESCRIPTION
In an attempt to boost the coverage for the checker and parser related packages, a couple of bugs were uncovered:

1. Abstract types were not properly identified as such in the checker.
2. Type-sanitization which renames well-known protobuf names to their CEL equivalents was not actually performing the necessary scrubbing.

Both issues have been fixed with tests added and as-needed, also simplified.