### PR TITLE
ext/lists: add max size check to genRange() to prevent OOM

### DIFF
--- a/ext/lists.go
+++ b/ext/lists.go
@@ -160,7 +160,7 @@ func Lists(options ...ListsOption) cel.EnvOption {
 	return cel.Lib(l)
 }
 
-const defaultMaxRangeSize = 10_000_000
+const defaultMaxRangeSize = 1_000_000
 
 type listsLib struct {
 	version      uint32

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -403,8 +403,17 @@ func (lib *listsLib) ProgramOptions() []cel.ProgramOption {
 	return opts
 }
 
+// maxRangeSize is the maximum number of elements lists.range() will allocate.
+const maxRangeSize = 10_000_000
+
 func genRange(n types.Int) (ref.Val, error) {
-	var newList []ref.Val
+	if n < 0 {
+		return nil, fmt.Errorf("lists.range: size must be non-negative, got %d", n)
+	}
+	if n > maxRangeSize {
+		return nil, fmt.Errorf("lists.range: size %d exceeds maximum allowed (%d)", n, maxRangeSize)
+	}
+	newList := make([]ref.Val, 0, n)
 	for i := types.Int(0); i < n; i++ {
 		newList = append(newList, i)
 	}

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -153,15 +153,18 @@ var comparableTypes = []*cel.Type{
 //	].sortBy(e, e.score).map(e, e.name)
 //	== ["bar", "foo", "baz"]
 func Lists(options ...ListsOption) cel.EnvOption {
-	l := &listsLib{version: math.MaxUint32}
+	l := &listsLib{version: math.MaxUint32, maxRangeSize: defaultMaxRangeSize}
 	for _, o := range options {
 		l = o(l)
 	}
 	return cel.Lib(l)
 }
 
+const defaultMaxRangeSize = 10_000_000
+
 type listsLib struct {
-	version uint32
+	version      uint32
+	maxRangeSize int64
 }
 
 // LibraryName implements the SingletonLibrary interface method.
@@ -184,6 +187,16 @@ type ListsOption func(*listsLib) *listsLib
 func ListsVersion(version uint32) ListsOption {
 	return func(lib *listsLib) *listsLib {
 		lib.version = version
+		return lib
+	}
+}
+
+// ListsMaxRangeSize sets the maximum number of elements lists.range() will
+// allocate. If not set, the default is 10,000,000. Setting this to zero
+// disables the limit (not recommended).
+func ListsMaxRangeSize(size int64) ListsOption {
+	return func(lib *listsLib) *listsLib {
+		lib.maxRangeSize = size
 		return lib
 	}
 }
@@ -309,11 +322,12 @@ func (lib listsLib) CompileOptions() []cel.EnvOption {
 			)...,
 		))
 
+		maxRange := lib.maxRangeSize
 		opts = append(opts, cel.Function("lists.range",
 			cel.Overload("lists_range",
 				[]*cel.Type{cel.IntType}, cel.ListType(cel.IntType),
 				cel.UnaryBinding(func(n ref.Val) ref.Val {
-					result, err := genRange(n.(types.Int))
+					result, err := genRange(n.(types.Int), maxRange)
 					if err != nil {
 						return types.WrapErr(err)
 					}
@@ -403,15 +417,12 @@ func (lib *listsLib) ProgramOptions() []cel.ProgramOption {
 	return opts
 }
 
-// maxRangeSize is the maximum number of elements lists.range() will allocate.
-const maxRangeSize = 10_000_000
-
-func genRange(n types.Int) (ref.Val, error) {
+func genRange(n types.Int, maxSize int64) (ref.Val, error) {
 	if n < 0 {
 		return nil, fmt.Errorf("lists.range: size must be non-negative, got %d", n)
 	}
-	if n > maxRangeSize {
-		return nil, fmt.Errorf("lists.range: size %d exceeds maximum allowed (%d)", n, maxRangeSize)
+	if maxSize > 0 && int64(n) > maxSize {
+		return nil, fmt.Errorf("lists.range: size %d exceeds maximum allowed (%d)", n, maxSize)
 	}
 	newList := make([]ref.Val, 0, n)
 	for i := types.Int(0); i < n; i++ {

--- a/ext/lists_test.go
+++ b/ext/lists_test.go
@@ -521,3 +521,26 @@ func testListsEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 	}
 	return env
 }
+
+func TestGenRangeMaxSize(t *testing.T) {
+	// Negative size should fail.
+	_, err := genRange(-1)
+	if err == nil {
+		t.Error("genRange(-1) should fail")
+	}
+
+	// Small size should work.
+	val, err := genRange(10)
+	if err != nil {
+		t.Fatalf("genRange(10) failed: %v", err)
+	}
+	if val == nil {
+		t.Fatal("genRange(10) returned nil")
+	}
+
+	// Over the limit should fail, not allocate.
+	_, err = genRange(maxRangeSize + 1)
+	if err == nil {
+		t.Error("genRange(maxRangeSize+1) should fail")
+	}
+}

--- a/ext/lists_test.go
+++ b/ext/lists_test.go
@@ -524,13 +524,13 @@ func testListsEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
 
 func TestGenRangeMaxSize(t *testing.T) {
 	// Negative size should fail.
-	_, err := genRange(-1)
+	_, err := genRange(-1, defaultMaxRangeSize)
 	if err == nil {
 		t.Error("genRange(-1) should fail")
 	}
 
 	// Small size should work.
-	val, err := genRange(10)
+	val, err := genRange(10, defaultMaxRangeSize)
 	if err != nil {
 		t.Fatalf("genRange(10) failed: %v", err)
 	}
@@ -539,8 +539,17 @@ func TestGenRangeMaxSize(t *testing.T) {
 	}
 
 	// Over the limit should fail, not allocate.
-	_, err = genRange(maxRangeSize + 1)
+	_, err = genRange(defaultMaxRangeSize+1, defaultMaxRangeSize)
 	if err == nil {
-		t.Error("genRange(maxRangeSize+1) should fail")
+		t.Error("genRange(defaultMaxRangeSize+1) should fail")
+	}
+
+	// Zero limit disables the check.
+	val, err = genRange(100, 0)
+	if err != nil {
+		t.Fatalf("genRange(100, 0) with disabled limit failed: %v", err)
+	}
+	if val == nil {
+		t.Fatal("genRange(100, 0) returned nil")
 	}
 }


### PR DESCRIPTION
lists.range(N) allocates N elements with no upper bound. A large
value like 2147483647 allocates ~16 GB and crashes the process.

This is dangerous in Kubernetes ValidatingAdmissionPolicy where
user-controlled input feeds into CEL expressions.

Add maxRangeSize (10M) check and reject negative values.

Fixes #1309