### PR TITLE
Fix unintentional unwrapping of optionals at any level of depth

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -3293,6 +3293,8 @@ func TestOptionalValuesEval(t *testing.T) {
 		{expr: `[optional.none(), optional.none()].unwrapOpt()`, out: []any{}},
 		{expr: `[optional.of(42), optional.none(), optional.of("a")].unwrapOpt()`, out: []any{types.Int(42), types.String("a")}},
 		{expr: `[optional.of(42), optional.of("a")].unwrapOpt()`, out: []any{types.Int(42), types.String("a")}},
+		{expr: `optional.of(optional.of(1)) != dyn(optional.of(1))`, out: types.True},
+		{expr: `(true ? optional.of(optional.of(1)) : dyn(optional.of(2))) != dyn(optional.of(1))`, out: types.True},
 	}
 
 	for i, tst := range tests {

--- a/common/types/optional_test.go
+++ b/common/types/optional_test.go
@@ -29,6 +29,31 @@ func TestOptionalOptionalOf(t *testing.T) {
 	}
 }
 
+func TestOptionalOptionalFormat(t *testing.T) {
+	tests := []struct {
+		val  ref.Val
+		want string
+	}{
+		{
+			val:  OptionalNone,
+			want: "optional.none()",
+		},
+		{
+			val:  OptionalOf(True),
+			want: "optional.of(true)",
+		},
+		{
+			val:  OptionalOf(OptionalOf(False)),
+			want: "optional.of(optional.of(false))",
+		},
+	}
+	for _, tc := range tests {
+		if Format(tc.val) != tc.want {
+			t.Errorf("got %v, wanted %v", Format(tc.val), tc.want)
+		}
+	}
+}
+
 func TestOptionalGetValue(t *testing.T) {
 	opt := OptionalOf(IntOne)
 	if opt.GetValue() != IntOne {
@@ -113,6 +138,26 @@ func TestOptionalEqual(t *testing.T) {
 			a:   OptionalOf(IntOne),
 			b:   OptionalOf(Double(1.0)),
 			out: True,
+		},
+		{
+			a:   OptionalOf(OptionalOf(IntOne)),
+			b:   OptionalOf(Double(1.0)),
+			out: False,
+		},
+		{
+			a:   OptionalOf(OptionalOf(IntOne)),
+			b:   OptionalOf(OptionalOf(OptionalOf(Double(1.0)))),
+			out: False,
+		},
+		{
+			a:   OptionalOf(Double(1.0)),
+			b:   OptionalOf(OptionalOf(IntOne)),
+			out: False,
+		},
+		{
+			a:   OptionalOf(OptionalOf(OptionalOf(Double(1.0)))),
+			b:   OptionalOf(OptionalOf(IntOne)),
+			out: False,
 		},
 	}
 

--- a/interpreter/attributes.go
+++ b/interpreter/attributes.go
@@ -1301,7 +1301,7 @@ func applyQualifiers(vars Activation, obj any, qualifiers []Qualifier) (any, boo
 		if !optObj.HasValue() {
 			return optObj, false, nil
 		}
-		obj = optObj.GetValue().Value()
+		obj = optObj.GetValue()
 	}
 
 	var err error


### PR DESCRIPTION
Fixes edge case where nested optionals within a conditional are unnested down to a single level.