### PR TITLE
Support context propagation

### DIFF
--- a/cel/decls.go
+++ b/cel/decls.go
@@ -287,6 +287,24 @@ func FunctionBinding(binding functions.FunctionOp) OverloadOpt {
 	return decls.FunctionBinding(binding)
 }
 
+// UnaryBindingContext provides the implementation of a unary overload. The provided function is protected by a runtime
+// type-guard which ensures runtime type agreement between the overload signature and runtime argument types.
+func UnaryBindingContext(binding functions.UnaryContextOp) OverloadOpt {
+	return decls.UnaryBindingContext(binding)
+}
+
+// BinaryBindingContext provides the implementation of a binary overload. The provided function is protected by a runtime
+// type-guard which ensures runtime type agreement between the overload signature and runtime argument types.
+func BinaryBindingContext(binding functions.BinaryContextOp) OverloadOpt {
+	return decls.BinaryBindingContext(binding)
+}
+
+// FunctionBindingContext provides the implementation of a variadic overload. The provided function is protected by a runtime
+// type-guard which ensures runtime type agreement between the overload signature and runtime argument types.
+func FunctionBindingContext(binding functions.FunctionContextOp) OverloadOpt {
+	return decls.FunctionBindingContext(binding)
+}
+
 // OverloadIsNonStrict enables the function to be called with error and unknown argument values.
 //
 // Note: do not use this option unless absoluately necessary as it should be an uncommon feature.

