### PR TITLE
Remove types as variables

### DIFF
--- a/cel/library.go
+++ b/cel/library.go
@@ -182,7 +182,6 @@ func (lib *stdLibrary) CompileOptions() []EnvOption {
 			if err = lib.subset.Validate(); err != nil {
 				return nil, err
 			}
-			e.variables = append(e.variables, stdlib.Types()...)
 			for _, fn := range funcs {
 				existing, found := e.functions[fn.Name()]
 				if found {

--- a/cel/testdata/standard_env.prompt.txt
+++ b/cel/testdata/standard_env.prompt.txt
@@ -11,21 +11,6 @@ found in C++ or Java code.
 
 Only use the following variables, macros, and functions in expressions.
 
-Variables:
-
-* bool is a type
-* bytes is a type
-* double is a type
-* google.protobuf.Duration is a type
-* google.protobuf.Timestamp is a type
-* int is a type
-* list is a type
-* map is a type
-* null_type is a type
-* string is a type
-* type is a type
-* uint is a type
-
 Functions:
 
 * !_ - logically negate a boolean value.

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1042,6 +1042,20 @@ func testData(t testing.TB) []testCase {
 			},
 		},
 		{
+			name: "type_dyn_equals_string",
+			expr: `type(dyn('')) == string`,
+		},
+		{
+			name: "type_override",
+			expr: `type == 'string'`,
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("type", types.StringType),
+			},
+			in: map[string]any{
+				"type": "string",
+			},
+		},
+		{
 			name: "select_key",
 			expr: `m.strMap['val'] == 'string'
 				&& m.floatMap['val'] == 1.5


### PR DESCRIPTION
Allow user-defined variables to shadow type variables.

With this change, the introduction of new libraries which introduce new types
will not collide with existing user-space variables.