### PR TITLE
Preserve operation interrupted in ContextEval error

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -1160,8 +1160,11 @@ func TestContextEval(t *testing.T) {
 	if err == nil {
 		t.Errorf("Got result %v, wanted timeout error", out)
 	}
-	if err != nil && err.Error() != "context deadline exceeded" {
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("Got %v, wanted context deadline exceeded", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "operation interrupted") {
+		t.Errorf("Got %v, wanted error containing 'operation interrupted'", err)
 	}
 }
 

--- a/cel/program.go
+++ b/cel/program.go
@@ -370,7 +370,7 @@ func (p *prog) ContextEval(ctx context.Context, input any) (ref.Val, *EvalDetail
 	}
 	out, det, err := p.Eval(vars)
 	if err != nil && errors.Is(err, interpreter.InterruptError{}) {
-		return out, det, context.Cause(ctx)
+		return out, det, fmt.Errorf("%w: %w", err, context.Cause(ctx))
 	}
 	return out, det, err
 }


### PR DESCRIPTION
When ContextEval detects an InterruptError, wrap both the original error and the context cause using `fmt.Errorf("%w: %w", ...)` so that:
- `errors.Is(err, context.Canceled)` works (new behavior)
- `errors.Is(err, context.DeadlineExceeded)` works (new behavior)
- `errors.Is(err, InterruptError{})` works (preserved)
- `strings.Contains(err.Error(), "operation interrupted")` works (backward compat)

Previously, the error was replaced entirely with context.Cause(ctx), which dropped the "operation interrupted" message that downstream consumers (e.g. Kubernetes) rely on for string matching.

Fixes #1195 while maintaining backward compatibility.

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests