### PR TITLE
Support mixing CEL values and native values in native structs

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2063,7 +2063,7 @@ _&&_(_==_(list~type(list(dyn))^list,
 					"b"
 				  )~optional_type(string)^select_optional_field
 				)~type(optional_type(string))^type,
-				optional_type~type(optional_type)^optional_type
+				optional_type~type(optional_type(dyn))^optional_type
 			  )~bool^equals`,
 		},
 		{

--- a/common/types/optional.go
+++ b/common/types/optional.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	// OptionalType indicates the runtime type of an optional value.
-	OptionalType = NewOpaqueType("optional_type")
+	OptionalType = NewOpaqueType("optional_type", DynType)
 
 	// OptionalNone is a sentinel value which is used to indicate an empty optional value.
 	OptionalNone = &Optional{}
@@ -58,6 +58,9 @@ func (o *Optional) GetValue() ref.Val {
 func (o *Optional) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	if !o.HasValue() {
 		return nil, errors.New("optional.none() dereference")
+	}
+	if typeDesc == reflect.TypeFor[*Optional]() {
+		return o, nil
 	}
 	return o.value.ConvertToNative(typeDesc)
 }

--- a/common/types/optional_test.go
+++ b/common/types/optional_test.go
@@ -51,6 +51,14 @@ func TestOptionalConvertToNative(t *testing.T) {
 	if out != "hello" {
 		t.Errorf("OptionalOf('hello').ConvertToNative(string) got %v, wanted 'hello'", out)
 	}
+	optInt := OptionalOf(Int(20))
+	out, err = optInt.ConvertToNative(reflect.TypeFor[*Optional]())
+	if err != nil {
+		t.Fatalf("OptionalOf(20).ConvertToNative(optional_type) failed: %v", err)
+	}
+	if out != optInt {
+		t.Errorf("OptionalOf(20) got %v, wanted original value", out)
+	}
 }
 
 func TestOptionalConvertToType(t *testing.T) {


### PR DESCRIPTION
Support a combination of Go native structs with CEL `ref.Val` types

Closes #1223