--- a/cel/decls_test.go
+++ b/cel/decls_test.go
@@ -15,6 +15,7 @@
 package cel
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"reflect"
@@ -673,7 +674,7 @@ func TestExprDeclToDeclaration(t *testing.T) {
 	}
 	prg, err := e.Program(ast, Functions(&functions.Overload{
 		Operator: overloads.SizeString,
-		Unary: func(arg ref.Val) ref.Val {
+		Unary: func(ctx context.Context, arg ref.Val) ref.Val {
 			str, ok := arg.(types.String)
 			if !ok {
 				return types.MaybeNoSuchOverloadErr(arg)
@@ -682,7 +683,7 @@ func TestExprDeclToDeclaration(t *testing.T) {
 		},
 	}, &functions.Overload{
 		Operator: overloads.SizeStringInst,
-		Unary: func(arg ref.Val) ref.Val {
+		Unary: func(ctx context.Context, arg ref.Val) ref.Val {
 			str, ok := arg.(types.String)
 			if !ok {
 				return types.MaybeNoSuchOverloadErr(arg)

--- a/cel/library.go
+++ b/cel/library.go
@@ -15,6 +15,7 @@
 package cel
 
 import (
+	"context"
 	"math"
 	"strconv"
 	"strings"
@@ -494,9 +495,9 @@ func (opt *evalOptionalOr) ID() int64 {
 
 // Eval evaluates the left-hand side optional to determine whether it contains a value, else
 // proceeds with the right-hand side evaluation.
-func (opt *evalOptionalOr) Eval(ctx interpreter.Activation) ref.Val {
+func (opt *evalOptionalOr) Eval(ctx context.Context, vars interpreter.Activation) ref.Val {
 	// short-circuit lhs.
-	optLHS := opt.lhs.Eval(ctx)
+	optLHS := opt.lhs.Eval(ctx, vars)
 	optVal, ok := optLHS.(*types.Optional)
 	if !ok {
 		return optLHS
@@ -504,7 +505,7 @@ func (opt *evalOptionalOr) Eval(ctx interpreter.Activation) ref.Val {
 	if optVal.HasValue() {
 		return optVal
 	}
-	return opt.rhs.Eval(ctx)
+	return opt.rhs.Eval(ctx, vars)
 }
 
 // evalOptionalOrValue selects between an optional or a concrete value. If the optional has a value,
@@ -522,9 +523,9 @@ func (opt *evalOptionalOrValue) ID() int64 {
 
 // Eval evaluates the left-hand side optional to determine whether it contains a value, else
 // proceeds with the right-hand side evaluation.
-func (opt *evalOptionalOrValue) Eval(ctx interpreter.Activation) ref.Val {
+func (opt *evalOptionalOrValue) Eval(ctx context.Context, vars interpreter.Activation) ref.Val {
 	// short-circuit lhs.
-	optLHS := opt.lhs.Eval(ctx)
+	optLHS := opt.lhs.Eval(ctx, vars)
 	optVal, ok := optLHS.(*types.Optional)
 	if !ok {
 		return optLHS
@@ -532,7 +533,7 @@ func (opt *evalOptionalOrValue) Eval(ctx interpreter.Activation) ref.Val {
 	if optVal.HasValue() {
 		return optVal.GetValue()
 	}
-	return opt.rhs.Eval(ctx)
+	return opt.rhs.Eval(ctx, vars)
 }
 
 type timeUTCLibrary struct{}

--- a/common/decls/decls_test.go
+++ b/common/decls/decls_test.go
@@ -15,6 +15,7 @@
 package decls
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -75,11 +76,11 @@ func TestFunctionBindings(t *testing.T) {
 			t.Errorf("binding missing unary implementation: %v", binding.Operator)
 			continue
 		}
-		if binding.Unary(in) != types.Int(2) {
-			t.Errorf("binding invocation got %v, wanted 2", binding.Unary(in))
+		if binding.Unary(context.Background(), in) != types.Int(2) {
+			t.Errorf("binding invocation got %v, wanted 2", binding.Unary(context.Background(), in))
 		}
-		if binding.Unary(empty) != types.IntZero {
-			t.Errorf("binding invocation got %v, wanted 0", binding.Unary(empty))
+		if binding.Unary(context.Background(), empty) != types.IntZero {
+			t.Errorf("binding invocation got %v, wanted 0", binding.Unary(context.Background(), empty))
 		}
 	}
 }
@@ -121,48 +122,49 @@ func TestFunctionVariableArgBindings(t *testing.T) {
 	if len(bindings) != 4 {
 		t.Errorf("sizeFunc.Bindings() produced %d bindings, wanted 4", len(bindings))
 	}
+	ctx := context.Background()
 	in := types.String("hi")
 	sep := types.String("")
 	out := types.DefaultTypeAdapter.NativeToValue([]string{"h", "i"})
 	for _, binding := range bindings {
 		if binding.Unary != nil {
-			if binding.Unary(in).Equal(out) != types.True {
-				t.Errorf("binding invocation got %v, wanted %v", binding.Unary(in), out)
+			if binding.Unary(ctx, in).Equal(out) != types.True {
+				t.Errorf("binding invocation got %v, wanted %v", binding.Unary(ctx, in), out)
 			}
-			celErr := binding.Unary(types.Bytes("hi"))
+			celErr := binding.Unary(ctx, types.Bytes("hi"))
 			if !types.IsError(celErr) || !strings.Contains(celErr.(*types.Err).String(), "no such overload") {
 				t.Errorf("binding.Unary(bytes) got %v, wanted no such overload", celErr)
 			}
 		}
 		if binding.Binary != nil {
-			if binding.Binary(in, sep).Equal(out) != types.True {
-				t.Errorf("binding invocation got %v, wanted %v", binding.Binary(in, sep), out)
+			if binding.Binary(ctx, in, sep).Equal(out) != types.True {
+				t.Errorf("binding invocation got %v, wanted %v", binding.Binary(ctx, in, sep), out)
 			}
-			celErr := binding.Binary(types.Bytes("hi"), sep)
+			celErr := binding.Binary(ctx, types.Bytes("hi"), sep)
 			if !types.IsError(celErr) || !strings.Contains(celErr.(*types.Err).String(), "no such overload") {
 				t.Errorf("binding.Binary(bytes, string) got %v, wanted no such overload", celErr)
 			}
-			celUnk := binding.Binary(types.Bytes("hi"), types.NewUnknown(1, types.NewAttributeTrail("x")))
+			celUnk := binding.Binary(ctx, types.Bytes("hi"), types.NewUnknown(1, types.NewAttributeTrail("x")))
 			if !types.IsUnknown(celUnk) {
 				t.Errorf("binding.Binary(bytes, unk) got %v, wanted unknown{1}", celUnk)
 			}
 		}
 		if binding.Function != nil {
-			if binding.Function(in, sep, types.IntNegOne).Equal(out) != types.True {
-				t.Errorf("binding invocation got %v, wanted %v", binding.Function(in, sep, types.IntNegOne), out)
+			if binding.Function(ctx, in, sep, types.IntNegOne).Equal(out) != types.True {
+				t.Errorf("binding invocation got %v, wanted %v", binding.Function(ctx, in, sep, types.IntNegOne), out)
 			}
-			celErr := binding.Function(types.Bytes("hi"), sep, types.IntOne)
+			celErr := binding.Function(ctx, types.Bytes("hi"), sep, types.IntOne)
 			if !types.IsError(celErr) || !strings.Contains(celErr.(*types.Err).String(), "no such overload") {
 				t.Errorf("binding.Function(bytes, string, int) got %v, wanted no such overload", celErr)
 			}
 			if binding.Operator == "split" {
-				if binding.Function(in).Equal(out) != types.True {
-					t.Errorf("binding invocation got %v, wanted %v", binding.Function(in), out)
+				if binding.Function(ctx, in).Equal(out) != types.True {
+					t.Errorf("binding invocation got %v, wanted %v", binding.Function(ctx, in), out)
 				}
-				if binding.Function(in, sep).Equal(out) != types.True {
-					t.Errorf("binding invocation got %v, wanted %v", binding.Function(in, sep), out)
+				if binding.Function(ctx, in, sep).Equal(out) != types.True {
+					t.Errorf("binding invocation got %v, wanted %v", binding.Function(ctx, in, sep), out)
 				}
-				out := binding.Function()
+				out := binding.Function(ctx)
 				if !types.IsError(out) || out.(*types.Err).String() != "no such overload: split()" {
 					t.Fatalf("binding.Function() got %v, wanted error", out)
 				}
@@ -189,7 +191,7 @@ func TestFunctionZeroArityBinding(t *testing.T) {
 	if len(bindings) != 1 {
 		t.Errorf("nowFunc.Bindings() produced %d bindings, wanted one", len(bindings))
 	}
-	out := bindings[0].Function()
+	out := bindings[0].Function(context.Background())
 	if out != now {
 		t.Errorf("now() got %v, wanted %v", out, now)
 	}
@@ -231,12 +233,13 @@ func TestFunctionSingletonBinding(t *testing.T) {
 	if bindings[0].Unary == nil {
 		t.Fatalf("size.Bindings() missing singleton unary binding")
 	}
-	result := bindings[0].Unary(types.String("hello"))
+	ctx := context.Background()
+	result := bindings[0].Unary(ctx, types.String("hello"))
 	if result.Equal(types.Int(5)) != types.True {
 		t.Errorf("size('hello') got %v, wanted 5", result)
 	}
 	// Invalid at type-check, but valid since type guard checks have been disabled
-	result = bindings[0].Unary(types.Bytes("hello"))
+	result = bindings[0].Unary(ctx, types.Bytes("hello"))
 	if result.Equal(types.Int(5)) != types.True {
 		t.Errorf("size(b'hello') got %v, wanted 5", result)
 	}
@@ -603,16 +606,17 @@ func TestOverloadIsNonStrict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fn.Binding() failed: %v", err)
 	}
+	ctx := context.Background()
 	m := types.DefaultTypeAdapter.NativeToValue(map[string]string{"hello": "world"})
-	out := bindings[0].Function(m, types.String("hello"), types.String("goodbye"))
+	out := bindings[0].Function(ctx, m, types.String("hello"), types.String("goodbye"))
 	if out.Equal(types.String("world")) != types.True {
 		t.Errorf("function got %v, wanted 'world'", out)
 	}
-	out = bindings[0].Function(m, types.String("missing"), types.String("goodbye"))
+	out = bindings[0].Function(ctx, m, types.String("missing"), types.String("goodbye"))
 	if out.Equal(types.String("goodbye")) != types.True {
 		t.Errorf("function got %v, wanted 'goodbye'", out)
 	}
-	out = bindings[0].Function(m, types.NewErr("no such key"), types.String("goodbye"))
+	out = bindings[0].Function(ctx, m, types.NewErr("no such key"), types.String("goodbye"))
 	if out.Equal(types.String("goodbye")) != types.True {
 		t.Errorf("function got %v, wanted 'goodbye'", out)
 	}
@@ -647,16 +651,17 @@ func TestOverloadOperandTrait(t *testing.T) {
 		t.Fatalf("fn.Binding() failed: %v", err)
 	}
 	m := types.DefaultTypeAdapter.NativeToValue(map[string]string{"hello": "world"})
-	out := bindings[0].Function(m, types.String("hello"), types.String("goodbye"))
+	ctx := context.Background()
+	out := bindings[0].Function(ctx, m, types.String("hello"), types.String("goodbye"))
 	if out.Equal(types.String("world")) != types.True {
 		t.Errorf("function got %v, wanted 'world'", out)
 	}
-	out = bindings[0].Function(m, types.String("missing"), types.String("goodbye"))
+	out = bindings[0].Function(ctx, m, types.String("missing"), types.String("goodbye"))
 	if out.Equal(types.String("goodbye")) != types.True {
 		t.Errorf("function got %v, wanted 'goodbye'", out)
 	}
 	noSuchKey := types.NewErr("no such key")
-	out = bindings[0].Function(m, noSuchKey, types.String("goodbye"))
+	out = bindings[0].Function(ctx, m, noSuchKey, types.String("goodbye"))
 	if out != noSuchKey {
 		t.Errorf("function got %v, wanted 'no such key'", out)
 	}

--- a/common/functions/functions.go
+++ b/common/functions/functions.go
@@ -15,7 +15,11 @@
 // Package functions defines the standard builtin functions supported by the interpreter
 package functions
 
-import "github.com/google/cel-go/common/types/ref"
+import (
+	"context"
+
+	"github.com/google/cel-go/common/types/ref"
+)
 
 // Overload defines a named overload of a function, indicating an operand trait
 // which must be present on the first argument to the overload as well as one
@@ -36,14 +40,14 @@ type Overload struct {
 	OperandTrait int
 
 	// Unary defines the overload with a UnaryOp implementation. May be nil.
-	Unary UnaryOp
+	Unary UnaryContextOp
 
 	// Binary defines the overload with a BinaryOp implementation. May be nil.
-	Binary BinaryOp
+	Binary BinaryContextOp
 
 	// Function defines the overload with a FunctionOp implementation. May be
 	// nil.
-	Function FunctionOp
+	Function FunctionContextOp
 
 	// NonStrict specifies whether the Overload will tolerate arguments that
 	// are types.Err or types.Unknown.
@@ -51,7 +55,7 @@ type Overload struct {
 }
 
 // UnaryOp is a function that takes a single value and produces an output.
-type UnaryOp func(value ref.Val) ref.Val
+type UnaryOp func(ref.Val) ref.Val
 
 // BinaryOp is a function that takes two values and produces an output.
 type BinaryOp func(lhs ref.Val, rhs ref.Val) ref.Val
@@ -59,3 +63,13 @@ type BinaryOp func(lhs ref.Val, rhs ref.Val) ref.Val
 // FunctionOp is a function with accepts zero or more arguments and produces
 // a value or error as a result.
 type FunctionOp func(values ...ref.Val) ref.Val
+
+// UnaryContextOp is a contextual function that takes a single value and produces an output.
+type UnaryContextOp func(context.Context, ref.Val) ref.Val
+
+// BinaryContextOp is a contextual function that takes two values and produces an output.
+type BinaryContextOp func(ctx context.Context, lhs ref.Val, rhs ref.Val) ref.Val
+
+// FunctionContextOp is a contextual function with accepts zero or more arguments and produces
+// a value or error as a result.
+type FunctionContextOp func(ctx context.Context, values ...ref.Val) ref.Val

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -15,6 +15,7 @@
 package interpreter
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/cel-go/common/containers"
@@ -240,6 +241,7 @@ func (fac *partialAttributeFactory) MaybeAttribute(id int64, name string) Attrib
 // example, the expression id representing variable `a` would be listed in the Unknown result,
 // whereas in the other pattern examples, the qualifier `b` would be returned as the Unknown.
 func (fac *partialAttributeFactory) matchesUnknownPatterns(
+	ctx context.Context,
 	vars PartialActivation,
 	attrID int64,
 	variableNames []string,
@@ -267,7 +269,7 @@ func (fac *partialAttributeFactory) matchesUnknownPatterns(
 	for i, qual := range qualifiers {
 		attr, isAttr := qual.(Attribute)
 		if isAttr {
-			val, err := attr.Resolve(vars)
+			val, err := attr.Resolve(ctx, vars)
 			if err != nil {
 				return nil, err
 			}
@@ -338,11 +340,11 @@ type attributeMatcher struct {
 }
 
 // AddQualifier implements the Attribute interface method.
-func (m *attributeMatcher) AddQualifier(qual Qualifier) (Attribute, error) {
+func (m *attributeMatcher) AddQualifier(ctx context.Context, qual Qualifier) (Attribute, error) {
 	// Add the qualifier to the embedded NamespacedAttribute. If the input to the Resolve
 	// method is not a PartialActivation, or does not match an unknown attribute pattern, the
 	// Resolve method is directly invoked on the underlying NamespacedAttribute.
-	_, err := m.NamespacedAttribute.AddQualifier(qual)
+	_, err := m.NamespacedAttribute.AddQualifier(ctx, qual)
 	if err != nil {
 		return nil, err
 	}
@@ -357,12 +359,13 @@ func (m *attributeMatcher) AddQualifier(qual Qualifier) (Attribute, error) {
 // Resolve is an implementation of the NamespacedAttribute interface method which tests
 // for matching unknown attribute patterns and returns types.Unknown if present. Otherwise,
 // the standard Resolve logic applies.
-func (m *attributeMatcher) Resolve(vars Activation) (any, error) {
+func (m *attributeMatcher) Resolve(ctx context.Context, vars Activation) (any, error) {
 	id := m.NamespacedAttribute.ID()
 	// Bug in how partial activation is resolved, should search parents as well.
 	partial, isPartial := toPartialActivation(vars)
 	if isPartial {
 		unk, err := m.fac.matchesUnknownPatterns(
+			ctx,
 			partial,
 			id,
 			m.CandidateVariableNames(),
@@ -374,17 +377,17 @@ func (m *attributeMatcher) Resolve(vars Activation) (any, error) {
 			return unk, nil
 		}
 	}
-	return m.NamespacedAttribute.Resolve(vars)
+	return m.NamespacedAttribute.Resolve(ctx, vars)
 }
 
 // Qualify is an implementation of the Qualifier interface method.
-func (m *attributeMatcher) Qualify(vars Activation, obj any) (any, error) {
-	return attrQualify(m.fac, vars, obj, m)
+func (m *attributeMatcher) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
+	return attrQualify(ctx, m.fac, vars, obj, m)
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (m *attributeMatcher) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
-	return attrQualifyIfPresent(m.fac, vars, obj, m, presenceOnly)
+func (m *attributeMatcher) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+	return attrQualifyIfPresent(ctx, m.fac, vars, obj, m, presenceOnly)
 }
 
 func toPartialActivation(vars Activation) (PartialActivation, bool) {

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -15,6 +15,7 @@
 package interpreter
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -77,12 +78,12 @@ type Qualifier interface {
 	// Qualify performs a qualification, e.g. field selection, on the input object and returns
 	// the value of the access and whether the value was set. A non-nil value with a false presence
 	// test result indicates that the value being returned is the default value.
-	Qualify(vars Activation, obj any) (any, error)
+	Qualify(ctx context.Context, vars Activation, obj any) (any, error)
 
 	// QualifyIfPresent qualifies the object if the qualifier is declared or defined on the object.
 	// The 'presenceOnly' flag indicates that the value is not necessary, just a boolean status as
 	// to whether the qualifier is present.
-	QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error)
+	QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error)
 }
 
 // ConstantQualifier interface embeds the Qualifier interface and provides an option to inspect the
@@ -102,7 +103,7 @@ type Attribute interface {
 	Qualifier
 
 	// AddQualifier adds a qualifier on the Attribute or error if the qualification is not a valid qualifier type.
-	AddQualifier(Qualifier) (Attribute, error)
+	AddQualifier(context.Context, Qualifier) (Attribute, error)
 
 	// Resolve returns the value of the Attribute and whether it was present given an Activation.
 	// For objects which support safe traversal, the value may be non-nil and the presence flag be false.
@@ -110,7 +111,7 @@ type Attribute interface {
 	// If an error is encountered during attribute resolution, it will be returned immediately.
 	// If the attribute cannot be resolved within the Activation, the result must be: `nil`, `error`
 	// with the error indicating which variable was missing.
-	Resolve(Activation) (any, error)
+	Resolve(context.Context, Activation) (any, error)
 }
 
 // NamespacedAttribute values are a variable within a namespace, and an optional set of qualifiers
@@ -245,7 +246,7 @@ func (a *absoluteAttribute) IsOptional() bool {
 }
 
 // AddQualifier implements the Attribute interface method.
-func (a *absoluteAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
+func (a *absoluteAttribute) AddQualifier(ctx context.Context, qual Qualifier) (Attribute, error) {
 	a.qualifiers = append(a.qualifiers, qual)
 	return a, nil
 }
@@ -261,13 +262,13 @@ func (a *absoluteAttribute) Qualifiers() []Qualifier {
 }
 
 // Qualify is an implementation of the Qualifier interface method.
-func (a *absoluteAttribute) Qualify(vars Activation, obj any) (any, error) {
-	return attrQualify(a.fac, vars, obj, a)
+func (a *absoluteAttribute) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
+	return attrQualify(ctx, a.fac, vars, obj, a)
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (a *absoluteAttribute) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
-	return attrQualifyIfPresent(a.fac, vars, obj, a, presenceOnly)
+func (a *absoluteAttribute) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+	return attrQualifyIfPresent(ctx, a.fac, vars, obj, a, presenceOnly)
 }
 
 // String implements the Stringer interface method.
@@ -281,7 +282,7 @@ func (a *absoluteAttribute) String() string {
 // If the variable name cannot be found as an Activation variable or in the TypeProvider as
 // a type, then the result is `nil`, `error` with the error indicating the name of the first
 // variable searched as missing.
-func (a *absoluteAttribute) Resolve(vars Activation) (any, error) {
+func (a *absoluteAttribute) Resolve(ctx context.Context, vars Activation) (any, error) {
 	for _, nm := range a.namespaceNames {
 		// If the variable is found, process it. Otherwise, wait until the checks to
 		// determine whether the type is unknown before returning.
@@ -290,7 +291,7 @@ func (a *absoluteAttribute) Resolve(vars Activation) (any, error) {
 			if celErr, ok := obj.(*types.Err); ok {
 				return nil, celErr.Unwrap()
 			}
-			obj, isOpt, err := applyQualifiers(vars, obj, a.qualifiers)
+			obj, isOpt, err := applyQualifiers(ctx, vars, obj, a.qualifiers)
 			if err != nil {
 				return nil, err
 			}
@@ -349,12 +350,12 @@ func (a *conditionalAttribute) IsOptional() bool {
 
 // AddQualifier appends the same qualifier to both sides of the conditional, in effect managing
 // the qualification of alternate attributes.
-func (a *conditionalAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
-	_, err := a.truthy.AddQualifier(qual)
+func (a *conditionalAttribute) AddQualifier(ctx context.Context, qual Qualifier) (Attribute, error) {
+	_, err := a.truthy.AddQualifier(ctx, qual)
 	if err != nil {
 		return nil, err
 	}
-	_, err = a.falsy.AddQualifier(qual)
+	_, err = a.falsy.AddQualifier(ctx, qual)
 	if err != nil {
 		return nil, err
 	}
@@ -362,23 +363,23 @@ func (a *conditionalAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
 }
 
 // Qualify is an implementation of the Qualifier interface method.
-func (a *conditionalAttribute) Qualify(vars Activation, obj any) (any, error) {
-	return attrQualify(a.fac, vars, obj, a)
+func (a *conditionalAttribute) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
+	return attrQualify(ctx, a.fac, vars, obj, a)
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (a *conditionalAttribute) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
-	return attrQualifyIfPresent(a.fac, vars, obj, a, presenceOnly)
+func (a *conditionalAttribute) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+	return attrQualifyIfPresent(ctx, a.fac, vars, obj, a, presenceOnly)
 }
 
 // Resolve evaluates the condition, and then resolves the truthy or falsy branch accordingly.
-func (a *conditionalAttribute) Resolve(vars Activation) (any, error) {
-	val := a.expr.Eval(vars)
+func (a *conditionalAttribute) Resolve(ctx context.Context, vars Activation) (any, error) {
+	val := a.expr.Eval(ctx, vars)
 	if val == types.True {
-		return a.truthy.Resolve(vars)
+		return a.truthy.Resolve(ctx, vars)
 	}
 	if val == types.False {
-		return a.falsy.Resolve(vars)
+		return a.falsy.Resolve(ctx, vars)
 	}
 	if types.IsUnknown(val) {
 		return val, nil
@@ -435,7 +436,7 @@ func (a *maybeAttribute) IsOptional() bool {
 //	possible field selection -- ns.a['b'], a['b']
 //
 // If none of the attributes within the maybe resolves a value, the result is an error.
-func (a *maybeAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
+func (a *maybeAttribute) AddQualifier(ctx context.Context, qual Qualifier) (Attribute, error) {
 	str := ""
 	isStr := false
 	cq, isConst := qual.(ConstantQualifier)
@@ -452,7 +453,7 @@ func (a *maybeAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
 				augmentedNames[i] = fmt.Sprintf("%s.%s", name, str)
 			}
 		}
-		_, err := attr.AddQualifier(qual)
+		_, err := attr.AddQualifier(ctx, qual)
 		if err != nil {
 			return nil, err
 		}
@@ -465,21 +466,21 @@ func (a *maybeAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
 }
 
 // Qualify is an implementation of the Qualifier interface method.
-func (a *maybeAttribute) Qualify(vars Activation, obj any) (any, error) {
-	return attrQualify(a.fac, vars, obj, a)
+func (a *maybeAttribute) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
+	return attrQualify(ctx, a.fac, vars, obj, a)
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (a *maybeAttribute) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
-	return attrQualifyIfPresent(a.fac, vars, obj, a, presenceOnly)
+func (a *maybeAttribute) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+	return attrQualifyIfPresent(ctx, a.fac, vars, obj, a, presenceOnly)
 }
 
 // Resolve follows the variable resolution rules to determine whether the attribute is a variable
 // or a field selection.
-func (a *maybeAttribute) Resolve(vars Activation) (any, error) {
+func (a *maybeAttribute) Resolve(ctx context.Context, vars Activation) (any, error) {
 	var maybeErr error
 	for _, attr := range a.attrs {
-		obj, err := attr.Resolve(vars)
+		obj, err := attr.Resolve(ctx, vars)
 		// Return an error if one is encountered.
 		if err != nil {
 			resErr, ok := err.(*resolutionError)
@@ -533,32 +534,32 @@ func (a *relativeAttribute) IsOptional() bool {
 }
 
 // AddQualifier implements the Attribute interface method.
-func (a *relativeAttribute) AddQualifier(qual Qualifier) (Attribute, error) {
+func (a *relativeAttribute) AddQualifier(ctx context.Context, qual Qualifier) (Attribute, error) {
 	a.qualifiers = append(a.qualifiers, qual)
 	return a, nil
 }
 
 // Qualify is an implementation of the Qualifier interface method.
-func (a *relativeAttribute) Qualify(vars Activation, obj any) (any, error) {
-	return attrQualify(a.fac, vars, obj, a)
+func (a *relativeAttribute) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
+	return attrQualify(ctx, a.fac, vars, obj, a)
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (a *relativeAttribute) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
-	return attrQualifyIfPresent(a.fac, vars, obj, a, presenceOnly)
+func (a *relativeAttribute) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+	return attrQualifyIfPresent(ctx, a.fac, vars, obj, a, presenceOnly)
 }
 
 // Resolve expression value and qualifier relative to the expression result.
-func (a *relativeAttribute) Resolve(vars Activation) (any, error) {
+func (a *relativeAttribute) Resolve(ctx context.Context, vars Activation) (any, error) {
 	// First, evaluate the operand.
-	v := a.operand.Eval(vars)
+	v := a.operand.Eval(ctx, vars)
 	if types.IsError(v) {
 		return nil, v.(*types.Err)
 	}
 	if types.IsUnknown(v) {
 		return v, nil
 	}
-	obj, isOpt, err := applyQualifiers(vars, v, a.qualifiers)
+	obj, isOpt, err := applyQualifiers(ctx, vars, v, a.qualifiers)
 	if err != nil {
 		return nil, err
 	}
@@ -705,13 +706,13 @@ func (q *stringQualifier) IsOptional() bool {
 }
 
 // Qualify implements the Qualifier interface method.
-func (q *stringQualifier) Qualify(vars Activation, obj any) (any, error) {
+func (q *stringQualifier) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
 	val, _, err := q.qualifyInternal(vars, obj, false, false)
 	return val, err
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (q *stringQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+func (q *stringQualifier) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.qualifyInternal(vars, obj, true, presenceOnly)
 }
 
@@ -806,13 +807,13 @@ func (q *intQualifier) IsOptional() bool {
 }
 
 // Qualify implements the Qualifier interface method.
-func (q *intQualifier) Qualify(vars Activation, obj any) (any, error) {
+func (q *intQualifier) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
 	val, _, err := q.qualifyInternal(vars, obj, false, false)
 	return val, err
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (q *intQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+func (q *intQualifier) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.qualifyInternal(vars, obj, true, presenceOnly)
 }
 
@@ -933,13 +934,13 @@ func (q *uintQualifier) IsOptional() bool {
 }
 
 // Qualify implements the Qualifier interface method.
-func (q *uintQualifier) Qualify(vars Activation, obj any) (any, error) {
+func (q *uintQualifier) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
 	val, _, err := q.qualifyInternal(vars, obj, false, false)
 	return val, err
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (q *uintQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+func (q *uintQualifier) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.qualifyInternal(vars, obj, true, presenceOnly)
 }
 
@@ -998,13 +999,13 @@ func (q *boolQualifier) IsOptional() bool {
 }
 
 // Qualify implements the Qualifier interface method.
-func (q *boolQualifier) Qualify(vars Activation, obj any) (any, error) {
+func (q *boolQualifier) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
 	val, _, err := q.qualifyInternal(vars, obj, false, false)
 	return val, err
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (q *boolQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+func (q *boolQualifier) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.qualifyInternal(vars, obj, true, presenceOnly)
 }
 
@@ -1052,7 +1053,7 @@ func (q *fieldQualifier) IsOptional() bool {
 }
 
 // Qualify implements the Qualifier interface method.
-func (q *fieldQualifier) Qualify(vars Activation, obj any) (any, error) {
+func (q *fieldQualifier) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
 	if rv, ok := obj.(ref.Val); ok {
 		obj = rv.Value()
 	}
@@ -1064,7 +1065,7 @@ func (q *fieldQualifier) Qualify(vars Activation, obj any) (any, error) {
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (q *fieldQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+func (q *fieldQualifier) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	if rv, ok := obj.(ref.Val); ok {
 		obj = rv.Value()
 	}
@@ -1110,12 +1111,12 @@ func (q *doubleQualifier) IsOptional() bool {
 }
 
 // Qualify implements the Qualifier interface method.
-func (q *doubleQualifier) Qualify(vars Activation, obj any) (any, error) {
+func (q *doubleQualifier) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
 	val, _, err := q.qualifyInternal(vars, obj, false, false)
 	return val, err
 }
 
-func (q *doubleQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+func (q *doubleQualifier) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.qualifyInternal(vars, obj, true, presenceOnly)
 }
 
@@ -1146,12 +1147,12 @@ func (q *unknownQualifier) IsOptional() bool {
 }
 
 // Qualify returns the unknown value associated with this qualifier.
-func (q *unknownQualifier) Qualify(vars Activation, obj any) (any, error) {
+func (q *unknownQualifier) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
 	return q.value, nil
 }
 
 // QualifyIfPresent is an implementation of the Qualifier interface method.
-func (q *unknownQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+func (q *unknownQualifier) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	return q.value, true, nil
 }
 
@@ -1160,7 +1161,7 @@ func (q *unknownQualifier) Value() ref.Val {
 	return q.value
 }
 
-func applyQualifiers(vars Activation, obj any, qualifiers []Qualifier) (any, bool, error) {
+func applyQualifiers(ctx context.Context, vars Activation, obj any, qualifiers []Qualifier) (any, bool, error) {
 	optObj, isOpt := obj.(*types.Optional)
 	if isOpt {
 		if !optObj.HasValue() {
@@ -1175,7 +1176,7 @@ func applyQualifiers(vars Activation, obj any, qualifiers []Qualifier) (any, boo
 		isOpt = isOpt || qual.IsOptional()
 		if isOpt {
 			var present bool
-			qualObj, present, err = qual.QualifyIfPresent(vars, obj, false)
+			qualObj, present, err = qual.QualifyIfPresent(ctx, vars, obj, false)
 			if err != nil {
 				return nil, false, err
 			}
@@ -1186,7 +1187,7 @@ func applyQualifiers(vars Activation, obj any, qualifiers []Qualifier) (any, boo
 				return types.OptionalNone, false, nil
 			}
 		} else {
-			qualObj, err = qual.Qualify(vars, obj)
+			qualObj, err = qual.Qualify(ctx, vars, obj)
 			if err != nil {
 				return nil, false, err
 			}
@@ -1197,8 +1198,8 @@ func applyQualifiers(vars Activation, obj any, qualifiers []Qualifier) (any, boo
 }
 
 // attrQualify performs a qualification using the result of an attribute evaluation.
-func attrQualify(fac AttributeFactory, vars Activation, obj any, qualAttr Attribute) (any, error) {
-	val, err := qualAttr.Resolve(vars)
+func attrQualify(ctx context.Context, fac AttributeFactory, vars Activation, obj any, qualAttr Attribute) (any, error) {
+	val, err := qualAttr.Resolve(ctx, vars)
 	if err != nil {
 		return nil, err
 	}
@@ -1206,14 +1207,14 @@ func attrQualify(fac AttributeFactory, vars Activation, obj any, qualAttr Attrib
 	if err != nil {
 		return nil, err
 	}
-	return qual.Qualify(vars, obj)
+	return qual.Qualify(ctx, vars, obj)
 }
 
 // attrQualifyIfPresent conditionally performs the qualification of the result of attribute is present
 // on the target object.
-func attrQualifyIfPresent(fac AttributeFactory, vars Activation, obj any, qualAttr Attribute,
+func attrQualifyIfPresent(ctx context.Context, fac AttributeFactory, vars Activation, obj any, qualAttr Attribute,
 	presenceOnly bool) (any, bool, error) {
-	val, err := qualAttr.Resolve(vars)
+	val, err := qualAttr.Resolve(ctx, vars)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1221,7 +1222,7 @@ func attrQualifyIfPresent(fac AttributeFactory, vars Activation, obj any, qualAt
 	if err != nil {
 		return nil, false, err
 	}
-	return qual.QualifyIfPresent(vars, obj, presenceOnly)
+	return qual.QualifyIfPresent(ctx, vars, obj, presenceOnly)
 }
 
 // refQualify attempts to convert the value to a CEL value and then uses reflection methods to try and

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -15,6 +15,7 @@
 package interpreter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -36,6 +37,7 @@ import (
 )
 
 func TestAttributesAbsoluteAttr(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	cont, err := containers.NewContainer(containers.Name("acme.ns"))
 	if err != nil {
@@ -57,10 +59,10 @@ func TestAttributesAbsoluteAttr(t *testing.T) {
 	qualB := makeQualifier(t, attrs, nil, 2, "b")
 	qual4 := makeQualifier(t, attrs, nil, 3, uint64(4))
 	qualFalse := makeQualifier(t, attrs, nil, 4, false)
-	attr.AddQualifier(qualB)
-	attr.AddQualifier(qual4)
-	attr.AddQualifier(qualFalse)
-	out, err := attr.Resolve(vars)
+	attr.AddQualifier(ctx, qualB)
+	attr.AddQualifier(ctx, qual4)
+	attr.AddQualifier(ctx, qualFalse)
+	out, err := attr.Resolve(ctx, vars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +77,7 @@ func TestAttributesAbsoluteAttrType(t *testing.T) {
 
 	// int
 	attr := attrs.AbsoluteAttribute(1, "int")
-	out, err := attr.Resolve(EmptyActivation())
+	out, err := attr.Resolve(context.Background(), EmptyActivation())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,6 +87,7 @@ func TestAttributesAbsoluteAttrType(t *testing.T) {
 }
 
 func TestAttributesAbsoluteAttrError(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
 	vars, err := NewActivation(map[string]any{
@@ -97,14 +100,15 @@ func TestAttributesAbsoluteAttrError(t *testing.T) {
 	// acme.a.b[4][false]
 	attr := attrs.AbsoluteAttribute(1, "err")
 	qualMsg := makeQualifier(t, attrs, nil, 2, "message")
-	attr.AddQualifier(qualMsg)
-	out, err := attr.Resolve(vars)
+	attr.AddQualifier(ctx, qualMsg)
+	out, err := attr.Resolve(ctx, vars)
 	if err == nil {
 		t.Errorf("attr.Resolve('err') got %v, wanted error", out)
 	}
 }
 
 func TestAttributesRelativeAttr(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
 	data := map[string]any{
@@ -126,10 +130,10 @@ func TestAttributesRelativeAttr(t *testing.T) {
 	attr := attrs.RelativeAttribute(1, op)
 	qualA := makeQualifier(t, attrs, nil, 2, "a")
 	qualNeg1 := makeQualifier(t, attrs, nil, 3, int64(-1))
-	attr.AddQualifier(qualA)
-	attr.AddQualifier(qualNeg1)
-	attr.AddQualifier(attrs.AbsoluteAttribute(4, "b"))
-	out, err := attr.Resolve(vars)
+	attr.AddQualifier(ctx, qualA)
+	attr.AddQualifier(ctx, qualNeg1)
+	attr.AddQualifier(ctx, attrs.AbsoluteAttribute(4, "b"))
+	out, err := attr.Resolve(ctx, vars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,6 +143,7 @@ func TestAttributesRelativeAttr(t *testing.T) {
 }
 
 func TestAttributesRelativeAttrOneOf(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	cont, err := containers.NewContainer(containers.Name("acme.ns"))
 	if err != nil {
@@ -171,10 +176,10 @@ func TestAttributesRelativeAttrOneOf(t *testing.T) {
 	attr := attrs.RelativeAttribute(1, op)
 	qualA := makeQualifier(t, attrs, nil, 2, "a")
 	qualNeg1 := makeQualifier(t, attrs, nil, 3, int64(-1))
-	attr.AddQualifier(qualA)
-	attr.AddQualifier(qualNeg1)
-	attr.AddQualifier(attrs.MaybeAttribute(4, "b"))
-	out, err := attr.Resolve(vars)
+	attr.AddQualifier(ctx, qualA)
+	attr.AddQualifier(ctx, qualNeg1)
+	attr.AddQualifier(ctx, attrs.MaybeAttribute(4, "b"))
+	out, err := attr.Resolve(ctx, vars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,6 +189,7 @@ func TestAttributesRelativeAttrOneOf(t *testing.T) {
 }
 
 func TestAttributesRelativeAttrConditional(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
 	data := map[string]any{
@@ -211,16 +217,16 @@ func TestAttributesRelativeAttrConditional(t *testing.T) {
 		attrs.AbsoluteAttribute(5, "b"),
 		attrs.AbsoluteAttribute(6, "c"))
 	qual0 := makeQualifier(t, attrs, nil, 7, 0)
-	condAttr.AddQualifier(qual0)
+	condAttr.AddQualifier(ctx, qual0)
 
 	obj := NewConstValue(1, reg.NativeToValue(data))
 	attr := attrs.RelativeAttribute(1, obj)
 	qualA := makeQualifier(t, attrs, nil, 2, "a")
 	qualNeg1 := makeQualifier(t, attrs, nil, 3, int64(-1))
-	attr.AddQualifier(qualA)
-	attr.AddQualifier(qualNeg1)
-	attr.AddQualifier(condAttr)
-	out, err := attr.Resolve(vars)
+	attr.AddQualifier(ctx, qualA)
+	attr.AddQualifier(ctx, qualNeg1)
+	attr.AddQualifier(ctx, condAttr)
+	out, err := attr.Resolve(ctx, vars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,6 +236,7 @@ func TestAttributesRelativeAttrConditional(t *testing.T) {
 }
 
 func TestAttributesRelativeAttrRelativeQualifier(t *testing.T) {
+	ctx := context.Background()
 	cont, err := containers.NewContainer(containers.Name("acme.ns"))
 	if err != nil {
 		t.Fatal(err)
@@ -282,15 +289,15 @@ func TestAttributesRelativeAttrRelativeQualifier(t *testing.T) {
 	}))
 	relAttr := attrs.RelativeAttribute(4, mp)
 	qualB := makeQualifier(t, attrs, nil, 5, attrs.AbsoluteAttribute(5, "b"))
-	relAttr.AddQualifier(qualB)
+	relAttr.AddQualifier(ctx, qualB)
 	attr := attrs.RelativeAttribute(1, obj)
 	qualA := makeQualifier(t, attrs, nil, 2, "a")
 	qualNeg1 := makeQualifier(t, attrs, nil, 3, int64(-1))
-	attr.AddQualifier(qualA)
-	attr.AddQualifier(qualNeg1)
-	attr.AddQualifier(relAttr)
+	attr.AddQualifier(ctx, qualA)
+	attr.AddQualifier(ctx, qualNeg1)
+	attr.AddQualifier(ctx, relAttr)
 
-	out, err := attr.Resolve(vars)
+	out, err := attr.Resolve(ctx, vars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,6 +307,7 @@ func TestAttributesRelativeAttrRelativeQualifier(t *testing.T) {
 }
 
 func TestAttributesOneofAttr(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	cont, err := containers.NewContainer(containers.Name("acme.ns"))
 	if err != nil {
@@ -318,8 +326,8 @@ func TestAttributesOneofAttr(t *testing.T) {
 	// a.b -> should resolve to acme.ns.a.b per namespace resolution rules.
 	attr := attrs.MaybeAttribute(1, "a")
 	qualB := makeQualifier(t, attrs, nil, 2, "b")
-	attr.AddQualifier(qualB)
-	out, err := attr.Resolve(vars)
+	attr.AddQualifier(ctx, qualB)
+	out, err := attr.Resolve(ctx, vars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,6 +337,7 @@ func TestAttributesOneofAttr(t *testing.T) {
 }
 
 func TestAttributesConditionalAttrTrueBranch(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
 	data := map[string]any{
@@ -347,13 +356,13 @@ func TestAttributesConditionalAttrTrueBranch(t *testing.T) {
 	tv := attrs.AbsoluteAttribute(2, "a")
 	fv := attrs.MaybeAttribute(3, "b")
 	qualC := makeQualifier(t, attrs, nil, 4, "c")
-	fv.AddQualifier(qualC)
+	fv.AddQualifier(ctx, qualC)
 	cond := attrs.ConditionalAttribute(1, NewConstValue(0, types.True), tv, fv)
 	qualNeg1 := makeQualifier(t, attrs, nil, 5, int64(-1))
 	qual1 := makeQualifier(t, attrs, nil, 6, int64(1))
-	cond.AddQualifier(qualNeg1)
-	cond.AddQualifier(qual1)
-	out, err := cond.Resolve(vars)
+	cond.AddQualifier(ctx, qualNeg1)
+	cond.AddQualifier(ctx, qual1)
+	out, err := cond.Resolve(ctx, vars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,6 +372,7 @@ func TestAttributesConditionalAttrTrueBranch(t *testing.T) {
 }
 
 func TestAttributesConditionalAttrFalseBranch(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
 	data := map[string]any{
@@ -381,13 +391,13 @@ func TestAttributesConditionalAttrFalseBranch(t *testing.T) {
 	tv := attrs.AbsoluteAttribute(2, "a")
 	fv := attrs.MaybeAttribute(3, "b")
 	qualC := makeQualifier(t, attrs, nil, 4, "c")
-	fv.AddQualifier(qualC)
+	fv.AddQualifier(ctx, qualC)
 	cond := attrs.ConditionalAttribute(1, NewConstValue(0, types.False), tv, fv)
 	qualNeg1 := makeQualifier(t, attrs, nil, 5, int64(-1))
 	qual1 := makeQualifier(t, attrs, nil, 6, int64(1))
-	cond.AddQualifier(qualNeg1)
-	cond.AddQualifier(qual1)
-	out, err := cond.Resolve(vars)
+	cond.AddQualifier(ctx, qualNeg1)
+	cond.AddQualifier(ctx, qual1)
+	out, err := cond.Resolve(ctx, vars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -715,21 +725,22 @@ func TestAttributesOptional(t *testing.T) {
 	for i, tst := range tests {
 		tc := tst
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ctx := context.Background()
 			i := int64(1)
 			attr := attrs.AbsoluteAttribute(i, tc.varName)
 			for _, q := range tc.quals {
 				i++
-				attr.AddQualifier(makeQualifier(t, attrs, nil, i, q))
+				attr.AddQualifier(ctx, makeQualifier(t, attrs, nil, i, q))
 			}
 			for _, oq := range tc.optQuals {
 				i++
-				attr.AddQualifier(makeOptQualifier(t, attrs, nil, i, oq))
+				attr.AddQualifier(ctx, makeOptQualifier(t, attrs, nil, i, oq))
 			}
 			vars, err := NewActivation(tc.vars)
 			if err != nil {
 				t.Fatalf("NewActivation() failed: %v", err)
 			}
-			out, err := attr.Resolve(vars)
+			out, err := attr.Resolve(ctx, vars)
 			if err != nil {
 				if tc.err != nil {
 					if tc.err.Error() == err.Error() {
@@ -747,6 +758,7 @@ func TestAttributesOptional(t *testing.T) {
 }
 
 func TestAttributesConditionalAttrErrorUnknown(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
 
@@ -754,14 +766,14 @@ func TestAttributesConditionalAttrErrorUnknown(t *testing.T) {
 	tv := attrs.AbsoluteAttribute(2, "a")
 	fv := attrs.MaybeAttribute(3, "b")
 	cond := attrs.ConditionalAttribute(1, NewConstValue(0, types.NewErr("test error")), tv, fv)
-	out, err := cond.Resolve(EmptyActivation())
+	out, err := cond.Resolve(ctx, EmptyActivation())
 	if err == nil {
 		t.Errorf("Got %v, wanted error", out)
 	}
 
 	// unk ? a : b
 	condUnk := attrs.ConditionalAttribute(1, NewConstValue(0, types.NewUnknown(1, nil)), tv, fv)
-	out, err = condUnk.Resolve(EmptyActivation())
+	out, err = condUnk.Resolve(ctx, EmptyActivation())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -771,6 +783,7 @@ func TestAttributesConditionalAttrErrorUnknown(t *testing.T) {
 }
 
 func BenchmarkResolverFieldQualifier(b *testing.B) {
+	ctx := context.Background()
 	msg := &proto3pb.TestAllTypes{
 		NestedType: &proto3pb.TestAllTypes_SingleNestedMessage{
 			SingleNestedMessage: &proto3pb.TestAllTypes_NestedMessage{
@@ -792,11 +805,11 @@ func BenchmarkResolverFieldQualifier(b *testing.B) {
 	if !found {
 		b.Fatal("FindType() could not find NestedMessage")
 	}
-	attr.AddQualifier(makeQualifier(b, attrs, testExprTypeToType(b, opType), 2, "single_nested_message"))
-	attr.AddQualifier(makeQualifier(b, attrs, testExprTypeToType(b, fieldType), 3, "bb"))
+	attr.AddQualifier(ctx, makeQualifier(b, attrs, testExprTypeToType(b, opType), 2, "single_nested_message"))
+	attr.AddQualifier(ctx, makeQualifier(b, attrs, testExprTypeToType(b, fieldType), 3, "bb"))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := attr.Resolve(vars)
+		_, err := attr.Resolve(ctx, vars)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -804,6 +817,7 @@ func BenchmarkResolverFieldQualifier(b *testing.B) {
 }
 
 func TestResolverCustomQualifier(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	attrs := &custAttrFactory{
 		AttributeFactory: NewAttributeFactory(containers.DefaultContainer, reg, reg),
@@ -817,8 +831,8 @@ func TestResolverCustomQualifier(t *testing.T) {
 	attr := attrs.AbsoluteAttribute(1, "msg")
 	fieldType := types.NewObjectType("google.expr.proto3.test.TestAllTypes.NestedMessage")
 	qualBB := makeQualifier(t, attrs, fieldType, 2, "bb")
-	attr.AddQualifier(qualBB)
-	out, err := attr.Resolve(vars)
+	attr.AddQualifier(ctx, qualBB)
+	out, err := attr.Resolve(ctx, vars)
 	if err != nil {
 		t.Error(err)
 	}
@@ -828,6 +842,7 @@ func TestResolverCustomQualifier(t *testing.T) {
 }
 
 func TestAttributesMissingMsg(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
 	anyPB, _ := anypb.New(&proto3pb.TestAllTypes{})
@@ -838,8 +853,8 @@ func TestAttributesMissingMsg(t *testing.T) {
 	// missing_msg.field
 	attr := attrs.AbsoluteAttribute(1, "missing_msg")
 	field := makeQualifier(t, attrs, nil, 2, "field")
-	attr.AddQualifier(field)
-	out, err := attr.Resolve(vars)
+	attr.AddQualifier(ctx, field)
+	out, err := attr.Resolve(ctx, vars)
 	if err == nil {
 		t.Fatalf("got %v, wanted error", out)
 	}
@@ -849,6 +864,7 @@ func TestAttributesMissingMsg(t *testing.T) {
 }
 
 func TestAttributeMissingMsgUnknownField(t *testing.T) {
+	ctx := context.Background()
 	reg := newTestRegistry(t)
 	attrs := NewPartialAttributeFactory(containers.DefaultContainer, reg, reg)
 	anyPB, _ := anypb.New(&proto3pb.TestAllTypes{})
@@ -859,8 +875,8 @@ func TestAttributeMissingMsgUnknownField(t *testing.T) {
 	// missing_msg.field
 	attr := attrs.AbsoluteAttribute(1, "missing_msg")
 	field := makeQualifier(t, attrs, nil, 2, "field")
-	attr.AddQualifier(field)
-	out, err := attr.Resolve(vars)
+	attr.AddQualifier(ctx, field)
+	out, err := attr.Resolve(ctx, vars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1158,7 +1174,7 @@ func TestAttributeStateTracking(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			out := i.Eval(in)
+			out := i.Eval(context.Background(), in)
 			if types.IsUnknown(tc.out) && types.IsUnknown(out) {
 				if !reflect.DeepEqual(tc.out, out) {
 					t.Errorf("got %v, wanted %v", out, tc.out)
@@ -1186,6 +1202,7 @@ func TestAttributeStateTracking(t *testing.T) {
 }
 
 func BenchmarkResolverCustomQualifier(b *testing.B) {
+	ctx := context.Background()
 	reg := newTestRegistry(b)
 	attrs := &custAttrFactory{
 		AttributeFactory: NewAttributeFactory(containers.DefaultContainer, reg, reg),
@@ -1199,9 +1216,9 @@ func BenchmarkResolverCustomQualifier(b *testing.B) {
 	attr := attrs.AbsoluteAttribute(1, "msg")
 	fieldType := types.NewObjectType("google.expr.proto3.test.TestAllTypes.NestedMessage")
 	qualBB := makeQualifier(b, attrs, fieldType, 2, "bb")
-	attr.AddQualifier(qualBB)
+	attr.AddQualifier(ctx, qualBB)
 	for i := 0; i < b.N; i++ {
-		attr.Resolve(vars)
+		attr.Resolve(ctx, vars)
 	}
 }
 
@@ -1235,12 +1252,12 @@ func (q *nestedMsgQualifier) IsOptional() bool {
 	return q.opt
 }
 
-func (q *nestedMsgQualifier) Qualify(vars Activation, obj any) (any, error) {
+func (q *nestedMsgQualifier) Qualify(ctx context.Context, vars Activation, obj any) (any, error) {
 	pb := obj.(*proto3pb.TestAllTypes_NestedMessage)
 	return pb.GetBb(), nil
 }
 
-func (q *nestedMsgQualifier) QualifyIfPresent(vars Activation, obj any, presenceOnly bool) (any, bool, error) {
+func (q *nestedMsgQualifier) QualifyIfPresent(ctx context.Context, vars Activation, obj any, presenceOnly bool) (any, bool, error) {
 	pb := obj.(*proto3pb.TestAllTypes_NestedMessage)
 	if pb.GetBb() == 0 {
 		return nil, false, nil
@@ -1250,7 +1267,7 @@ func (q *nestedMsgQualifier) QualifyIfPresent(vars Activation, obj any, presence
 
 func addQualifier(t testing.TB, attr Attribute, qual Qualifier) Attribute {
 	t.Helper()
-	_, err := attr.AddQualifier(qual)
+	_, err := attr.AddQualifier(context.Background(), qual)
 	if err != nil {
 		t.Fatalf("attr.AddQualifier(%v) failed: %v", qual, err)
 	}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -18,6 +18,8 @@
 package interpreter
 
 import (
+	"context"
+
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/types"
@@ -118,7 +120,7 @@ func InterruptableEval() InterpretableDecorator {
 // Optimize will pre-compute operations such as list and map construction and optimize
 // call arguments to set membership tests. The set of optimizations will increase over time.
 func Optimize() InterpretableDecorator {
-	return decOptimize()
+	return decOptimize(context.TODO())
 }
 
 // RegexOptimization provides a way to replace an InterpretableCall for a regex function when the

--- a/interpreter/optimizations.go
+++ b/interpreter/optimizations.go
@@ -15,6 +15,7 @@
 package interpreter
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/google/cel-go/common/types"
@@ -32,7 +33,7 @@ var MatchesRegexOptimization = &RegexOptimization{
 		if err != nil {
 			return nil, err
 		}
-		return NewCall(call.ID(), call.Function(), call.OverloadID(), call.Args(), func(values ...ref.Val) ref.Val {
+		return NewCall(call.ID(), call.Function(), call.OverloadID(), call.Args(), func(ctx context.Context, values ...ref.Val) ref.Val {
 			if len(values) != 2 {
 				return types.NoSuchOverloadErr()
 			}

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -15,6 +15,7 @@
 package interpreter
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -201,7 +202,7 @@ func (p *planner) planSelect(expr ast.Expr) (Interpretable, error) {
 		}
 	}
 	// Append the qualifier on the attribute.
-	_, err = attr.AddQualifier(qual)
+	_, err = attr.AddQualifier(context.TODO(), qual)
 	return attr, err
 }
 
@@ -306,7 +307,7 @@ func (p *planner) planCallUnary(expr ast.Expr,
 	overload string,
 	impl *functions.Overload,
 	args []Interpretable) (Interpretable, error) {
-	var fn functions.UnaryOp
+	var fn functions.UnaryContextOp
 	var trait int
 	var nonStrict bool
 	if impl != nil {
@@ -334,7 +335,7 @@ func (p *planner) planCallBinary(expr ast.Expr,
 	overload string,
 	impl *functions.Overload,
 	args []Interpretable) (Interpretable, error) {
-	var fn functions.BinaryOp
+	var fn functions.BinaryContextOp
 	var trait int
 	var nonStrict bool
 	if impl != nil {
@@ -363,7 +364,7 @@ func (p *planner) planCallVarArgs(expr ast.Expr,
 	overload string,
 	impl *functions.Overload,
 	args []Interpretable) (Interpretable, error) {
-	var fn functions.FunctionOp
+	var fn functions.FunctionContextOp
 	var trait int
 	var nonStrict bool
 	if impl != nil {
@@ -478,7 +479,7 @@ func (p *planner) planCallIndex(expr ast.Expr, args []Interpretable, optional bo
 	}
 
 	// Add the qualifier to the attribute
-	_, err = attr.AddQualifier(qual)
+	_, err = attr.AddQualifier(context.TODO(), qual)
 	return attr, err
 }
 

--- a/interpreter/prune_test.go
+++ b/interpreter/prune_test.go
@@ -15,6 +15,7 @@
 package interpreter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/cel-go/common"
@@ -471,7 +472,7 @@ func TestPrune(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewUncheckedInterpretable() failed: %v", err)
 		}
-		interpretable.Eval(testActivation(t, tst.in))
+		interpretable.Eval(context.Background(), testActivation(t, tst.in))
 		newExpr := PruneAst(parsed.Expr(), parsed.SourceInfo().MacroCalls(), state)
 		if tst.iterRange != "" {
 			if newExpr.Expr().Kind() != ast.ComprehensionKind {

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -15,6 +15,7 @@
 package interpreter
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -159,7 +160,7 @@ func computeCost(t *testing.T, expr string, vars []*decls.VariableDecl, ctx Acti
 			}
 		}
 	}()
-	prg.Eval(ctx)
+	prg.Eval(context.Background(), ctx)
 	// TODO: enable this once all attributes are properly pushed and popped from stack.
 	//if len(costTracker.stack) != 1 {
 	//	t.Fatalf(`Expected resulting stack size to be 1 but got %d: %#+v`, len(costTracker.stack), costTracker.stack)

--- a/repl/evaluator.go
+++ b/repl/evaluator.go
@@ -16,6 +16,7 @@
 package repl
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -232,17 +233,17 @@ func (l *letFunction) generateFunction() *functions.Overload {
 	case 1:
 		return &functions.Overload{
 			Operator: l.identifier,
-			Unary:    func(v ref.Val) ref.Val { return l.impl(v) },
+			Unary:    func(ctx context.Context, v ref.Val) ref.Val { return l.impl(v) },
 		}
 	case 2:
 		return &functions.Overload{
 			Operator: l.identifier,
-			Binary:   func(lhs ref.Val, rhs ref.Val) ref.Val { return l.impl(lhs, rhs) },
+			Binary:   func(ctx context.Context, lhs ref.Val, rhs ref.Val) ref.Val { return l.impl(lhs, rhs) },
 		}
 	default:
 		return &functions.Overload{
 			Operator: l.identifier,
-			Function: l.impl,
+			Function: func(ctx context.Context, values ...ref.Val) ref.Val { return l.impl(values...) },
 		}
 	}
 }


### PR DESCRIPTION
`context.Context` instance passed in `ContextEval()` can be propagated to binding function to cancel the process.


First of all, thanks for the great OSS. We are using cel-go heavily in https://github.com/mercari/grpc-federation .
In our OSS, we may want to pass `context.Context` against bound functions. e.g.) pass to the gRPC metadata or perform a cancel.

Now that the `ContextEval` function is provided, so I fixed to the `context.Context` instance is passed to the bound function.

Although I have tried to keep the Interface as unchanged as possible, I have made some changes to the Public Interface. If there is a problem, please let me know so that I can correct it.

ref https://github.com/google/cel-go/issues/557

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests