### PR TITLE
Add runtime cost tracking for string extension functions

### DIFF
--- a/ext/strings.go
+++ b/ext/strings.go
@@ -28,9 +28,11 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+	"github.com/google/cel-go/interpreter"
 )
 
 const (
@@ -553,8 +555,41 @@ func (lib *stringLib) CompileOptions() []cel.EnvOption {
 }
 
 // ProgramOptions implements the Library interface method.
-func (*stringLib) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{}
+func (lib *stringLib) ProgramOptions() []cel.ProgramOption {
+	trackers := []interpreter.CostTrackerOption{
+		// O(n) single-pass operations
+		interpreter.OverloadCostTracker("string_char_at_int", trackStringArgCost),
+		interpreter.OverloadCostTracker("string_lower_ascii", trackStringArgCost),
+		interpreter.OverloadCostTracker("string_upper_ascii", trackStringArgCost),
+		interpreter.OverloadCostTracker("string_trim", trackStringArgCost),
+		interpreter.OverloadCostTracker("string_substring_int", trackStringArgCost),
+		interpreter.OverloadCostTracker("string_substring_int_int", trackStringArgCost),
+		// O(n*m) search operations
+		interpreter.OverloadCostTracker("string_index_of_string", trackStringSearchCost),
+		interpreter.OverloadCostTracker("string_index_of_string_int", trackStringSearchCost),
+		interpreter.OverloadCostTracker("string_last_index_of_string", trackStringSearchCost),
+		interpreter.OverloadCostTracker("string_last_index_of_string_int", trackStringSearchCost),
+		// O(n) search + output allocation
+		interpreter.OverloadCostTracker("string_replace_string_string", trackStringReplaceCost),
+		interpreter.OverloadCostTracker("string_replace_string_string_int", trackStringReplaceCost),
+		// O(n*m) search + list allocation
+		interpreter.OverloadCostTracker("string_split_string", trackStringSplitCost),
+		interpreter.OverloadCostTracker("string_split_string_int", trackStringSplitCost),
+	}
+	if lib.version >= 2 {
+		trackers = append(trackers,
+			interpreter.OverloadCostTracker("list_join", trackStringResultCost),
+			interpreter.OverloadCostTracker("list_join_string", trackStringResultCost),
+		)
+	}
+	if lib.version >= 3 {
+		trackers = append(trackers,
+			interpreter.OverloadCostTracker("string_reverse", trackStringArgCost),
+		)
+	}
+	return []cel.ProgramOption{
+		cel.CostTrackerOptions(trackers...),
+	}
 }
 
 func charAt(str string, ind int64) (string, error) {
@@ -794,3 +829,55 @@ func sanitize(s string) string {
 var (
 	stringListType = reflect.TypeOf([]string{})
 )
+
+// trackStringArgCost computes runtime cost proportional to the first argument's string size.
+// Used for O(n) single-pass operations (charAt, lowerAscii, upperAscii, trim, substring, reverse).
+func trackStringArgCost(args []ref.Val, _ ref.Val) *uint64 {
+	cost := callCost + uint64(math.Ceil(float64(actualSize(args[0]))*common.StringTraversalCostFactor))
+	return &cost
+}
+
+// trackStringSearchCost computes runtime cost for O(n*m) string search operations (indexOf, lastIndexOf).
+func trackStringSearchCost(args []ref.Val, _ ref.Val) *uint64 {
+	strCost := uint64(math.Ceil(float64(actualSize(args[0])) * common.StringTraversalCostFactor))
+	substrCost := uint64(math.Ceil(float64(actualSize(args[1])) * common.StringTraversalCostFactor))
+	if strCost == 0 {
+		strCost = 1
+	}
+	if substrCost == 0 {
+		substrCost = 1
+	}
+	cost := callCost + strCost*substrCost
+	return &cost
+}
+
+// trackStringReplaceCost computes runtime cost for string replace operations.
+// Cost accounts for both the search traversal and the output string allocation.
+func trackStringReplaceCost(args []ref.Val, result ref.Val) *uint64 {
+	strCost := uint64(math.Ceil(float64(actualSize(args[0])) * common.StringTraversalCostFactor))
+	if strCost == 0 {
+		strCost = 1
+	}
+	resultCost := uint64(math.Ceil(float64(actualSize(result)) * common.StringTraversalCostFactor))
+	cost := callCost + strCost + resultCost
+	return &cost
+}
+
+// trackStringSplitCost computes runtime cost for string split operations.
+// Cost accounts for the search traversal and the list allocation.
+func trackStringSplitCost(args []ref.Val, result ref.Val) *uint64 {
+	strCost := uint64(math.Ceil(float64(actualSize(args[0])) * common.StringTraversalCostFactor))
+	if strCost == 0 {
+		strCost = 1
+	}
+	resultCost := uint64(actualSize(result))
+	cost := callCost + strCost + resultCost + common.ListCreateBaseCost
+	return &cost
+}
+
+// trackStringResultCost computes runtime cost proportional to the result size.
+// Used for join operations where the cost is dominated by the output string.
+func trackStringResultCost(_ []ref.Val, result ref.Val) *uint64 {
+	cost := callCost + uint64(math.Ceil(float64(actualSize(result))*common.StringTraversalCostFactor))
+	return &cost
+}

--- a/ext/strings_cost_test.go
+++ b/ext/strings_cost_test.go
@@ -1,0 +1,141 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ext
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+)
+
+func TestStringCostTracking(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantMin uint64
+	}{
+		{
+			name:    "charAt",
+			expr:    `"hello world".charAt(0)`,
+			wantMin: 2,
+		},
+		{
+			name:    "indexOf",
+			expr:    `"hello world".indexOf("world")`,
+			wantMin: 2,
+		},
+		{
+			name:    "lastIndexOf",
+			expr:    `"hello world".lastIndexOf("o")`,
+			wantMin: 2,
+		},
+		{
+			name:    "lowerAscii",
+			expr:    `"HELLO".lowerAscii()`,
+			wantMin: 2,
+		},
+		{
+			name:    "upperAscii",
+			expr:    `"hello".upperAscii()`,
+			wantMin: 2,
+		},
+		{
+			name:    "replace",
+			expr:    `"hello world".replace("world", "CEL")`,
+			wantMin: 2,
+		},
+		{
+			name:    "replace_exponential_growth",
+			expr:    `"A".replace("", "AAAAAAAAAA").replace("", "AAAAAAAAAA")`,
+			wantMin: 10,
+		},
+		{
+			name:    "split",
+			expr:    `"a,b,c,d,e".split(",")`,
+			wantMin: 2,
+		},
+		{
+			name:    "substring",
+			expr:    `"hello world".substring(0, 5)`,
+			wantMin: 2,
+		},
+		{
+			name:    "trim",
+			expr:    `"  hello  ".trim()`,
+			wantMin: 2,
+		},
+		{
+			name:    "join",
+			expr:    `["a", "b", "c", "d", "e"].join("-")`,
+			wantMin: 2,
+		},
+		{
+			name:    "reverse",
+			expr:    `"hello".reverse()`,
+			wantMin: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := cel.NewEnv(Strings(StringsVersion(3)))
+			if err != nil {
+				t.Fatalf("cel.NewEnv() failed: %v", err)
+			}
+			ast, iss := env.Compile(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Compile(%q) failed: %v", tc.expr, iss.Err())
+			}
+			prg, err := env.Program(ast, cel.CostTracking(nil))
+			if err != nil {
+				t.Fatalf("env.Program() failed: %v", err)
+			}
+			_, det, err := prg.Eval(cel.NoVars())
+			if err != nil {
+				t.Fatalf("prg.Eval() failed: %v", err)
+			}
+			cost := det.ActualCost()
+			if cost == nil {
+				t.Fatal("cost tracking returned nil")
+			}
+			if *cost < tc.wantMin {
+				t.Errorf("cost for %q = %d, want at least %d", tc.expr, *cost, tc.wantMin)
+			}
+		})
+	}
+}
+
+func TestStringCostLimitEnforced(t *testing.T) {
+	env, err := cel.NewEnv(Strings())
+	if err != nil {
+		t.Fatalf("cel.NewEnv() failed: %v", err)
+	}
+	// Chained replaces that produce exponential output.
+	// Without cost tracking, this would be charged ~6. With tracking, the cost
+	// scales with output size and should exceed any reasonable limit.
+	expr := `"A".replace("", "AAAAAAAAAA").replace("", "AAAAAAAAAA").replace("", "AAAAAAAAAA").replace("", "AAAAAAAAAA").replace("", "AAAAAAAAAA").replace("", "AAAAAAAAAA")`
+	ast, iss := env.Compile(expr)
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast, cel.CostLimit(1000), cel.CostTracking(nil))
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	_, _, err = prg.Eval(cel.NoVars())
+	if err == nil {
+		t.Error("expected cost limit exceeded error for exponential string growth, got nil")
+	}
+}


### PR DESCRIPTION
`stringLib.ProgramOptions()` returns an empty slice, so string extension calls (replace, split, join, indexOf, etc.) all get charged a flat runtime cost of 1 in `costCall()` regardless of input size. This makes `CostLimit` ineffective for these operations — chained `replace` calls can produce exponentially growing output while staying under the cost budget.

The lists and regex extensions already register proper cost trackers. This adds the same for string extension overloads, version-gated to match function availability.