### PR TITLE
Preserve source information during CEL policy composition.

### DIFF
--- a/cel/folding_test.go
+++ b/cel/folding_test.go
@@ -366,7 +366,10 @@ func TestConstantFoldingOptimizer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
 			}
-			opt := NewStaticOptimizer(folder)
+			opt, err := NewStaticOptimizer(folder)
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
 			optimized, iss := opt.Optimize(e, checked)
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())
@@ -441,7 +444,10 @@ func TestConstantFoldingCallsWithSideEffects(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
 			}
-			opt := NewStaticOptimizer(folder)
+			opt, err := NewStaticOptimizer(folder)
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
 			optimized, iss := opt.Optimize(e, checked)
 			if tc.error != "" {
 				if iss.Err() == nil {
@@ -508,7 +514,10 @@ func TestConstantFoldingOptimizerMacroElimination(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
 			}
-			opt := NewStaticOptimizer(folder)
+			opt, err := NewStaticOptimizer(folder)
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
 			optimized, iss := opt.Optimize(e, checked)
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())
@@ -570,7 +579,10 @@ func TestConstantFoldingOptimizerWithLimit(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
 			}
-			opt := NewStaticOptimizer(folder)
+			opt, err := NewStaticOptimizer(folder)
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
 			optimized, iss := opt.Optimize(e, checked)
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())
@@ -828,7 +840,10 @@ func TestConstantFoldingNormalizeIDs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
 			}
-			opt := NewStaticOptimizer(folder)
+			opt, err := NewStaticOptimizer(folder)
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
 			optimized, iss := opt.Optimize(e, checked)
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())

--- a/cel/inlining_test.go
+++ b/cel/inlining_test.go
@@ -220,7 +220,10 @@ func TestInliningOptimizer(t *testing.T) {
 				t.Fatalf("Compile() failed: %v", iss.Err())
 			}
 
-			opt := cel.NewStaticOptimizer(cel.NewInliningOptimizer(inlinedVars...))
+			opt, err := cel.NewStaticOptimizer(cel.NewInliningOptimizer(inlinedVars...))
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
 			optimized, iss := opt.Optimize(e, checked)
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())
@@ -236,7 +239,10 @@ func TestInliningOptimizer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
 			}
-			opt = cel.NewStaticOptimizer(folder)
+			opt, err = cel.NewStaticOptimizer(folder)
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
 			optimized, iss = opt.Optimize(e, optimized)
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())
@@ -727,7 +733,10 @@ func TestInliningOptimizerMultiStage(t *testing.T) {
 				t.Fatalf("Compile() failed: %v", iss.Err())
 			}
 
-			opt := cel.NewStaticOptimizer(cel.NewInliningOptimizer(inlinedVars...))
+			opt, err := cel.NewStaticOptimizer(cel.NewInliningOptimizer(inlinedVars...))
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
 			optimized, iss := opt.Optimize(e, checked)
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())
@@ -743,7 +752,10 @@ func TestInliningOptimizerMultiStage(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
 			}
-			opt = cel.NewStaticOptimizer(folder)
+			opt, err = cel.NewStaticOptimizer(folder)
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
 			optimized, iss = opt.Optimize(e, optimized)
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())

--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -404,6 +404,12 @@ func (s *SourceInfo) ComputeOffset(line, col int32) int32 {
 		line = s.baseLine + line
 		col = s.baseCol + col
 	}
