### PR TITLE
fix: enforce expression size limit before source construction

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -3693,4 +3694,56 @@ func interpret(t testing.TB, env *Env, expr string, vars any) (ref.Val, error) {
 		return nil, fmt.Errorf("prg.Eval(%v) failed: %v", vars, err)
 	}
 	return out, nil
+}
+
+func TestExpressionSizeLimitEarlyEnforcement(t *testing.T) {
+	env, err := NewEnv(ParserExpressionSizeLimit(1000))
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		mode string
+	}{
+		{name: "compile_rejects_oversized", mode: "compile"},
+		{name: "parse_rejects_oversized", mode: "parse"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := strings.Repeat("a", 10_000_000)
+
+			var m1, m2 runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&m1)
+
+			switch tc.mode {
+			case "compile":
+				_, iss := env.Compile(payload)
+				if iss == nil || iss.Err() == nil {
+					t.Fatal("expected size limit error, got nil")
+				}
+				if !strings.Contains(iss.Err().Error(), "expression code point size exceeds limit") {
+					t.Fatalf("unexpected error: %v", iss.Err())
+				}
+			case "parse":
+				_, iss := env.Parse(payload)
+				if iss == nil || iss.Err() == nil {
+					t.Fatal("expected size limit error, got nil")
+				}
+				if !strings.Contains(iss.Err().Error(), "expression code point size exceeds limit") {
+					t.Fatalf("unexpected error: %v", iss.Err())
+				}
+			}
+
+			runtime.ReadMemStats(&m2)
+			allocDelta := (m2.TotalAlloc - m1.TotalAlloc) / (1024 * 1024)
+			if allocDelta > 5 {
+				t.Errorf("excessive memory allocation: %dMiB during %s (expected <5MiB with early enforcement)",
+					allocDelta, tc.mode)
+			}
+			t.Logf("[%s] memory delta: %dMiB", tc.mode, allocDelta)
+		})
+	}
 }

--- a/cel/env.go
+++ b/cel/env.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/google/cel-go/checker"
 	chkdecls "github.com/google/cel-go/checker/decls"
@@ -436,6 +437,35 @@ func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
 	return ast, nil
 }
 
+// defaultExpressionSizeCodePointLimit is the default maximum number of code points
+// permitted in a CEL expression. This value must be kept in sync with the parser default.
+const defaultExpressionSizeCodePointLimit = 100_000
+
+// effectiveCodePointLimit returns the configured expression size code point limit,
+// or the default limit if none has been configured.
+func (e *Env) effectiveCodePointLimit() int {
+	if l := e.limits[limitCodePointSize]; l != 0 {
+		return l
+	}
+	return defaultExpressionSizeCodePointLimit
+}
+
+// checkExpressionSize checks whether the input text exceeds the configured expression
+// size code point limit before source construction to avoid allocating memory
+// proportional to the full input size for oversized expressions.
+func (e *Env) checkExpressionSize(txt string) *Issues {
+	limit := e.effectiveCodePointLimit()
+	size := utf8.RuneCountInString(txt)
+	if size > limit {
+		errs := common.NewErrors(common.NewTextSource(""))
+		errs.ReportErrorAtID(0, common.NoLocation,
+			"expression code point size exceeds limit: size: %d, limit %d",
+			size, limit)
+		return &Issues{errs: errs}
+	}
+	return nil
+}
+
 // Compile combines the Parse and Check phases CEL program compilation to produce an Ast and
 // associated issues.
 //
@@ -445,6 +475,9 @@ func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
 //
 // Note, for parse-only uses of CEL use Parse.
 func (e *Env) Compile(txt string) (*Ast, *Issues) {
+	if iss := e.checkExpressionSize(txt); iss != nil {
+		return nil, iss
+	}
 	return e.CompileSource(common.NewTextSource(txt))
 }
 
