### PR TITLE
Better context-related error messages

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1160,8 +1160,8 @@ func TestContextEval(t *testing.T) {
 	if err == nil {
 		t.Errorf("Got result %v, wanted timeout error", out)
 	}
-	if err != nil && err.Error() != "operation interrupted" {
-		t.Errorf("Got %v, wanted operation interrupted error", err)
+	if err != nil && err.Error() != "context deadline exceeded" {
+		t.Errorf("Got %v, wanted context deadline exceeded", err)
 	}
 }
 

--- a/cel/program.go
+++ b/cel/program.go
@@ -16,6 +16,7 @@ package cel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -361,7 +362,11 @@ func (p *prog) ContextEval(ctx context.Context, input any) (ref.Val, *EvalDetail
 	default:
 		return nil, nil, fmt.Errorf("invalid input, wanted Activation or map[string]any, got: (%T)%v", input, input)
 	}
-	return p.Eval(vars)
+	out, det, err := p.Eval(vars)
+	if err != nil && errors.Is(err, interpreter.InterruptError{}) {
+		return out, det, context.Cause(ctx)
+	}
+	return out, det, err
 }
 
 type ctxEvalActivation struct {

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -1433,7 +1433,7 @@ func (f *folder) AsPartialActivation() (PartialActivation, bool) {
 func (f *folder) evalResult() ref.Val {
 	f.computeResult = true
 	if f.interrupted {
-		return types.NewErr("operation interrupted")
+		return types.WrapErr(InterruptError{})
 	}
 	res := f.result.Eval(f)
 	// Convert a mutable list or map to an immutable one if the comprehension has generated a list or
@@ -1466,6 +1466,20 @@ func (f *folder) reset() {
 func checkInterrupt(a Activation) bool {
 	stop, found := a.ResolveName("#interrupted")
 	return found && stop == true
+}
+
+// InterruptError is a specialized error type used to signal that program evaluation should check
+// whether a context cancellation is responsible for the error.
+type InterruptError struct{}
+
+// Error returns operation interrupted.
+func (InterruptError) Error() string {
+	return "operation interrupted"
+}
+
+// Is returns whether two errors are interrupt errors.
+func (ie InterruptError) Is(target error) bool {
+	return target.Error() == ie.Error()
 }
 
 var (


### PR DESCRIPTION
Use a specially-typed error related to program interruption as a cue to retrieve
more meaningful error messages from `context.Context` if available.

Closes #1195