+	return s.ComputeOffsetAbsolute(line, col)
+}
+
+// ComputeOffsetAbsolute calculates the 0-based character offset from a 1-based line and 0-based column
+// based on the absolute line and column of the SourceInfo.
+func (s *SourceInfo) ComputeOffsetAbsolute(line, col int32) int32 {
 	if line == 1 {
 		return col
 	}

--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -16,6 +16,8 @@
 package ast
 
 import (
+	"slices"
+
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -250,6 +252,23 @@ type SourceInfo struct {
 	baseCol      int32
 	offsetRanges map[int64]OffsetRange
 	macroCalls   map[int64]Expr
+}
+
+// RenumberIDs performs an in-place update of the expression IDs within the SourceInfo.
+func (s *SourceInfo) RenumberIDs(idGen IDGenerator) {
+	if s == nil {
+		return
+	}
+	oldIDs := []int64{}
+	for id := range s.offsetRanges {
+		oldIDs = append(oldIDs, id)
+	}
+	slices.Sort(oldIDs)
+	newRanges := make(map[int64]OffsetRange)
+	for _, id := range oldIDs {
+		newRanges[idGen(id)] = s.offsetRanges[id]
+	}
+	s.offsetRanges = newRanges
 }
 
 // SyntaxVersion returns the syntax version associated with the text expression.

--- a/ext/sets_test.go
+++ b/ext/sets_test.go
@@ -430,7 +430,10 @@ func TestSetsMembershipRewriter(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewSetMembershipOptimizer() failed with error: %v", err)
 			}
-			opt := cel.NewStaticOptimizer(setsOpt)
+			opt, err := cel.NewStaticOptimizer(setsOpt)
+			if err != nil {
+				t.Fatalf("cel.NewStaticOptimizer() failed with error: %v", err)
+			}
 			optAST, iss := opt.Optimize(env, a)
 			if iss.Err() != nil {
 				t.Fatalf("opt.Optimize() failed: %v", iss.Err())

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -159,7 +159,7 @@ func (p *parserHelper) id(ctx any) int64 {
 		offset.Start = p.sourceInfo.ComputeOffset(int32(c.GetLine()), int32(c.GetColumn()))
 		offset.Stop = offset.Start + int32(len(c.GetText()))
 	case common.Location:
-		offset.Start = p.sourceInfo.ComputeOffset(int32(c.Line()), int32(c.Column()))
+		offset.Start = p.sourceInfo.ComputeOffsetAbsolute(int32(c.Line()), int32(c.Column()))
 		offset.Stop = offset.Start
 	case ast.OffsetRange:
 		offset = c

--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
     size = "small",
     srcs = [
         "compiler_test.go",
+        "composer_test.go",
         "config_test.go",
         "helper_test.go",
         "parser_test.go",
@@ -66,12 +67,15 @@ go_test(
     deps = [
         "//cel:go_default_library",
         "//test:go_default_library",
+        "//common/debug:go_default_library",
         "//common/types:go_default_library",
         "//interpreter:go_default_library",
         "//common/types/ref:go_default_library",
         "//test/proto3pb:go_default_library",
         "@in_yaml_go_yaml_v3//:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@org_golang_google_genproto_googleapis_api//expr/v1alpha1:go_default_library",
+        "@org_golang_google_protobuf//encoding/prototext:go_default_library",
     ],
 )
 

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -531,6 +531,9 @@ func verifySourceInfoCoverage(t testing.TB, policy *Policy, ast *cel.Ast) {
 	coveredLines := make(map[int]bool)
 	ids := ast.NativeRep().IDs()
 	for id, offset := range info.GetPositions() {
+		if offset <= 0 {
+			t.Errorf("id %d has invalid offset %v", id, offset)
+		}
 		// Check that each position in the SourceInfo corresponds to a valid AST node.
 		if !ids[id] {
 			t.Errorf("id %d not found in AST", id)

--- a/policy/composer_test.go
+++ b/policy/composer_test.go
@@ -1,0 +1,171 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/debug"
+	"github.com/google/cel-go/ext"
+)
+
+func TestCompose_SourceInfo(t *testing.T) {
+	policyYAML := `name: test_policy
+rule:
+  match:
+    - condition: "2 == 1"
+      output: "'hi'"
+    - output: "'hello' + ' world'"
+`
+	src := StringSource(policyYAML, "test_policy.yaml")
+	parser, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser() failed: %v", err)
+	}
+	policy, iss := parser.Parse(src)
+	if iss.Err() != nil {
+		t.Fatalf("parser.Parse() failed: %v", iss.Err())
+	}
+
+	env, err := cel.NewEnv(cel.OptionalTypes(), ext.Bindings())
+	if err != nil {
+		t.Fatalf("cel.NewEnv() failed: %v", err)
+	}
+	compiledRule, iss := CompileRule(env, policy)
+	if iss.Err() != nil {
+		t.Fatalf("CompileRule() failed: %v", iss.Err())
+	}
+	composer, err := NewRuleComposer(env)
+	if err != nil {
+		t.Fatalf("NewRuleComposer() failed: %v", err)
+	}
+	compAST, iss := composer.Compose(compiledRule)
+	if iss.Err() != nil {
+		t.Fatalf("composer.Compose() failed: %v", iss.Err())
+	}
+
+	si := compAST.SourceInfo()
+	if si.Location != "test_policy.yaml" {
+		t.Errorf("SourceInfo.Location got %q, wanted test_policy.yaml", si.Location)
+	}
+	verifySourceInfoTransfer(t, compiledRule, compAST)
+}
+
+func TestCompose_Unnest(t *testing.T) {
+	policyYAML := `name: unnest
+rule:
+  match:
+    - condition: "2 == 1"
+      output: "'hi'"
+    - output: "'hello'"
+`
+	src := StringSource(policyYAML, "unnest.yaml")
+	parser, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser() failed: %v", err)
+	}
+	policy, iss := parser.Parse(src)
+	if iss.Err() != nil {
+		t.Fatalf("parser.Parse() failed: %v", iss.Err())
+	}
+
+	env, err := cel.NewEnv(cel.OptionalTypes(), ext.Bindings())
+	if err != nil {
+		t.Fatalf("cel.NewEnv() failed: %v", err)
+	}
+	compiledRule, iss := CompileRule(env, policy)
+	if iss.Err() != nil {
+		t.Fatalf("CompileRule() failed: %v", iss.Err())
+	}
+
+	composer, err := NewRuleComposer(env, ExpressionUnnestHeight(1))
+	if err != nil {
+		t.Fatalf("NewRuleComposer() failed: %v", err)
+	}
+	compAST, iss := composer.Compose(compiledRule)
+	if iss.Err() != nil {
+		t.Fatalf("composer.Compose() failed: %v", iss.Err())
+	}
+
+	verifySourceInfoTransfer(t, compiledRule, compAST)
+	if t.Failed() {
+		t.Logf("composed AST: %s", debug.ToDebugStringWithIDs(compAST.NativeRep().Expr()))
+		t.Logf("SourceInfo: %v", compAST.NativeRep().SourceInfo().OffsetRanges())
+	}
+}
+
+// verifySourceInfoTransfer checks that each offset range in the compiledRule has a corresponding node in composed
+func verifySourceInfoTransfer(t *testing.T, compiledRule *CompiledRule, composed *cel.Ast) {
+	t.Helper()
+	dstRanges := make(map[ast.OffsetRange]ast.Expr)
+	check := func(a *cel.Ast) {
+		ast.PostOrderVisit(a.NativeRep().Expr(), &transferChecker{
+			t:       t,
+			srcInfo: a.NativeRep().SourceInfo(),
+			dstInfo: composed.NativeRep().SourceInfo(),
+			ranges:  &dstRanges})
+	}
+	ast.PostOrderVisit(composed.NativeRep().Expr(), &collectRanges{sourceInfo: composed.NativeRep().SourceInfo(), ranges: &dstRanges})
+	for _, match := range compiledRule.matches {
+		check(match.cond)
+		check(match.output.expr)
+	}
+}
+
+type collectRanges struct {
+	sourceInfo *ast.SourceInfo
+	ranges     *map[ast.OffsetRange]ast.Expr
+}
+
+func (r *collectRanges) VisitExpr(e ast.Expr) {
+	if or, found := r.sourceInfo.GetOffsetRange(e.ID()); found {
+		(*r.ranges)[or] = e
+	}
+}
+
+func (r *collectRanges) VisitEntryExpr(ast.EntryExpr) {
+}
+
+type transferChecker struct {
+	t       *testing.T
+	srcInfo *ast.SourceInfo
+	dstInfo *ast.SourceInfo
+	ranges  *map[ast.OffsetRange]ast.Expr
+}
+
+func (c *transferChecker) VisitExpr(srcExpr ast.Expr) {
+	if srcRange, haveSrc := c.srcInfo.GetOffsetRange(srcExpr.ID()); haveSrc {
+		if srcRange.Start == 0 {
+			// Ignore synthetic "true" default condition which has an incorrect source location
+			return
+		}
+		dstExpr, haveDst := (*c.ranges)[srcRange]
+		if !haveDst {
+			c.t.Errorf("composed node not found for rule node: %s", debug.ToDebugString(srcExpr))
+			return
+		}
+
+		// Check that the two nodes have the same textual representation
+		if dstExpr.Kind() == ast.IdentKind && strings.HasPrefix(dstExpr.AsIdent(), "@index") {
+			// Skip the check for unnested vars
+			return
+		}
+		dstStr, err := cel.ExprToString(dstExpr, c.dstInfo)
+		if err != nil {
+			c.t.Errorf("failed to convert dstExpr")
+			return
+		}
+		srcStr, err := cel.ExprToString(srcExpr, c.srcInfo)
+		if err != nil {
+			c.t.Errorf("failed to convert srcExpr")
+			return
+		}
+		if srcStr != dstStr {
+			c.t.Errorf("mismatched nodes, rule: %s composed: %s", srcStr, dstStr)
+		}
+	}
+}
+
+func (c *transferChecker) VisitEntryExpr(ast.EntryExpr) {
+}


### PR DESCRIPTION
The old implementation outputs the wrong source information for policy files derived from the dummy AST created by RuleComposer.Compose. This change fixes that by preserving the correct source and merging the offset ranges of the rule match expressions inserted by the composer optimizer into the final AST.