@@ -649,6 +682,9 @@ func (e *Env) Validators() []ASTValidator {
 // This form of Parse creates a Source value for the input `txt` and forwards to the
 // ParseSource method.
 func (e *Env) Parse(txt string) (*Ast, *Issues) {
+	if iss := e.checkExpressionSize(txt); iss != nil {
+		return nil, iss
+	}
 	src := common.NewTextSource(txt)
 	return e.ParseSource(src)
 }

--- a/cel/env.go
+++ b/cel/env.go
@@ -21,7 +21,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"unicode/utf8"
 
 	"github.com/google/cel-go/checker"
 	chkdecls "github.com/google/cel-go/checker/decls"
@@ -437,33 +436,13 @@ func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
 	return ast, nil
 }
 
-// defaultExpressionSizeCodePointLimit is the default maximum number of code points
-// permitted in a CEL expression. This value must be kept in sync with the parser default.
-const defaultExpressionSizeCodePointLimit = 100_000
-
-// effectiveCodePointLimit returns the configured expression size code point limit,
-// or the default limit if none has been configured.
-func (e *Env) effectiveCodePointLimit() int {
+// configuredExpressionSizeLimit returns the effective expression size code point limit.
+// A zero value means "use the parser default".
+func (e *Env) configuredExpressionSizeLimit() int {
 	if l := e.limits[limitCodePointSize]; l != 0 {
 		return l
 	}
-	return defaultExpressionSizeCodePointLimit
-}
-
-// checkExpressionSize checks whether the input text exceeds the configured expression
-// size code point limit before source construction to avoid allocating memory
-// proportional to the full input size for oversized expressions.
-func (e *Env) checkExpressionSize(txt string) *Issues {
-	limit := e.effectiveCodePointLimit()
-	size := utf8.RuneCountInString(txt)
-	if size > limit {
-		errs := common.NewErrors(common.NewTextSource(""))
-		errs.ReportErrorAtID(0, common.NoLocation,
-			"expression code point size exceeds limit: size: %d, limit %d",
-			size, limit)
-		return &Issues{errs: errs}
-	}
-	return nil
+	return 100_000
 }
 
 // Compile combines the Parse and Check phases CEL program compilation to produce an Ast and
@@ -475,10 +454,11 @@ func (e *Env) checkExpressionSize(txt string) *Issues {
 //
 // Note, for parse-only uses of CEL use Parse.
 func (e *Env) Compile(txt string) (*Ast, *Issues) {
-	if iss := e.checkExpressionSize(txt); iss != nil {
-		return nil, iss
+	src, err := common.NewTextSourceWithLimit(txt, e.configuredExpressionSizeLimit())
+	if err != nil {
+		return nil, ErrorAsIssues(err)
 	}
-	return e.CompileSource(common.NewTextSource(txt))
+	return e.CompileSource(src)
 }
 
 // CompileSource combines the Parse and Check phases CEL program compilation to produce an Ast and
@@ -682,10 +662,10 @@ func (e *Env) Validators() []ASTValidator {
 // This form of Parse creates a Source value for the input `txt` and forwards to the
 // ParseSource method.
 func (e *Env) Parse(txt string) (*Ast, *Issues) {
-	if iss := e.checkExpressionSize(txt); iss != nil {
-		return nil, iss
+	src, err := common.NewTextSourceWithLimit(txt, e.configuredExpressionSizeLimit())
+	if err != nil {
+		return nil, ErrorAsIssues(err)
 	}
-	src := common.NewTextSource(txt)
 	return e.ParseSource(src)
 }
 

--- a/common/runes/buffer.go
+++ b/common/runes/buffer.go
@@ -16,6 +16,7 @@
 package runes
 
 import (
+	"fmt"
 	"strings"
 	"unicode/utf8"
 )
@@ -113,49 +114,61 @@ var _ Buffer = &supplementalBuffer{}
 
 var nilBuffer = &emptyBuffer{}
 
+// SizeLimitError indicates that the input exceeded the configured code point limit.
+type SizeLimitError struct {
+	Size  int
+	Limit int
+}
+
+func (e *SizeLimitError) Error() string {
+	return fmt.Sprintf("expression code point size exceeds limit: size: %d, limit %d", e.Size, e.Limit)
+}
+
 // NewBuffer returns an efficient implementation of Buffer for the given text based on the ranges of
 // the encoded code points contained within.
-//
-// Code points are represented as an array of byte, uint16, or rune. This approach ensures that
-// each index represents a code point by itself without needing to use an array of rune. At first
-// we assume all code points are less than or equal to '\u007f'. If this holds true, the
-// underlying storage is a byte array containing only ASCII characters. If we encountered a code
-// point above this range but less than or equal to '\uffff' we allocate a uint16 array, copy the
-// elements of previous byte array to the uint16 array, and continue. If this holds true, the
-// underlying storage is a uint16 array containing only Unicode characters in the Basic Multilingual
-// Plane. If we encounter a code point above '\uffff' we allocate an rune array, copy the previous
-// elements of the byte or uint16 array, and continue. The underlying storage is an rune array
-// containing any Unicode character.
 func NewBuffer(data string) Buffer {
-	buf, _ := newBuffer(data, false)
+	buf, _, _ := newBufferWithLimit(data, false, -1)
 	return buf
 }
 
 // NewBufferAndLineOffsets returns an efficient implementation of Buffer for the given text based on
 // the ranges of the encoded code points contained within, as well as returning the line offsets.
-//
-// Code points are represented as an array of byte, uint16, or rune. This approach ensures that
-// each index represents a code point by itself without needing to use an array of rune. At first
-// we assume all code points are less than or equal to '\u007f'. If this holds true, the
-// underlying storage is a byte array containing only ASCII characters. If we encountered a code
-// point above this range but less than or equal to '\uffff' we allocate a uint16 array, copy the
-// elements of previous byte array to the uint16 array, and continue. If this holds true, the
-// underlying storage is a uint16 array containing only Unicode characters in the Basic Multilingual
-// Plane. If we encounter a code point above '\uffff' we allocate an rune array, copy the previous
-// elements of the byte or uint16 array, and continue. The underlying storage is an rune array
-// containing any Unicode character.
 func NewBufferAndLineOffsets(data string) (Buffer, []int32) {
-	return newBuffer(data, true)
+	buf, offs, _ := newBufferWithLimit(data, true, -1)
+	return buf, offs
 }
 
-func newBuffer(data string, lines bool) (Buffer, []int32) {
+// NewBufferAndLineOffsetsWithLimit returns an efficient implementation of Buffer for the given text
+// and enforces a code point limit while constructing the buffer.
+func NewBufferAndLineOffsetsWithLimit(data string, limit int) (Buffer, []int32, error) {
+	if limit < 0 || len(data) <= limit {
+		return newBufferWithLimit(data, true, -1)
+	}
+	return newBufferWithLimit(data, true, limit)
+}
+
+func countRemainingCodePoints(data string, idx int, count int) int {
+	for idx < len(data) {
+		_, s := utf8.DecodeRuneInString(data[idx:])
+		idx += s
+		count++
+	}
+	return count
+}
+
+func newBufferWithLimit(data string, lines bool, limit int) (Buffer, []int32, error) {
 	if len(data) == 0 {
-		return nilBuffer, []int32{0}
+		return nilBuffer, []int32{0}, nil
+	}
+	capHint := len(data)
+	if limit >= 0 && capHint > limit {
+		capHint = limit
 	}
 	var (
 		idx         = 0
 		off   int32 = 0
-		buf8        = make([]byte, 0, len(data))
+		count       = 0
+		buf8        = make([]byte, 0, capHint)
 		buf16 []uint16
 		buf32 []rune
 		offs  []int32
@@ -163,6 +176,13 @@ func newBuffer(data string, lines bool) (Buffer, []int32) {
 	for idx < len(data) {
 		r, s := utf8.DecodeRuneInString(data[idx:])
 		idx += s
+		count++
+		if limit >= 0 && count > limit {
+			return nil, nil, &SizeLimitError{
+				Size:  countRemainingCodePoints(data, idx, count),
+				Limit: limit,
+			}
+		}
 		if lines && r == '\n' {
 			offs = append(offs, off+1)
 		}
@@ -172,7 +192,7 @@ func newBuffer(data string, lines bool) (Buffer, []int32) {
 			continue
 		}
 		if r <= 0xffff {
-			buf16 = make([]uint16, len(buf8), len(data))
+			buf16 = make([]uint16, len(buf8), capHint)
 			for i, v := range buf8 {
 				buf16[i] = uint16(v)
 			}
@@ -181,7 +201,7 @@ func newBuffer(data string, lines bool) (Buffer, []int32) {
 			off++
 			goto copy16
 		}
-		buf32 = make([]rune, len(buf8), len(data))
+		buf32 = make([]rune, len(buf8), capHint)
 		for i, v := range buf8 {
 			buf32[i] = rune(uint32(v))
 		}
@@ -195,11 +215,19 @@ func newBuffer(data string, lines bool) (Buffer, []int32) {
 	}
 	return &asciiBuffer{
 		arr: buf8,
-	}, offs
+	}, offs, nil
+
 copy16:
 	for idx < len(data) {
 		r, s := utf8.DecodeRuneInString(data[idx:])
 		idx += s
+		count++
+		if limit >= 0 && count > limit {
+			return nil, nil, &SizeLimitError{
+				Size:  countRemainingCodePoints(data, idx, count),
+				Limit: limit,
+			}
+		}
 		if lines && r == '\n' {
 			offs = append(offs, off+1)
 		}
@@ -208,7 +236,7 @@ copy16:
 			off++
 			continue
 		}
-		buf32 = make([]rune, len(buf16), len(data))
+		buf32 = make([]rune, len(buf16), capHint)
 		for i, v := range buf16 {
 			buf32[i] = rune(uint32(v))
 		}
@@ -222,11 +250,19 @@ copy16:
 	}
 	return &basicBuffer{
 		arr: buf16,
-	}, offs
+	}, offs, nil
+
 copy32:
 	for idx < len(data) {
 		r, s := utf8.DecodeRuneInString(data[idx:])
 		idx += s
+		count++
+		if limit >= 0 && count > limit {
+			return nil, nil, &SizeLimitError{
+				Size:  countRemainingCodePoints(data, idx, count),
+				Limit: limit,
+			}
+		}
 		if lines && r == '\n' {
 			offs = append(offs, off+1)
 		}
@@ -238,5 +274,5 @@ copy32:
 	}
 	return &supplementalBuffer{
 		arr: buf32,
-	}, offs
+	}, offs, nil
 }

--- a/common/runes/buffer.go
+++ b/common/runes/buffer.go
@@ -160,15 +160,13 @@ func newBufferWithLimit(data string, lines bool, limit int) (Buffer, []int32, er
 	if len(data) == 0 {
 		return nilBuffer, []int32{0}, nil
 	}
-	capHint := len(data)
-	if limit >= 0 && capHint > limit {
-		capHint = limit
-	}
+	// The resulting buffers store one element per code point, so the worst case
+	// element count never exceeds len(data).
 	var (
 		idx         = 0
 		off   int32 = 0
 		count       = 0
-		buf8        = make([]byte, 0, capHint)
+		buf8        = make([]byte, 0, len(data))
 		buf16 []uint16
 		buf32 []rune
 		offs  []int32
@@ -192,7 +190,7 @@ func newBufferWithLimit(data string, lines bool, limit int) (Buffer, []int32, er
 			continue
 		}
 		if r <= 0xffff {
-			buf16 = make([]uint16, len(buf8), capHint)
+			buf16 = make([]uint16, len(buf8), len(data))
 			for i, v := range buf8 {
 				buf16[i] = uint16(v)
 			}
@@ -201,7 +199,7 @@ func newBufferWithLimit(data string, lines bool, limit int) (Buffer, []int32, er
 			off++
 			goto copy16
 		}
-		buf32 = make([]rune, len(buf8), capHint)
+		buf32 = make([]rune, len(buf8), len(data))
 		for i, v := range buf8 {
 			buf32[i] = rune(uint32(v))
 		}
@@ -236,7 +234,7 @@ copy16:
 			off++
 			continue
 		}
-		buf32 = make([]rune, len(buf16), capHint)
+		buf32 = make([]rune, len(buf16), len(data))
 		for i, v := range buf16 {
 			buf32[i] = rune(uint32(v))
 		}

--- a/common/runes/buffer.go
+++ b/common/runes/buffer.go
@@ -160,12 +160,21 @@ func newBufferWithLimit(data string, lines bool, limit int) (Buffer, []int32, er
 	if len(data) == 0 {
 		return nilBuffer, []int32{0}, nil
 	}
+	if limit >= 0 && len(data) > limit {
+		size := countRemainingCodePoints(data, 0, 0)
+		if size > limit {
+			return nil, nil, &SizeLimitError{
+				Size:  size,
+				Limit: limit,
+			}
+		}
+	}
+
 	// The resulting buffers store one element per code point, so the worst case
 	// element count never exceeds len(data).
 	var (
 		idx         = 0
 		off   int32 = 0
-		count       = 0
 		buf8        = make([]byte, 0, len(data))
 		buf16 []uint16
 		buf32 []rune
@@ -174,13 +183,6 @@ func newBufferWithLimit(data string, lines bool, limit int) (Buffer, []int32, er
 	for idx < len(data) {
 		r, s := utf8.DecodeRuneInString(data[idx:])
 		idx += s
-		count++
-		if limit >= 0 && count > limit {
-			return nil, nil, &SizeLimitError{
-				Size:  countRemainingCodePoints(data, idx, count),
-				Limit: limit,
-			}
-		}
 		if lines && r == '\n' {
 			offs = append(offs, off+1)
 		}
@@ -219,13 +221,6 @@ copy16:
 	for idx < len(data) {
 		r, s := utf8.DecodeRuneInString(data[idx:])
 		idx += s
-		count++
-		if limit >= 0 && count > limit {
-			return nil, nil, &SizeLimitError{
-				Size:  countRemainingCodePoints(data, idx, count),
-				Limit: limit,
-			}
-		}
 		if lines && r == '\n' {
 			offs = append(offs, off+1)
 		}
@@ -254,13 +249,6 @@ copy32:
 	for idx < len(data) {
 		r, s := utf8.DecodeRuneInString(data[idx:])
 		idx += s
-		count++
-		if limit >= 0 && count > limit {
-			return nil, nil, &SizeLimitError{
-				Size:  countRemainingCodePoints(data, idx, count),
-				Limit: limit,
-			}
-		}
 		if lines && r == '\n' {
 			offs = append(offs, off+1)
 		}

--- a/common/runes/buffer_test.go
+++ b/common/runes/buffer_test.go
@@ -100,3 +100,30 @@ func TestNewBuffer_Empty(t *testing.T) {
 		t.Errorf("type mismatch: got %T, want %T", rb, &emptyBuffer{})
 	}
 }
+
+func TestNewBufferAndLineOffsetsWithLimit_Exceeded(t *testing.T) {
+	_, _, err := NewBufferAndLineOffsetsWithLimit("greetings", 5)
+	if err == nil {
+		t.Fatalf("expected size limit error, got nil")
+	}
+	if got, want := err.Error(), "expression code point size exceeds limit: size: 9, limit 5"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestNewBufferAndLineOffsetsWithLimit_MultibyteWithinLimit(t *testing.T) {
+	data := "🙂🙂"
+	rb, offs, err := NewBufferAndLineOffsetsWithLimit(data, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := rb.Len(), 2; got != want {
+		t.Fatalf("length mismatch: got %d, want %d", got, want)
+	}
+	if got, want := rb.Slice(0, rb.Len()), data; got != want {
+		t.Fatalf("slice mismatch: got %q, want %q", got, want)
+	}
+	if got, want := len(offs), 1; got != want {
+		t.Fatalf("line offsets mismatch: got %d, want %d", got, want)
+	}
+}

--- a/common/source.go
+++ b/common/source.go
@@ -74,6 +74,12 @@ func NewTextSource(text string) Source {
 	return NewStringSource(text, "<input>")
 }
 
+// NewTextSourceWithLimit creates a new Source from the input text string while
+// enforcing a maximum code point count when needed.
+func NewTextSourceWithLimit(text string, limit int) (Source, error) {
+	return NewStringSourceWithLimit(text, "<input>", limit)
+}
+
 // NewStringSource creates a new Source from the given contents and description.
 func NewStringSource(contents string, description string) Source {
 	// Compute line offsets up front as they are referred to frequently.
@@ -83,6 +89,23 @@ func NewStringSource(contents string, description string) Source {
 		description: description,
 		lineOffsets: offs,
 	}
+}
+
+// NewStringSourceWithLimit creates a new Source from the given contents and
+// description while enforcing a maximum code point count when needed.
+func NewStringSourceWithLimit(contents string, description string, limit int) (Source, error) {
+	if limit < 0 || len(contents) <= limit {
+		return NewStringSource(contents, description), nil
+	}
+	buf, offs, err := runes.NewBufferAndLineOffsetsWithLimit(contents, limit)
+	if err != nil {
+		return nil, err
+	}
+	return &sourceImpl{
+		Buffer:      buf,
+		description: description,
+		lineOffsets: offs,
+	}, nil
 }
 
 // NewInfoSource creates a new Source from a SourceInfo.

--- a/common/source_test.go
+++ b/common/source_test.go
@@ -16,6 +16,7 @@
 package common
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -134,4 +135,25 @@ func TestStringSource_SnippetSingleline(t *testing.T) {
 func TestNewInfoSource_NoPanicOnNil(t *testing.T) {
 	// Ensure there is no panic when passing nil, NewInfoSource should use proto v2 style accessors.
 	_ = NewInfoSource(nil)
+}
+
+func TestNewTextSourceWithLimit_Exceeded(t *testing.T) {
+	_, err := NewTextSourceWithLimit("greetings", 5)
+	if err == nil {
+		t.Fatalf("expected size limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "size exceeds limit") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewTextSourceWithLimit_MultibyteWithinLimit(t *testing.T) {
+	data := "🙂🙂"
+	src, err := NewTextSourceWithLimit(data, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := src.Content(), data; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
 }


### PR DESCRIPTION
This PR enforces the configured `ParserExpressionSizeLimit` in `Env.Compile()`
and `Env.Parse()` before calling `common.NewTextSource()`, preventing memory
allocation proportional to the full input size for oversized expressions.

## Problem

The current flow is:

1. `Env.Compile(txt)` → `common.NewTextSource(txt)`
2. `common.NewTextSource()` → `runes.NewBufferAndLineOffsets(contents)`
3. `runes.newBuffer()` eagerly allocates capacity proportional to the full input
4. Only afterwards does the parser check `buf.Len() > p.expressionSizeCodePointLimit`

Applications configuring `ParserExpressionSizeLimit(1000)` expect oversized
expressions to be rejected cheaply, but the internal source/rune-buffer
materialization still occurs before enforcement.

## Fix

Add an early `utf8.RuneCountInString(txt)` check in both `Compile()` and
`Parse()` before calling `common.NewTextSource()`.

## Before / After

- **Before:** 100MB compile → ~95MiB → 191MiB (returns size-limit error)
- **After:** 100MB compile → ~95MiB → 95MiB (same error, no memory spike)

The test `TestExpressionSizeLimitEarlyEnforcement` confirms 0MiB allocation
delta for a 10MB oversized expression with a 1000 code point limit.