### PR TITLE
Fix the signature overlap check for parameterized types

### DIFF
--- a/cel/decls.go
+++ b/cel/decls.go
@@ -650,7 +650,7 @@ func (f *functionDecl) merge(other *functionDecl) (*functionDecl, error) {
 	for _, o := range other.overloads {
 		err := merged.addOverload(o)
 		if err != nil {
-			return nil, fmt.Errorf("function declration merge failed: %v", err)
+			return nil, fmt.Errorf("function declaration merge failed: %v", err)
 		}
 	}
 	if other.singleton != nil {
@@ -821,8 +821,8 @@ func (o *overloadDecl) signatureOverlaps(other *overloadDecl) bool {
 	for i, argType := range o.argTypes {
 		otherArgType := other.argTypes[i]
 		argsOverlap = argsOverlap &&
-			(argType.IsAssignableRuntimeType(otherArgType.runtimeType) ||
-				otherArgType.IsAssignableRuntimeType(argType.runtimeType))
+			(argType.IsAssignableType(otherArgType) ||
+				otherArgType.IsAssignableType(argType))
 	}
 	return argsOverlap
 }


### PR DESCRIPTION
Signature overlap checks were using the runtime type rather than the declaration type which resulted in false positives for collision detections.