### PR TITLE
fix(checker): Correct Sprintf argument count

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -152,7 +152,7 @@ func (c *checker) checkOptSelect(e ast.Expr) {
 		}
 		c.errors.notAnOptionalFieldSelectionCall(e.ID(), c.location(e),
 			fmt.Sprintf(
-				"incorrect signature.%s argument count: %d%s", t, len(call.Args())))
+				"incorrect signature.%s argument count: %d", t, len(call.Args())))
 		return
 	}
 


### PR DESCRIPTION


# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

In the notAnOptionalFieldSelectionCall method, the call to fmt.Sprintf
had a format string with three placeholders (%s, %d, %s) but only two
arguments were provided. This would cause the last %s to be rendered
as "%!s(MISSING)" at runtime.

This commit removes the redundant trailing %s placeholder from the
format string to ensure the number of arguments matches the placeholders,
thus fixing the error.



## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests