### PR TITLE
Use shorthand type specifiers in env yaml files

### DIFF
--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -545,6 +545,28 @@ func TestEnvFromConfig(t *testing.T) {
 			},
 		},
 		{
+			name:       "std env - wrapper type aliases",
+			beforeOpts: []EnvOption{Types(&proto3pb.TestAllTypes{})},
+			conf: env.NewConfig("std env - wrapper_type_aliases").
+				AddVariables(env.NewVariable("single_int64_wrapper", env.NewTypeDesc("int_wrapper")),
+					env.NewVariable("single_double_wrapper", env.NewTypeDesc("double_wrapper"))),
+
+			exprs: []exprCase{
+				{
+					name: "eq_int_wrapper",
+					in:   map[string]any{"single_int64_wrapper": 42},
+					expr: "single_int64_wrapper != null && single_int64_wrapper == 42",
+					out:  types.True,
+				},
+				{
+					name: "eq_double_wrapper",
+					in:   map[string]any{"single_double_wrapper": 42.1},
+					expr: "single_double_wrapper != null && single_double_wrapper == 42.1",
+					out:  types.True,
+				},
+			},
+		},
+		{
 			name:       "custom env - variables",
 			beforeOpts: []EnvOption{Types(&proto3pb.TestAllTypes{})},
 			conf: env.NewConfig("custom env - variables").

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -258,6 +258,8 @@ type Variable struct {
 
 	// Type represents the type declaration for the variable.
 	//
+	// When serialized, 'type' is used for shorthand specifier string.
+	//
 	// Deprecated: use the embedded *TypeDesc fields directly.
 	Type *TypeDesc `yaml:"type,omitempty"`
 

--- a/common/env/env.go
+++ b/common/env/env.go
@@ -260,7 +260,7 @@ type Variable struct {
 	//
 	// When serialized, 'type' is used for shorthand specifier string.
 	//
-	// Deprecated: use the embedded *TypeDesc fields directly.
+	// Use GetType() for getting the effective type.
 	Type *TypeDesc `yaml:"type,omitempty"`
 
 	// TypeDesc is an embedded set of fields allowing for the specification of the Variable type.

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -35,11 +35,10 @@ import (
 func TestConfig(t *testing.T) {
 	tests := []struct {
 		name string
-		json bool
 		want *Config
 	}{
 		{
-			name: "context_env",
+			name: "context_env.yaml",
 			want: NewConfig("context-env").
 				SetContainer("google.expr").
 				AddImports(NewImport("google.expr.proto3.test.TestAllTypes")).
@@ -76,7 +75,7 @@ func TestConfig(t *testing.T) {
 				),
 		},
 		{
-			name: "extended_env",
+			name: "extended_env.yaml",
 			want: NewConfig("extended-env").
 				SetContainer("google.expr").
 				AddExtensions(
@@ -108,7 +107,7 @@ func TestConfig(t *testing.T) {
 						`determines whether a list is empty,`,
 						`or a string has no characters`),
 					NewMemberOverload("wrapper_string_isEmpty",
-						NewTypeDesc("google.protobuf.StringValue"), nil,
+						NewTypeDesc("string_wrapper"), nil,
 						NewTypeDesc("bool"),
 						`''.isEmptyAlt() // true`),
 					NewMemberOverload("list_isEmpty",
@@ -142,8 +141,7 @@ func TestConfig(t *testing.T) {
 			),
 		},
 		{
-			name: "extended_env",
-			json: true,
+			name: "json_env.json",
 			want: NewConfig("extended-env").
 				SetContainer("google.expr").
 				AddExtensions(
@@ -162,7 +160,7 @@ func TestConfig(t *testing.T) {
 						`determines whether a list is empty,`,
 						`or a string has no characters`),
 					NewMemberOverload("wrapper_string_isEmpty",
-						NewTypeDesc("google.protobuf.StringValue"), nil,
+						NewTypeDesc("wrapper_string"), nil,
 						NewTypeDesc("bool"),
 						`''.isEmpty() // true`),
 					NewMemberOverload("list_isEmpty",
@@ -170,19 +168,6 @@ func TestConfig(t *testing.T) {
 						NewTypeDesc("bool"),
 						`[].isEmpty() // true`,
 						`[1].isEmpty() // false`)),
-				NewFunctionWithDoc("isEmptyAlt",
-					common.MultilineDescription(
-						`determines whether a list is empty,`,
-						`or a string has no characters`),
-					NewMemberOverload("wrapper_string_isEmpty",
-						NewTypeDesc("google.protobuf.StringValue"), nil,
-						NewTypeDesc("bool"),
-						`''.isEmptyAlt() // true`),
-					NewMemberOverload("list_isEmpty",
-						NewTypeDesc("list", NewTypeParam("T")), nil,
-						NewTypeDesc("bool"),
-						`[].isEmptyAlt() // true`,
-						`[1].isEmptyAlt() // false`)),
 				NewFunctionWithDoc(
 					"getOrDefault",
 					common.MultilineDescription(
@@ -209,7 +194,7 @@ func TestConfig(t *testing.T) {
 			),
 		},
 		{
-			name: "subset_env",
+			name: "subset_env.yaml",
 			want: NewConfig("subset-env").
 				SetStdLib(NewLibrarySubset().
 					AddExcludedMacros("map", "filter").
@@ -238,10 +223,7 @@ func TestConfig(t *testing.T) {
 	for _, tst := range tests {
 		tc := tst
 		t.Run(tc.name, func(t *testing.T) {
-			fileName := fmt.Sprintf("testdata/%s.yaml", tc.name)
-			if tc.json {
-				fileName = fmt.Sprintf("testdata/%s.json", tc.name)
-			}
+			fileName := fmt.Sprintf("testdata/%s", tc.name)
 			data, err := os.ReadFile(fileName)
 			if err != nil {
 				t.Fatalf("os.ReadFile(%q) failed: %v", fileName, err)
@@ -753,6 +735,14 @@ func TestVariableAsCELVariable(t *testing.T) {
 			v: &Variable{
 				Name:     "msg",
 				TypeDesc: NewTypeDesc("google.protobuf.StringValue"),
+			},
+			want: decls.NewVariable("msg", types.NewNullableType(types.StringType)),
+		},
+		{
+			name: "wrapper type alias variable",
+			v: &Variable{
+				Name:     "msg",
+				TypeDesc: NewTypeDesc("string_wrapper"),
 			},
 			want: decls.NewVariable("msg", types.NewNullableType(types.StringType)),
 		},

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -35,6 +35,7 @@ import (
 func TestConfig(t *testing.T) {
 	tests := []struct {
 		name string
+		json bool
 		want *Config
 	}{
 		{
@@ -141,6 +142,73 @@ func TestConfig(t *testing.T) {
 			),
 		},
 		{
+			name: "extended_env",
+			json: true,
+			want: NewConfig("extended-env").
+				SetContainer("google.expr").
+				AddExtensions(
+					NewExtension("optional", 2),
+					NewExtension("math", math.MaxUint32),
+				).AddVariables(
+				NewVariableWithDoc("msg",
+					NewTypeDesc("google.expr.proto3.test.TestAllTypes"),
+					`msg represents all possible type permutation which CEL understands from a proto perspective`),
+				NewVariableWithDoc("opt_msg",
+					NewTypeDesc("optional_type", NewTypeDesc("google.expr.proto3.test.TestAllTypes")),
+					`opt_msg represents all possible type permutation which CEL understands from a proto perspective`),
+			).AddFunctions(
+				NewFunctionWithDoc("isEmpty",
+					common.MultilineDescription(
+						`determines whether a list is empty,`,
+						`or a string has no characters`),
+					NewMemberOverload("wrapper_string_isEmpty",
+						NewTypeDesc("google.protobuf.StringValue"), nil,
+						NewTypeDesc("bool"),
+						`''.isEmpty() // true`),
+					NewMemberOverload("list_isEmpty",
+						NewTypeDesc("list", NewTypeParam("T")), nil,
+						NewTypeDesc("bool"),
+						`[].isEmpty() // true`,
+						`[1].isEmpty() // false`)),
+				NewFunctionWithDoc("isEmptyAlt",
+					common.MultilineDescription(
+						`determines whether a list is empty,`,
+						`or a string has no characters`),
+					NewMemberOverload("wrapper_string_isEmpty",
+						NewTypeDesc("google.protobuf.StringValue"), nil,
+						NewTypeDesc("bool"),
+						`''.isEmptyAlt() // true`),
+					NewMemberOverload("list_isEmpty",
+						NewTypeDesc("list", NewTypeParam("T")), nil,
+						NewTypeDesc("bool"),
+						`[].isEmptyAlt() // true`,
+						`[1].isEmptyAlt() // false`)),
+				NewFunctionWithDoc(
+					"getOrDefault",
+					common.MultilineDescription(
+						"Returns the value of a key in a map or the provided",
+						"default value."),
+					NewMemberOverload("map_getOrDefault",
+						NewTypeDesc("map", NewTypeParam("K"), NewTypeParam("V")),
+						[]*TypeDesc{
+							NewTypeParam("K"),
+							NewTypeParam("V"),
+						},
+						NewTypeParam("V"),
+					)),
+			).AddFeatures(
+				NewFeature("cel.feature.macro_call_tracking", true),
+			).AddLimits(
+				NewLimit("cel.limit.parse_recursion_depth", 7),
+			).AddValidators(
+				NewValidator("cel.validator.duration"),
+				NewValidator("cel.validator.matches"),
+				NewValidator("cel.validator.timestamp"),
+				NewValidator("cel.validator.comprehension_nesting_limit").
+					SetConfig(map[string]any{"limit": 2}),
+			),
+		},
+		{
 			name: "subset_env",
 			want: NewConfig("subset-env").
 				SetStdLib(NewLibrarySubset().
@@ -171,6 +239,9 @@ func TestConfig(t *testing.T) {
 		tc := tst
 		t.Run(tc.name, func(t *testing.T) {
 			fileName := fmt.Sprintf("testdata/%s.yaml", tc.name)
+			if tc.json {
+				fileName = fmt.Sprintf("testdata/%s.json", tc.name)
+			}
 			data, err := os.ReadFile(fileName)
 			if err != nil {
 				t.Fatalf("os.ReadFile(%q) failed: %v", fileName, err)

--- a/common/env/testdata/context_env.yaml
+++ b/common/env/testdata/context_env.yaml
@@ -43,23 +43,20 @@ functions:
           - "coalesce(null, 1) // 1"
           - "coalesce(2, 1) // 2"
         args:
-          - type_name: "google.protobuf.Int64Value"
-          - type_name: "int"
-        return:
-          type_name: "int"
+          - "google.protobuf.Int64Value"
+          - "int"
+        return: "int"
       - id: "coalesce_wrapped_double"
         examples:
           - "coalesce(null, 1.3) // 1.3"
         args:
-          - type_name: "google.protobuf.DoubleValue"
-          - type_name: "double"
-        return:
-          type_name: "double"
+          - "google.protobuf.DoubleValue"
+          - "double"
+        return: "double"
       - id: "coalesce_wrapped_uint"
         examples:
           - "coalesce(null, 14u) // 14u"
         args:
-          - type_name: "google.protobuf.UInt64Value"
-          - type_name: "uint"
-        return:
-          type_name: "uint"
+          - "google.protobuf.UInt64Value"
+          - "uint"
+        return: "uint"

--- a/common/env/testdata/extended_env.json
+++ b/common/env/testdata/extended_env.json
@@ -1,0 +1,132 @@
+{
+  "name": "extended-env",
+  "container": "google.expr",
+  "extensions": [
+    {
+      "name": "optional",
+      "version": "2"
+    },
+    {
+      "name": "math",
+      "version": "latest"
+    }
+  ],
+  "variables": [
+    {
+      "name": "msg",
+      "type_name": "google.expr.proto3.test.TestAllTypes",
+      "description": "msg represents all possible type permutation which CEL understands from a proto perspective"
+    },
+    {
+      "name": "opt_msg",
+      "type": "optional_type<google.expr.proto3.test.TestAllTypes>",
+      "description": "opt_msg represents all possible type permutation which CEL understands from a proto perspective"
+    }
+  ],
+  "functions": [
+    {
+      "name": "isEmpty",
+      "description": "determines whether a list is empty,\nor a string has no characters",
+      "overloads": [
+        {
+          "id": "wrapper_string_isEmpty",
+          "examples": [
+            "''.isEmpty() // true"
+          ],
+          "target": {
+            "type_name": "google.protobuf.StringValue"
+          },
+          "return": {
+            "type_name": "bool"
+          }
+        },
+        {
+          "id": "list_isEmpty",
+          "examples": [
+            "[].isEmpty() // true",
+            "[1].isEmpty() // false"
+          ],
+          "target": {
+            "type_name": "list",
+            "params": [
+              {
+                "type_name": "T",
+                "is_type_param": true
+              }
+            ]
+          },
+          "return": {
+            "type_name": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "isEmptyAlt",
+      "description": "determines whether a list is empty,\nor a string has no characters",
+      "overloads": [
+        {
+          "id": "wrapper_string_isEmpty",
+          "examples": [
+            "''.isEmptyAlt() // true"
+          ],
+          "target": "google.protobuf.StringValue",
+          "return": "bool"
+        },
+        {
+          "id": "list_isEmpty",
+          "examples": [
+            "[].isEmptyAlt() // true",
+            "[1].isEmptyAlt() // false"
+          ],
+          "target": "list<~T>",
+          "return": "bool"
+        }
+      ]
+    },
+    {
+      "name": "getOrDefault",
+      "description": "Returns the value of a key in a map or the provided\ndefault value.",
+      "overloads": [
+        {
+          "id": "map_getOrDefault",
+          "target": "map<~K, ~V>",
+          "return": "~V",
+          "args": [
+            "~K",
+            "~V"
+          ]
+        }
+      ]
+    }
+  ],
+  "validators": [
+    {
+      "name": "cel.validator.duration"
+    },
+    {
+      "name": "cel.validator.matches"
+    },
+    {
+      "name": "cel.validator.timestamp"
+    },
+    {
+      "name": "cel.validator.comprehension_nesting_limit",
+      "config": {
+        "limit": 2
+      }
+    }
+  ],
+  "features": [
+    {
+      "name": "cel.feature.macro_call_tracking",
+      "enabled": true
+    }
+  ],
+  "limits": [
+    {
+      "name": "cel.limit.parse_recursion_depth",
+      "value": 7
+    }
+  ]
+}

--- a/common/env/testdata/extended_env.yaml
+++ b/common/env/testdata/extended_env.yaml
@@ -62,7 +62,7 @@ functions:
       - id: "wrapper_string_isEmpty"
         examples:
           - "''.isEmptyAlt() // true"
-        target: "google.protobuf.StringValue"
+        target: "string_wrapper"
         return: "bool"
       - id: "list_isEmpty"
         examples:

--- a/common/env/testdata/json_env.json
+++ b/common/env/testdata/json_env.json
@@ -1,5 +1,5 @@
 {
-  "name": "extended-env",
+  "name": "json-env",
   "container": "google.expr",
   "extensions": [
     {
@@ -14,7 +14,7 @@
   "variables": [
     {
       "name": "msg",
-      "type_name": "google.expr.proto3.test.TestAllTypes",
+      "type": "google.expr.proto3.test.TestAllTypes",
       "description": "msg represents all possible type permutation which CEL understands from a proto perspective"
     },
     {
@@ -33,51 +33,14 @@
           "examples": [
             "''.isEmpty() // true"
           ],
-          "target": {
-            "type_name": "google.protobuf.StringValue"
-          },
-          "return": {
-            "type_name": "bool"
-          }
+          "target": "wrapper_string",
+          "return": "bool"
         },
         {
           "id": "list_isEmpty",
           "examples": [
             "[].isEmpty() // true",
             "[1].isEmpty() // false"
-          ],
-          "target": {
-            "type_name": "list",
-            "params": [
-              {
-                "type_name": "T",
-                "is_type_param": true
-              }
-            ]
-          },
-          "return": {
-            "type_name": "bool"
-          }
-        }
-      ]
-    },
-    {
-      "name": "isEmptyAlt",
-      "description": "determines whether a list is empty,\nor a string has no characters",
-      "overloads": [
-        {
-          "id": "wrapper_string_isEmpty",
-          "examples": [
-            "''.isEmptyAlt() // true"
-          ],
-          "target": "google.protobuf.StringValue",
-          "return": "bool"
-        },
-        {
-          "id": "list_isEmpty",
-          "examples": [
-            "[].isEmptyAlt() // true",
-            "[1].isEmptyAlt() // false"
           ],
           "target": "list<~T>",
           "return": "bool"

--- a/common/env/testdata/subset_env.yaml
+++ b/common/env/testdata/subset_env.yaml
@@ -32,8 +32,8 @@ stdlib:
         - id: "string_to_duration"
 variables:
   - name: "x"
-    type_name: "int"
+    type: "int"
   - name: "y"
-    type_name: "double"
+    type: "double"
   - name: "z"
-    type_name: "uint"
+    type: "uint"

--- a/repl/evaluator_test.go
+++ b/repl/evaluator_test.go
@@ -1115,20 +1115,20 @@ name: repl-session
 container: google
 variables:
     - name: x
-      type_name: int
+      type: int
 functions:
     - name: fn
       overloads:
         - id: fn
-          return:
-            type_name: int
+          args: ["int"]
+          return: "int"
 features:
     - name: cel.feature.macro_call_tracking
       enabled: true
 
 
 # REPL Bindings: 
-# %let fn() : int -> 2
+# %let fn(x : int) : int -> x + 2
 #
 # %let x = 1
 #`,
@@ -1149,6 +1149,8 @@ functions:
     - name: fn
       overloads:
         - id: fn
+          args:
+            - type_name: int
           return:
             type_name: int
 features:
@@ -1157,7 +1159,7 @@ features:
 
 
 # REPL Bindings: 
-# %let fn() : int -> 2
+# %let fn(x: int) : int -> x + 2
 #
 # %let x = 1
 #

--- a/repl/testdata/multiline_test_env.yaml
+++ b/repl/testdata/multiline_test_env.yaml
@@ -21,9 +21,9 @@ extensions:
       version: latest
 variables:
     - name: pb3
-      type_name: cel.expr.conformance.proto3.TestAllTypes
+      type: cel.expr.conformance.proto3.TestAllTypes
     - name: pb2
-      type_name: cel.expr.conformance.proto2.TestAllTypes
+      type: cel.expr.conformance.proto2.TestAllTypes
 features:
     - name: cel.feature.macro_call_tracking
       enabled: true

--- a/repl/testdata/test_env.yaml
+++ b/repl/testdata/test_env.yaml
@@ -21,9 +21,9 @@ extensions:
       version: latest
 variables:
     - name: pb3
-      type_name: cel.expr.conformance.proto3.TestAllTypes
+      type: cel.expr.conformance.proto3.TestAllTypes
     - name: pb2
-      type_name: cel.expr.conformance.proto2.TestAllTypes
+      type: cel.expr.conformance.proto2.TestAllTypes
 features:
     - name: cel.feature.macro_call_tracking
       enabled: true

--- a/tools/compiler/testdata/config.yaml
+++ b/tools/compiler/testdata/config.yaml
@@ -25,19 +25,13 @@ stdlib:
     - name: "_==_"
       overloads:
         - id: equals
-          args:
-            - type_name: "string"
-            - type_name: "string"
-          return:
-            type_name: "bool"
+          args: ["string", "string"]
+          return: "bool"
     - name: "_||_"
       overloads:
         - id: logical_or
-          args:
-            - type_name: "bool"
-            - type_name: "bool"
-          return:
-            type_name: "bool"
+          args: ["bool", "bool"]
+          return: "bool"
 extensions:
   - name: "lists"
     version: "latest"
@@ -45,33 +39,23 @@ extensions:
     version: "latest"
 variables:
   - name: "destination.ip"
-    type_name: "string"
+    type: "string"
   - name: "origin.ip"
-    type_name: "string"
+    type: "string"
   - name: "spec.restricted_destinations"
-    type_name: "list"
-    params:
-      - type_name: "string"
+    type: "list<string>"
   - name: "spec.origin"
-    type_name: "string"
+    type: "string"
   - name: "request"
-    type_name: "map"
-    params:
-      - type_name: "string"
-      - type_name: "dyn"
+    type: "map<string, dyn>"
   - name: "resource"
-    type_name: "map"
-    params:
-      - type_name: "string"
-      - type_name: "dyn"
+    type: "map<string, dyn>"
 functions:
   - name: "locationCode"
     overloads:
       - id: "locationCode_string"
-        args:
-          - type_name: "string"
-        return:
-          type_name: "string"
+        args: ["string"]
+        return: "string"
 validators:
   - name: cel.validator.duration
   - name: cel.validator.comprehension_nesting_limit


### PR DESCRIPTION
Also add a test that JSON as yaml works.

Marshaling will still use the structured / yaml-map types, but we could default to the string form after the other implementations all support it.