### PR TITLE
Expose Match source ID to callers.

### DIFF
--- a/policy/parser.go
+++ b/policy/parser.go
@@ -301,6 +301,11 @@ type Match struct {
 	rule        *Rule
 }
 
+// SourceID returns the source identifier associated with the match.
+func (m *Match) SourceID() int64 {
+	return m.exprID
+}
+
 // Condition returns the condition CEL expression.
 func (m *Match) Condition() ValueString {
 	return m.condition


### PR DESCRIPTION
Making the exprID of Matches accessible to callers.

Will be used as keys for additional per-Match metadata, with the end
goal of compiling an AST where the output is comprised of this metadata
instead.
