### PR TITLE
Fix race in the checker around reference types

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2355,14 +2355,13 @@ func TestCheck(t *testing.T) {
 			}
 
 			reg, err := types.NewRegistry(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{})
-			if tc.env.optionalSyntax {
-				err = reg.RegisterType(types.OptionalType)
-				if err != nil {
-					t.Fatalf("reg.RegisterType(optional_type) failed: %v", err)
-				}
-			}
 			if err != nil {
 				t.Fatalf("types.NewRegistry() failed: %v", err)
+			}
+			if tc.env.optionalSyntax {
+				if err := reg.RegisterType(types.OptionalType); err != nil {
+					t.Fatalf("reg.RegisterType(optional_type) failed: %v", err)
+				}
 			}
 			cont, err := containers.NewContainer(containers.Name(tc.container))
 			if err != nil {
@@ -2452,6 +2451,11 @@ func BenchmarkCheck(b *testing.B) {
 			reg, err := types.NewRegistry(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{})
 			if err != nil {
 				b.Fatalf("types.NewRegistry() failed: %v", err)
+			}
+			if tc.env.optionalSyntax {
+				if err := reg.RegisterType(types.OptionalType); err != nil {
+					b.Fatalf("reg.RegisterType(optional_type) failed: %v", err)
+				}
 			}
 			cont, err := containers.NewContainer(containers.Name(tc.container))
 			if err != nil {

--- a/checker/env.go
+++ b/checker/env.go
@@ -137,29 +137,20 @@ func (e *Env) LookupIdent(name string) *decls.VariableDecl {
 			return ident
 		}
 
-		// Next try to import the name as a reference to a message type. If found,
-		// the declaration is added to the outest (global) scope of the
-		// environment, so next time we can access it faster.
+		// Next try to import the name as a reference to a message type.
 		if t, found := e.provider.FindStructType(candidate); found {
-			decl := decls.NewVariable(candidate, t)
-			e.declarations.AddIdent(decl)
-			return decl
+			return decls.NewVariable(candidate, t)
 		}
-
 		if i, found := e.provider.FindIdent(candidate); found {
 			if t, ok := i.(*types.Type); ok {
-				decl := decls.NewVariable(candidate, types.NewTypeTypeWithParam(t))
-				e.declarations.AddIdent(decl)
-				return decl
+				return decls.NewVariable(candidate, types.NewTypeTypeWithParam(t))
 			}
 		}
 
 		// Next try to import this as an enum value by splitting the name in a type prefix and
 		// the enum inside.
 		if enumValue := e.provider.EnumValue(candidate); enumValue.Type() != types.ErrType {
-			decl := decls.NewConstant(candidate, types.IntType, enumValue)
-			e.declarations.AddIdent(decl)
-			return decl
+			return decls.NewConstant(candidate, types.IntType, enumValue)
 		}
 	}
 	return nil


### PR DESCRIPTION
The checker had an optimization which would mutate internal identifier references and trigger a data race

Removing this optimization (which is probably not often used), I'm able to verify that the `go test -race github.com/google/cel-go/cel` over the repro case from #1222 results in a fix.

Closes #1222 