### PR TITLE
fix: deleted `IntToDuration` overload

### DIFF
--- a/cel/testdata/field_paths.prompt.txt
+++ b/cel/testdata/field_paths.prompt.txt
@@ -256,7 +256,6 @@ Functions:
 * duration - convert a value to a google.protobuf.Duration
 
       duration(duration('1s')) // duration('1s')
-      duration(int) -> google.protobuf.Duration
       duration('1h2m3s') // duration('3723s')
 
 * dyn - indicate that the type is dynamic for type-checking purposes

--- a/cel/testdata/standard_env.prompt.txt
+++ b/cel/testdata/standard_env.prompt.txt
@@ -219,7 +219,6 @@ Functions:
 * duration - convert a value to a google.protobuf.Duration
 
       duration(duration('1s')) // duration('1s')
-      duration(int) -> google.protobuf.Duration
       duration('1h2m3s') // duration('3723s')
 
 * dyn - indicate that the type is dynamic for type-checking purposes

--- a/common/overloads/overloads.go
+++ b/common/overloads/overloads.go
@@ -291,7 +291,6 @@ const (
 const (
 	DurationToDuration = "duration_to_duration"
 	StringToDuration   = "string_to_duration"
-	IntToDuration      = "int64_to_duration"
 )
 
 // Convert to dyn

--- a/common/stdlib/standard.go
+++ b/common/stdlib/standard.go
@@ -605,8 +605,6 @@ func init() {
 			decls.Overload(overloads.DurationToDuration, argTypes(types.DurationType), types.DurationType,
 				decls.OverloadExamples(`duration(duration('1s')) // duration('1s')`),
 				decls.UnaryBinding(identity)),
-			decls.Overload(overloads.IntToDuration, argTypes(types.IntType), types.DurationType,
-				decls.UnaryBinding(convertToType(types.DurationType))),
 			decls.Overload(overloads.StringToDuration, argTypes(types.StringType), types.DurationType,
 				decls.OverloadExamples(`duration('1h2m3s') // duration('3723s')`),
 				decls.UnaryBinding(convertToType(types.DurationType)))),


### PR DESCRIPTION
The conversion isn't implemented, but mostly isn't part of the language specification. The behavior remains mostly unchanged, the resulting error changes tho, still an error:

 - pre: type conversion error from 'int' to 'google.protobuf.Duration'
 - post: found no matching overload for 'duration' applied to '(int)'

The error would now be caught by the checker, instead of the evaluation time one previously.