### PR TITLE
Default enable identifier escaping with backticks

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -42,6 +42,7 @@ type Parser struct {
 func NewParser(opts ...Option) (*Parser, error) {
 	p := &Parser{}
 	p.enableHiddenAccumulatorName = true
+	p.enableIdentEscapeSyntax = true
 	for _, opt := range opts {
 		if err := opt(&p.options); err != nil {
 			return nil, err


### PR DESCRIPTION
Default enable quoted identifiers