### PR TITLE
Managed execution frame with async call foundations

### DIFF
--- a/common/functions/functions.go
+++ b/common/functions/functions.go
@@ -68,6 +68,11 @@ type FunctionOp func(...ref.Val) ref.Val
 
 // AsyncOp is a function that accepts zero or more arguments and produces
 // a value or error asynchronously via a channel.
+//
+// AsyncOp is an internal interface intended for use by CEL to manage goroutines and
+// channels associated with async calls. For public API usage, use BlockingAsyncOp.
+// Implementers should listen for context cancellation on the provided context for
+// resource cleanup.
 type AsyncOp func(context.Context, ...ref.Val) <-chan ref.Val
 
 // BlockingAsyncOp is a function that accepts zero or more arguments and blocks until

--- a/common/functions/functions.go
+++ b/common/functions/functions.go
@@ -15,7 +15,11 @@
 // Package functions defines the standard builtin functions supported by the interpreter
 package functions
 
-import "github.com/google/cel-go/common/types/ref"
+import (
+	"context"
+
+	"github.com/google/cel-go/common/types/ref"
+)
 
 // Overload defines a named overload of a function, indicating an operand trait
 // which must be present on the first argument to the overload as well as one
@@ -41,9 +45,11 @@ type Overload struct {
 	// Binary defines the overload with a BinaryOp implementation. May be nil.
 	Binary BinaryOp
 
-	// Function defines the overload with a FunctionOp implementation. May be
-	// nil.
+	// Function defines the overload with a FunctionOp implementation. May be nil.
 	Function FunctionOp
+
+	// Async defines the overload with an AsyncOp implementation. May be nil.
+	Async AsyncOp
 
 	// NonStrict specifies whether the Overload will tolerate arguments that
 	// are types.Err or types.Unknown.
@@ -51,11 +57,20 @@ type Overload struct {
 }
 
 // UnaryOp is a function that takes a single value and produces an output.
-type UnaryOp func(value ref.Val) ref.Val
+type UnaryOp func(ref.Val) ref.Val
 
 // BinaryOp is a function that takes two values and produces an output.
-type BinaryOp func(lhs ref.Val, rhs ref.Val) ref.Val
+type BinaryOp func(ref.Val, ref.Val) ref.Val
 
 // FunctionOp is a function with accepts zero or more arguments and produces
 // a value or error as a result.
-type FunctionOp func(values ...ref.Val) ref.Val
+type FunctionOp func(...ref.Val) ref.Val
+
+// AsyncOp is a function that accepts zero or more arguments and produces
+// a value or error asynchronously via a channel.
+type AsyncOp func(context.Context, ...ref.Val) <-chan ref.Val
+
+// BlockingAsyncOp is a function that accepts zero or more arguments and blocks until
+// the result is available. When used with AsyncBinding, the framework runs the function
+// in its own goroutine and manages channel lifecycle internally.
+type BlockingAsyncOp func(context.Context, ...ref.Val) ref.Val

--- a/common/types/unknown.go
+++ b/common/types/unknown.go
@@ -181,6 +181,20 @@ func (u *Unknown) GetAttributeTrails(id int64) ([]*AttributeTrail, bool) {
 	return trails, found
 }
 
+// HasUnknownFunction returns whether any of the attribute trails contained within the unknown
+// are unspecified. Unspecified attributes typically indicate an unresolved function call
+// or operation, rather than a missing variable.
+func (u *Unknown) HasUnknownFunction() bool {
+	for _, trails := range u.attributeTrails {
+		for _, t := range trails {
+			if t.variable == "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Contains returns true if the input unknown is a subset of the current unknown.
 func (u *Unknown) Contains(other *Unknown) bool {
 	for id, otherTrails := range other.attributeTrails {

--- a/interpreter/frame.go
+++ b/interpreter/frame.go
@@ -18,19 +18,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
-
-	"github.com/google/cel-go/common/functions"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
 )
-
-// AsyncObserver provides callbacks for monitoring the lifecycle of asynchronous function calls.
-type AsyncObserver interface {
-	// OnCallStarted is called when an asynchronous function is first launched.
-	OnCallStarted(callID int64, function, overload string, args []ref.Val)
-	// OnCallFinished is called when an asynchronous function completes.
-	OnCallFinished(callID int64, function, overload string, res ref.Val)
-}
 
 // evalContext contains the stateful information needed for a single evaluation.
 //
@@ -55,23 +43,11 @@ type evalContext struct {
 	// costs provides the context for tracking the evaluation costs.
 	costs *CostTracker
 
-	// asyncCalls provides the context for tracking async call states.
-	asyncCalls *asyncCallStateTracker
-
 	// ctx is the context for async call implementations to use.
 	ctx context.Context
 
 	// cancel cancels the context when the evaluation is finished.
 	cancel context.CancelFunc
-
-	// completions channel for asynchronous function calls to send their call ID to when completed.
-	completions chan<- int64
-
-	// observer for monitoring async calls.
-	observer AsyncObserver
-
-	// semaphore for limiting concurrency.
-	semaphore chan struct{}
 }
 
 // ExecutionFrame provides the context for a single evaluation of an expression.
@@ -102,7 +78,6 @@ func (f *ExecutionFrame) SetContext(ctx context.Context, interruptCheckFrequency
 		f.ctx = evalContextPool.Get().(*evalContext)
 	}
 	f.ctx.ctx, f.ctx.cancel = context.WithCancel(ctx)
-	f.ctx.asyncCalls = asyncCallStateTrackerPool.create()
 	f.ctx.interrupt = ctx.Done()
 	f.ctx.interruptCheckFrequency = interruptCheckFrequency
 	f.ctx.interruptCheckCount.Store(0)
@@ -117,16 +92,12 @@ func (f *ExecutionFrame) Close() {
 			f.ctx.cancel = nil
 		}
 		f.ctx.ctx = nil
-		f.ctx.completions = nil
-		asyncCallStateTrackerPool.release(f.ctx.asyncCalls)
-		f.ctx.asyncCalls = nil
 		f.ctx.interrupt = nil
 		f.ctx.state = nil
 		f.ctx.costs = nil
 		f.ctx.interrupted.Store(false)
 		f.ctx.interruptCheckCount.Store(0)
 		f.ctx.interruptCheckFrequency = 0
-		f.ctx.observer = nil
 		evalContextPool.Put(f.ctx)
 		f.ctx = nil
 	}
@@ -134,13 +105,6 @@ func (f *ExecutionFrame) Close() {
 	activationStack.release(f.Activation)
 	f.Activation = nil
 	frameStack.Put(f)
-}
-
-// SetCompletions configures a channel to receive completions when asynchronous evaluations finish.
-func (f *ExecutionFrame) SetCompletions(ch chan<- int64) {
-	if f.ctx != nil {
-		f.ctx.completions = ch
-	}
 }
 
 // push pushes the given activation onto the activation stack and returns the new frame.
@@ -207,222 +171,6 @@ func (f *ExecutionFrame) CheckInterrupt() bool {
 	return false
 }
 
-// asyncCallStateTracker manages async call states across frames
-type asyncCallStateTracker struct {
-	mu           sync.RWMutex
-	calls        map[int64]*asyncCallState
-	callsByID    map[int64]*asyncCallState
-	nextCallID   atomic.Int64
-	pendingCalls atomic.Int32
-}
-
-func newAsyncCallStateTracker() *asyncCallStateTracker {
-	return &asyncCallStateTracker{
-		calls:     make(map[int64]*asyncCallState),
-		callsByID: make(map[int64]*asyncCallState),
-	}
-}
-
-func (t *asyncCallStateTracker) getOrCreate(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp, completions chan<- int64) *asyncCallState {
-	t.mu.RLock()
-	acs, ok := t.calls[id]
-	t.mu.RUnlock()
-
-	potentialState := newAsyncCallState(id, function, overload, argVals, impl)
-	if ok && acs.equals(potentialState) {
-		return acs
-	}
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	// Check again in case it was created while waiting for the lock
-	if acs, ok := t.calls[id]; ok && acs.equals(potentialState) {
-		return acs
-	}
-
-	// Set a new call ID for this async call.
-	callID := t.nextCallID.Add(1)
-	potentialState.callID = callID
-	potentialState.completions = completions
-	t.calls[potentialState.id] = potentialState
-	t.callsByID[callID] = potentialState
-	t.pendingCalls.Add(1)
-	return potentialState
-}
-
-func (t *asyncCallStateTracker) getByID(callID int64) *asyncCallState {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.callsByID[callID]
-}
-
-func (t *asyncCallStateTracker) pendingCount() int {
-	return int(t.pendingCalls.Load())
-}
-
-func (t *asyncCallStateTracker) NotifyCompletion(callID int64) {
-	t.pendingCalls.Add(-1)
-}
-
-// ComputeResult tracks and computes the result of the given asynchronous function.
-func (f *ExecutionFrame) ComputeResult(id int64, function, overload string, impl functions.AsyncOp, argVals []ref.Val) ref.Val {
-	if f.ctx == nil || f.ctx.asyncCalls == nil {
-		return types.NewErrWithNodeID(id, "async call tracking is not initialized")
-	}
-	acs := f.ctx.asyncCalls.getOrCreate(id, function, overload, argVals, impl, f.ctx.completions)
-	return acs.call(f.ctx.ctx, f.ctx.observer, f.ctx.semaphore)
-}
-
-// AsyncCall describes a pending or completed asynchronous function call.
-type AsyncCall interface {
-	// CallID returns the unique identifier for this async call invocation.
-	CallID() int64
-	// Function returns the name of the function being called.
-	Function() string
-	// Overload returns the specific overload ID being invoked.
-	Overload() string
-}
-
-// PendingAsyncCalls returns the number of async function calls that have been launched
-// but have not yet returned a result.
-func (f *ExecutionFrame) PendingAsyncCalls() int {
-	if f.ctx == nil || f.ctx.asyncCalls == nil {
-		return 0
-	}
-	return f.ctx.asyncCalls.pendingCount()
-}
-
-// AsyncCall returns the state of an async call by its callID, or nil if not found.
-func (f *ExecutionFrame) AsyncCall(callID int64) AsyncCall {
-	if f.ctx == nil || f.ctx.asyncCalls == nil {
-		return nil
-	}
-	return f.ctx.asyncCalls.getByID(callID)
-}
-
-// NotifyCompletion notifies the execution frame that an async call has completed.
-func (f *ExecutionFrame) NotifyCompletion(callID int64) {
-	if f.ctx != nil && f.ctx.asyncCalls != nil {
-		f.ctx.asyncCalls.NotifyCompletion(callID)
-	}
-}
-
-// SetAsyncObserver sets the observer for monitoring asynchronous function calls.
-func (f *ExecutionFrame) SetAsyncObserver(observer AsyncObserver) {
-	if f.ctx != nil {
-		f.ctx.observer = observer
-	}
-}
-
-// SetAsyncMaxConcurrency sets the maximum concurrency for asynchronous function calls.
-func (f *ExecutionFrame) SetAsyncMaxConcurrency(n int) {
-	if f.ctx != nil {
-		if n > 0 {
-			f.ctx.semaphore = make(chan struct{}, n)
-		} else {
-			f.ctx.semaphore = nil
-		}
-	}
-}
-
-func newAsyncCallState(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp) *asyncCallState {
-	return &asyncCallState{
-		id:       id,
-		function: function,
-		overload: overload,
-		argVals:  argVals,
-		impl:     impl,
-	}
-}
-
-// asyncCallState is used to track the results of function calls across multiple iterations.
-type asyncCallState struct {
-	id       int64
-	callID   int64
-	function string
-	overload string
-	argVals  []ref.Val
-	impl     functions.AsyncOp
-
-	once   sync.Once
-	mu     sync.RWMutex
-	result ref.Val
-
-	completions chan<- int64
-}
-
-// CallID returns the unique identifier for this async call invocation.
-func (acs *asyncCallState) CallID() int64 {
-	return acs.callID
-}
-
-// Function returns the name of the function being called.
-func (acs *asyncCallState) Function() string {
-	return acs.function
-}
-
-// Overload returns the specific overload ID being invoked.
-func (acs *asyncCallState) Overload() string {
-	return acs.overload
-}
-
-func (acs *asyncCallState) call(ctx context.Context, observer AsyncObserver, semaphore chan struct{}) ref.Val {
-	acs.once.Do(func() {
-		if observer != nil {
-			observer.OnCallStarted(acs.callID, acs.function, acs.overload, acs.argVals)
-		}
-		go func() {
-			if semaphore != nil {
-				select {
-				case semaphore <- struct{}{}:
-					defer func() { <-semaphore }()
-				case <-ctx.Done():
-					return
-				}
-			}
-			ch := acs.impl(ctx, acs.argVals...)
-			select {
-			case res := <-ch:
-				acs.mu.Lock()
-				acs.result = res
-				acs.mu.Unlock()
-				if observer != nil {
-					observer.OnCallFinished(acs.callID, acs.function, acs.overload, res)
-				}
-				if acs.completions != nil {
-					select {
-					case acs.completions <- acs.callID:
-					case <-ctx.Done():
-					}
-				}
-			case <-ctx.Done():
-			}
-		}()
-	})
-
-	acs.mu.RLock()
-	defer acs.mu.RUnlock()
-	if acs.result != nil {
-		return acs.result
-	}
-	return types.NewUnknown(acs.callID, nil)
-}
-
-func (acs *asyncCallState) equals(other *asyncCallState) bool {
-	if acs == nil || other == nil {
-		return false
-	}
-	if acs.function != other.function || acs.overload != other.overload {
-		return false
-	}
-	for i, v := range acs.argVals {
-		if types.Equal(v, other.argVals[i]) != types.True {
-			return false
-		}
-	}
-	return true
-}
-
 // frameStack provides a synchronized pool of ExecutionFrames.
 var frameStack = &sync.Pool{
 	New: func() any {
@@ -468,42 +216,6 @@ func newActivationPool() *activationStackPool {
 	}
 }
 
-type asyncCallStateTrackerPoolStruct struct {
-	sync.Pool
-}
-
-func (pool *asyncCallStateTrackerPoolStruct) create() *asyncCallStateTracker {
-	return pool.Get().(*asyncCallStateTracker)
-}
-
-func (pool *asyncCallStateTrackerPoolStruct) release(tracker *asyncCallStateTracker) {
-	if tracker == nil {
-		return
-	}
-	tracker.mu.Lock()
-	for k := range tracker.calls {
-		delete(tracker.calls, k)
-	}
-	for k := range tracker.callsByID {
-		delete(tracker.callsByID, k)
-	}
-	tracker.pendingCalls.Store(0)
-	tracker.nextCallID.Store(0)
-	tracker.mu.Unlock()
-	pool.Pool.Put(tracker)
-}
-
-func newAsyncCallTrackerPool() *asyncCallStateTrackerPoolStruct {
-	return &asyncCallStateTrackerPoolStruct{
-		Pool: sync.Pool{
-			New: func() any {
-				return newAsyncCallStateTracker()
-			},
-		},
-	}
-}
-
 var (
 	activationStack           = newActivationPool()
-	asyncCallStateTrackerPool = newAsyncCallTrackerPool()
 )

--- a/interpreter/frame.go
+++ b/interpreter/frame.go
@@ -1,0 +1,509 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/cel-go/common/functions"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// AsyncObserver provides callbacks for monitoring the lifecycle of asynchronous function calls.
+type AsyncObserver interface {
+	// OnCallStarted is called when an asynchronous function is first launched.
+	OnCallStarted(callID int64, function, overload string, args []ref.Val)
+	// OnCallFinished is called when an asynchronous function completes.
+	OnCallFinished(callID int64, function, overload string, res ref.Val)
+}
+
+// evalContext contains the stateful information needed for a single evaluation.
+//
+// This state is shared across all frames within a single evaluation, including
+// child frames created for comprehension blocks.
+type evalContext struct {
+	// interrupt exposes a callback channel for cancellation.
+	interrupt <-chan struct{}
+
+	// interruptCheckCount is the number of times the interrupt channel has been checked.
+	interruptCheckCount atomic.Uint64
+
+	// interruptCheckFrequency is the frequency at which the interrupt channel is checked.
+	interruptCheckFrequency uint
+
+	// interrupted indicates whether the evaluation has been interrupted.
+	interrupted atomic.Bool
+
+	// state provides the context for tracking the evaluation state.
+	state EvalState
+
+	// costs provides the context for tracking the evaluation costs.
+	costs *CostTracker
+
+	// asyncCalls provides the context for tracking async call states.
+	asyncCalls *asyncCallStateTracker
+
+	// ctx is the context for async call implementations to use.
+	ctx context.Context
+
+	// cancel cancels the context when the evaluation is finished.
+	cancel context.CancelFunc
+
+	// completions channel for asynchronous function calls to send their call ID to when completed.
+	completions chan<- int64
+
+	// observer for monitoring async calls.
+	observer AsyncObserver
+
+	// semaphore for limiting concurrency.
+	semaphore chan struct{}
+}
+
+// ExecutionFrame provides the context for a single evaluation of an expression.
+//
+// The execution frame must not be stored in any fashion as its lifecycle is completely
+// controlled by the CEL evaluation process.
+type ExecutionFrame struct {
+	// Activation provides the context for resolving variables by name.
+	Activation
+
+	// parent provides the context for parent scopes (used for comprehension iterators).
+	parent *ExecutionFrame
+
+	// ctx provides the shared evaluation state across frames.
+	ctx *evalContext
+}
+
+// NewExecutionFrame creates a new execution frame from the pool.
+func NewExecutionFrame(vars Activation) *ExecutionFrame {
+	f := frameStack.Get().(*ExecutionFrame)
+	f.Activation = vars
+	return f
+}
+
+// SetContext sets the context for the execution frame.
+func (f *ExecutionFrame) SetContext(ctx context.Context, interruptCheckFrequency uint) {
+	if f.ctx == nil {
+		f.ctx = evalContextPool.Get().(*evalContext)
+	}
+	f.ctx.ctx, f.ctx.cancel = context.WithCancel(ctx)
+	f.ctx.asyncCalls = asyncCallStateTrackerPool.create()
+	f.ctx.interrupt = ctx.Done()
+	f.ctx.interruptCheckFrequency = interruptCheckFrequency
+	f.ctx.interruptCheckCount.Store(0)
+	f.ctx.interrupted.Store(false)
+}
+
+// Close releases the resources held by the execution frame and returns it to the pool.
+func (f *ExecutionFrame) Close() {
+	if f.ctx != nil {
+		if f.ctx.cancel != nil {
+			f.ctx.cancel()
+			f.ctx.cancel = nil
+		}
+		f.ctx.ctx = nil
+		f.ctx.completions = nil
+		asyncCallStateTrackerPool.release(f.ctx.asyncCalls)
+		f.ctx.asyncCalls = nil
+		f.ctx.interrupt = nil
+		f.ctx.state = nil
+		f.ctx.costs = nil
+		f.ctx.interrupted.Store(false)
+		f.ctx.interruptCheckCount.Store(0)
+		f.ctx.interruptCheckFrequency = 0
+		f.ctx.observer = nil
+		evalContextPool.Put(f.ctx)
+		f.ctx = nil
+	}
+	f.parent = nil
+	activationStack.release(f.Activation)
+	f.Activation = nil
+	frameStack.Put(f)
+}
+
+// SetCompletions configures a channel to receive completions when asynchronous evaluations finish.
+func (f *ExecutionFrame) SetCompletions(ch chan<- int64) {
+	if f.ctx != nil {
+		f.ctx.completions = ch
+	}
+}
+
+// push pushes the given activation onto the activation stack and returns the new frame.
+//
+// This operation is internal to the interpreter and is used to handle comprehension
+// scoping. The child frame inherits the shared evalContext from the parent.
+func (f *ExecutionFrame) push(activation Activation) *ExecutionFrame {
+	child := frameStack.Get().(*ExecutionFrame)
+	child.parent = f
+	child.ctx = f.ctx
+	child.Activation = activationStack.create(f.Activation, activation)
+	return child
+}
+
+// pop returns the parent frame, releasing the current frame back to the pool.
+func (f *ExecutionFrame) pop() *ExecutionFrame {
+	parent := f.parent
+	activationStack.release(f.Activation)
+	f.Activation = nil
+	f.parent = nil
+	f.ctx = nil
+	frameStack.Put(f)
+	return parent
+}
+
+// ResolveName implements the Activation interface by proxying to the internal activation.
+func (f *ExecutionFrame) ResolveName(name string) (any, bool) {
+	return f.Activation.ResolveName(name)
+}
+
+// Parent implements the Activation interface by proxying to the internal activation.
+func (f *ExecutionFrame) Parent() Activation {
+	return f.Activation.Parent()
+}
+
+// AsPartialActivation implements the PartialActivation interface by proxying to the internal activation.
+func (f *ExecutionFrame) AsPartialActivation() (PartialActivation, bool) {
+	return AsPartialActivation(f.Activation)
+}
+
+// Unwrap returns the internal activation.
+func (f *ExecutionFrame) Unwrap() Activation {
+	return f.Activation
+}
+
+// CheckInterrupt returns whether the evaluation has been interrupted.
+func (f *ExecutionFrame) CheckInterrupt() bool {
+	if f.ctx == nil {
+		return false
+	}
+	if f.ctx.interrupted.Load() {
+		return true
+	}
+	count := f.ctx.interruptCheckCount.Add(1)
+	if f.ctx.interruptCheckFrequency > 0 && count%uint64(f.ctx.interruptCheckFrequency) == 0 {
+		select {
+		case <-f.ctx.interrupt:
+			f.ctx.interrupted.Store(true)
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// asyncCallStateTracker manages async call states across frames
+type asyncCallStateTracker struct {
+	mu           sync.RWMutex
+	calls        map[int64]*asyncCallState
+	callsByID    map[int64]*asyncCallState
+	nextCallID   atomic.Int64
+	pendingCalls atomic.Int32
+}
+
+func newAsyncCallStateTracker() *asyncCallStateTracker {
+	return &asyncCallStateTracker{
+		calls:     make(map[int64]*asyncCallState),
+		callsByID: make(map[int64]*asyncCallState),
+	}
+}
+
+func (t *asyncCallStateTracker) getOrCreate(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp, completions chan<- int64) *asyncCallState {
+	t.mu.RLock()
+	acs, ok := t.calls[id]
+	t.mu.RUnlock()
+
+	potentialState := newAsyncCallState(id, function, overload, argVals, impl)
+	if ok && acs.equals(potentialState) {
+		return acs
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	// Check again in case it was created while waiting for the lock
+	if acs, ok := t.calls[id]; ok && acs.equals(potentialState) {
+		return acs
+	}
+
+	// Set a new call ID for this async call.
+	callID := t.nextCallID.Add(1)
+	potentialState.callID = callID
+	potentialState.completions = completions
+	t.calls[potentialState.id] = potentialState
+	t.callsByID[callID] = potentialState
+	t.pendingCalls.Add(1)
+	return potentialState
+}
+
+func (t *asyncCallStateTracker) getByID(callID int64) *asyncCallState {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.callsByID[callID]
+}
+
+func (t *asyncCallStateTracker) pendingCount() int {
+	return int(t.pendingCalls.Load())
+}
+
+func (t *asyncCallStateTracker) NotifyCompletion(callID int64) {
+	t.pendingCalls.Add(-1)
+}
+
+// ComputeResult tracks and computes the result of the given asynchronous function.
+func (f *ExecutionFrame) ComputeResult(id int64, function, overload string, impl functions.AsyncOp, argVals []ref.Val) ref.Val {
+	if f.ctx == nil || f.ctx.asyncCalls == nil {
+		return types.NewErrWithNodeID(id, "async call tracking is not initialized")
+	}
+	acs := f.ctx.asyncCalls.getOrCreate(id, function, overload, argVals, impl, f.ctx.completions)
+	return acs.call(f.ctx.ctx, f.ctx.observer, f.ctx.semaphore)
+}
+
+// AsyncCall describes a pending or completed asynchronous function call.
+type AsyncCall interface {
+	// CallID returns the unique identifier for this async call invocation.
+	CallID() int64
+	// Function returns the name of the function being called.
+	Function() string
+	// Overload returns the specific overload ID being invoked.
+	Overload() string
+}
+
+// PendingAsyncCalls returns the number of async function calls that have been launched
+// but have not yet returned a result.
+func (f *ExecutionFrame) PendingAsyncCalls() int {
+	if f.ctx == nil || f.ctx.asyncCalls == nil {
+		return 0
+	}
+	return f.ctx.asyncCalls.pendingCount()
+}
+
+// AsyncCall returns the state of an async call by its callID, or nil if not found.
+func (f *ExecutionFrame) AsyncCall(callID int64) AsyncCall {
+	if f.ctx == nil || f.ctx.asyncCalls == nil {
+		return nil
+	}
+	return f.ctx.asyncCalls.getByID(callID)
+}
+
+// NotifyCompletion notifies the execution frame that an async call has completed.
+func (f *ExecutionFrame) NotifyCompletion(callID int64) {
+	if f.ctx != nil && f.ctx.asyncCalls != nil {
+		f.ctx.asyncCalls.NotifyCompletion(callID)
+	}
+}
+
+// SetAsyncObserver sets the observer for monitoring asynchronous function calls.
+func (f *ExecutionFrame) SetAsyncObserver(observer AsyncObserver) {
+	if f.ctx != nil {
+		f.ctx.observer = observer
+	}
+}
+
+// SetAsyncMaxConcurrency sets the maximum concurrency for asynchronous function calls.
+func (f *ExecutionFrame) SetAsyncMaxConcurrency(n int) {
+	if f.ctx != nil {
+		if n > 0 {
+			f.ctx.semaphore = make(chan struct{}, n)
+		} else {
+			f.ctx.semaphore = nil
+		}
+	}
+}
+
+func newAsyncCallState(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp) *asyncCallState {
+	return &asyncCallState{
+		id:       id,
+		function: function,
+		overload: overload,
+		argVals:  argVals,
+		impl:     impl,
+	}
+}
+
+// asyncCallState is used to track the results of function calls across multiple iterations.
+type asyncCallState struct {
+	id       int64
+	callID   int64
+	function string
+	overload string
+	argVals  []ref.Val
+	impl     functions.AsyncOp
+
+	once   sync.Once
+	mu     sync.RWMutex
+	result ref.Val
+
+	completions chan<- int64
+}
+
+// CallID returns the unique identifier for this async call invocation.
+func (acs *asyncCallState) CallID() int64 {
+	return acs.callID
+}
+
+// Function returns the name of the function being called.
+func (acs *asyncCallState) Function() string {
+	return acs.function
+}
+
+// Overload returns the specific overload ID being invoked.
+func (acs *asyncCallState) Overload() string {
+	return acs.overload
+}
+
+func (acs *asyncCallState) call(ctx context.Context, observer AsyncObserver, semaphore chan struct{}) ref.Val {
+	acs.once.Do(func() {
+		if observer != nil {
+			observer.OnCallStarted(acs.callID, acs.function, acs.overload, acs.argVals)
+		}
+		go func() {
+			if semaphore != nil {
+				select {
+				case semaphore <- struct{}{}:
+					defer func() { <-semaphore }()
+				case <-ctx.Done():
+					return
+				}
+			}
+			ch := acs.impl(ctx, acs.argVals...)
+			select {
+			case res := <-ch:
+				acs.mu.Lock()
+				acs.result = res
+				acs.mu.Unlock()
+				if observer != nil {
+					observer.OnCallFinished(acs.callID, acs.function, acs.overload, res)
+				}
+				if acs.completions != nil {
+					select {
+					case acs.completions <- acs.callID:
+					case <-ctx.Done():
+					}
+				}
+			case <-ctx.Done():
+			}
+		}()
+	})
+
+	acs.mu.RLock()
+	defer acs.mu.RUnlock()
+	if acs.result != nil {
+		return acs.result
+	}
+	return types.NewUnknown(acs.callID, nil)
+}
+
+func (acs *asyncCallState) equals(other *asyncCallState) bool {
+	if acs == nil || other == nil {
+		return false
+	}
+	if acs.function != other.function || acs.overload != other.overload {
+		return false
+	}
+	for i, v := range acs.argVals {
+		if types.Equal(v, other.argVals[i]) != types.True {
+			return false
+		}
+	}
+	return true
+}
+
+// frameStack provides a synchronized pool of ExecutionFrames.
+var frameStack = &sync.Pool{
+	New: func() any {
+		return &ExecutionFrame{}
+	},
+}
+
+// evalContextPool provides a synchronized pool of evalContexts.
+var evalContextPool = &sync.Pool{
+	New: func() any {
+		return &evalContext{}
+	},
+}
+
+type activationStackPool struct {
+	sync.Pool
+}
+
+func (pool *activationStackPool) create(parent, child Activation) Activation {
+	h := pool.Get().(*hierarchicalActivation)
+	h.child = child
+	h.parent = parent
+	return h
+}
+
+func (pool *activationStackPool) release(activation Activation) {
+	h, ok := activation.(*hierarchicalActivation)
+	if !ok {
+		return
+	}
+	h.parent = nil
+	h.child = nil
+	pool.Pool.Put(h)
+}
+
+func newActivationPool() *activationStackPool {
+	return &activationStackPool{
+		Pool: sync.Pool{
+			New: func() any {
+				return &hierarchicalActivation{}
+			},
+		},
+	}
+}
+
+type asyncCallStateTrackerPoolStruct struct {
+	sync.Pool
+}
+
+func (pool *asyncCallStateTrackerPoolStruct) create() *asyncCallStateTracker {
+	return pool.Get().(*asyncCallStateTracker)
+}
+
+func (pool *asyncCallStateTrackerPoolStruct) release(tracker *asyncCallStateTracker) {
+	if tracker == nil {
+		return
+	}
+	tracker.mu.Lock()
+	for k := range tracker.calls {
+		delete(tracker.calls, k)
+	}
+	for k := range tracker.callsByID {
+		delete(tracker.callsByID, k)
+	}
+	tracker.pendingCalls.Store(0)
+	tracker.nextCallID.Store(0)
+	tracker.mu.Unlock()
+	pool.Pool.Put(tracker)
+}
+
+func newAsyncCallTrackerPool() *asyncCallStateTrackerPoolStruct {
+	return &asyncCallStateTrackerPoolStruct{
+		Pool: sync.Pool{
+			New: func() any {
+				return newAsyncCallStateTracker()
+			},
+		},
+	}
+}
+
+var (
+	activationStack           = newActivationPool()
+	asyncCallStateTrackerPool = newAsyncCallTrackerPool()
+)

--- a/interpreter/frame_test.go
+++ b/interpreter/frame_test.go
@@ -1,0 +1,439 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+func TestFrameInterrupt(t *testing.T) {
+	tests := []struct {
+		name        string
+		concurrency int
+	}{
+		{
+			name:        "without semaphores",
+			concurrency: 0,
+		},
+		{
+			name:        "with semaphores",
+			concurrency: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			frame := NewExecutionFrame(EmptyActivation())
+			defer frame.Close()
+
+			// Test CheckInterrupt with nil ctx
+			if frame.CheckInterrupt() {
+				t.Error("CheckInterrupt() returned true for nil ctx")
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			frame.SetContext(ctx, 1)
+			frame.SetAsyncMaxConcurrency(tc.concurrency)
+
+			// First check with active context should return false
+			if frame.CheckInterrupt() {
+				t.Error("frame.CheckInterrupt() returned true, wanted false")
+			}
+
+			// Cancel context to trigger interrupt
+			cancel()
+
+			// Second check should observe cancellation and return true
+			if !frame.CheckInterrupt() {
+				t.Error("frame.CheckInterrupt() returned false, wanted true")
+			}
+
+			// Third check should hit the cached/loaded interrupted flag and return true
+			if !frame.CheckInterrupt() {
+				t.Error("frame.CheckInterrupt() (cached) returned false, wanted true")
+			}
+		})
+	}
+
+	t.Run("check frequency not triggered", func(t *testing.T) {
+		frame := NewExecutionFrame(EmptyActivation())
+		defer frame.Close()
+
+		frame.SetContext(context.Background(), 2)
+		// first call adds 1 to count -> 1%2 != 0 -> returns false
+		if frame.CheckInterrupt() {
+			t.Error("CheckInterrupt() returned true unexpectedly")
+		}
+	})
+}
+
+func TestFrameAsyncErrors(t *testing.T) {
+	frame := NewExecutionFrame(EmptyActivation())
+	defer frame.Close()
+
+	// ComputeResult without SetContext should return an error
+	res := frame.ComputeResult(1, "test", "test", nil, nil)
+	if !types.IsError(res) {
+		t.Errorf("ComputeResult() returned %v, wanted error", res)
+	}
+}
+
+func TestFrameCompletions(t *testing.T) {
+	frame := NewExecutionFrame(EmptyActivation())
+	defer frame.Close()
+
+	ctx := context.Background()
+	frame.SetContext(ctx, 1)
+
+	completionCh := make(chan int64, 1)
+	frame.SetCompletions(completionCh)
+
+	syncCh := make(chan ref.Val, 1)
+	impl := func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
+		return syncCh
+	}
+
+	// First call returns unknown
+	res := frame.ComputeResult(10, "test", "test", impl, nil)
+	if !types.IsUnknown(res) {
+		t.Fatalf("ComputeResult() returned %v, wanted unknown", res)
+	}
+
+	// Send result
+	syncCh <- types.String("done")
+
+	// Wait for completion signal
+	select {
+	case id := <-completionCh:
+		if id != res.(*types.Unknown).IDs()[0] {
+			t.Errorf("completion signal ID mismatch: got %d, wanted %d", id, res.(*types.Unknown).IDs()[0])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion signal")
+	}
+
+	// Second call should return the result
+	res2 := frame.ComputeResult(10, "test", "test", impl, nil)
+	if res2.Equal(types.String("done")) != types.True {
+		t.Errorf("ComputeResult() returned %v, wanted 'done'", res2)
+	}
+}
+
+func TestEvalAsyncFunc(t *testing.T) {
+	frame := NewExecutionFrame(EmptyActivation())
+	defer frame.Close()
+	frame.SetContext(context.Background(), 1)
+
+	impl := func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
+		ch := make(chan ref.Val, 1)
+		ch <- types.Int(args[0].(types.Int) + 1)
+		return ch
+	}
+
+	fn := &evalAsyncFunc{
+		id:       1,
+		function: "inc",
+		overload: "inc_int",
+		args:     []InterpretableV2{NewConstValue(1, types.Int(10))},
+		impl:     impl,
+	}
+
+	// First exec triggers the call
+	res := fn.Exec(frame)
+	if !types.IsUnknown(res) {
+		t.Fatalf("Exec() returned %v, wanted unknown", res)
+	}
+
+	// Test Args()
+	if len(fn.Args()) != 1 {
+		t.Errorf("Args() returned %d, wanted 1", len(fn.Args()))
+	}
+
+	// Wait for async result (it's buffered in the impl channel in this test)
+	time.Sleep(10 * time.Millisecond)
+
+	// Test Eval() returns result
+	res3 := fn.Eval(frame)
+	if res3.Equal(types.Int(11)) != types.True {
+		t.Errorf("Eval() returned %v, wanted 11", res3)
+	}
+}
+
+func TestEvalAsyncFuncShortCircuit(t *testing.T) {
+	frame := NewExecutionFrame(EmptyActivation())
+	defer frame.Close()
+	frame.SetContext(context.Background(), 1)
+
+	fn := &evalAsyncFunc{
+		id:       1,
+		function: "inc",
+		args:     []InterpretableV2{NewConstValue(2, types.NewErr("bad arg"))},
+	}
+
+	res := fn.Exec(frame)
+	if !types.IsError(res) {
+		t.Errorf("Exec() returned %v, wanted error", res)
+	}
+
+	fn.args = []InterpretableV2{NewConstValue(3, types.NewUnknown(4, nil))}
+	res = fn.Exec(frame)
+	if !types.IsUnknown(res) {
+		t.Errorf("Exec() returned %v, wanted unknown", res)
+	}
+}
+
+type testAsyncObserver struct {
+	startedCalls  int
+	finishedCalls int
+}
+
+func (o *testAsyncObserver) OnCallStarted(callID int64, function, overload string, args []ref.Val) {
+	o.startedCalls++
+}
+
+func (o *testAsyncObserver) OnCallFinished(callID int64, function, overload string, res ref.Val) {
+	o.finishedCalls++
+}
+
+func TestFrameActivationMethods(t *testing.T) {
+	baseAct, _ := NewActivation(map[string]any{"x": 1})
+	frame := NewExecutionFrame(baseAct)
+	defer frame.Close()
+
+	childAct, _ := NewActivation(map[string]any{"y": 2})
+	childFrame := frame.push(childAct)
+
+	// Test ResolveName on childFrame
+	if v, ok := childFrame.ResolveName("y"); !ok || v != 2 {
+		t.Errorf("ResolveName('y') got %v, %v", v, ok)
+	}
+	if v, ok := childFrame.ResolveName("x"); !ok || v != 1 {
+		t.Errorf("ResolveName('x') got %v, %v", v, ok)
+	}
+	if _, ok := childFrame.ResolveName("missing"); ok {
+		t.Errorf("ResolveName('missing') unexpectedly found")
+	}
+
+	// Test Parent(), Unwrap(), AsPartialActivation() on childFrame
+	if childFrame.Parent() == nil {
+		t.Errorf("Parent() returned nil")
+	}
+	if childFrame.Unwrap() == nil {
+		t.Errorf("Unwrap() returned nil")
+	}
+	if _, ok := childFrame.AsPartialActivation(); ok {
+		t.Errorf("AsPartialActivation() unexpectedly true")
+	}
+
+	// Pop back to parent
+	popped := childFrame.pop()
+	if popped != frame {
+		t.Errorf("pop() did not return parent frame")
+	}
+
+	// Test AsPartialActivation returning true when frame wraps a PartialActivation
+	partAct, _ := NewPartialActivation(map[string]any{"z": 3})
+	partFrame := NewExecutionFrame(partAct)
+	defer partFrame.Close()
+	if _, ok := partFrame.AsPartialActivation(); !ok {
+		t.Errorf("AsPartialActivation() returned false for PartialActivation")
+	}
+}
+
+func TestFrameAsyncCallAndObserver(t *testing.T) {
+	frame := NewExecutionFrame(EmptyActivation())
+	defer frame.Close()
+
+	// Calling PendingAsyncCalls, AsyncCall, NotifyCompletion with nil ctx/asyncCalls
+	if count := frame.PendingAsyncCalls(); count != 0 {
+		t.Errorf("PendingAsyncCalls() = %d, wanted 0", count)
+	}
+	if call := frame.AsyncCall(1); call != nil {
+		t.Errorf("AsyncCall() = %v, wanted nil", call)
+	}
+	frame.NotifyCompletion(1) // should be no-op
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	frame.SetContext(ctx, 1)
+
+	obs := &testAsyncObserver{}
+	frame.SetAsyncObserver(obs)
+	frame.SetAsyncMaxConcurrency(1)
+
+	syncCh := make(chan ref.Val, 1)
+	impl := func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
+		return syncCh
+	}
+
+	argVals := []ref.Val{types.String("arg")}
+	res := frame.ComputeResult(100, "fn", "overload", impl, argVals)
+	if !types.IsUnknown(res) {
+		t.Fatalf("ComputeResult() = %v, wanted unknown", res)
+	}
+
+	// Call ComputeResult again with identical parameters to hit cached branch in getOrCreate
+	resCached := frame.ComputeResult(100, "fn", "overload", impl, argVals)
+	if !types.IsUnknown(resCached) {
+		t.Fatalf("ComputeResult() cached = %v, wanted unknown", resCached)
+	}
+
+	if count := frame.PendingAsyncCalls(); count != 1 {
+		t.Errorf("PendingAsyncCalls() = %d, wanted 1", count)
+	}
+
+	callID := res.(*types.Unknown).IDs()[0]
+	asyncCall := frame.AsyncCall(callID)
+	if asyncCall == nil {
+		t.Fatalf("AsyncCall() returned nil")
+	}
+	if asyncCall.CallID() != callID {
+		t.Errorf("CallID() = %d, wanted %d", asyncCall.CallID(), callID)
+	}
+	if asyncCall.Function() != "fn" {
+		t.Errorf("Function() = %s, wanted fn", asyncCall.Function())
+	}
+	if asyncCall.Overload() != "overload" {
+		t.Errorf("Overload() = %s, wanted overload", asyncCall.Overload())
+	}
+
+	// Send result to unblock the original async call
+	syncCh <- types.String("success")
+
+	// Wait for observer to see finished call
+	time.Sleep(20 * time.Millisecond)
+	if obs.startedCalls == 0 {
+		t.Errorf("observer OnCallStarted not called")
+	}
+	if obs.finishedCalls == 0 {
+		t.Errorf("observer OnCallFinished not called")
+	}
+
+	// Test SetAsyncMaxConcurrency(0) resets semaphore
+	frame.SetAsyncMaxConcurrency(0)
+	if frame.ctx.semaphore != nil {
+		t.Errorf("semaphore not set to nil")
+	}
+
+	// Test explicit NotifyCompletion
+	frame.NotifyCompletion(callID)
+}
+
+func TestAsyncCallStateEquals(t *testing.T) {
+	baseAcs := &asyncCallState{
+		function: "fn",
+		overload: "ov",
+		argVals:  []ref.Val{types.Int(1)},
+	}
+	var nilAcs *asyncCallState
+
+	tests := []struct {
+		name     string
+		receiver *asyncCallState
+		other    *asyncCallState
+		want     bool
+	}{
+		{
+			name:     "receiver nil",
+			receiver: nilAcs,
+			other:    baseAcs,
+			want:     false,
+		},
+		{
+			name:     "other nil",
+			receiver: baseAcs,
+			other:    nil,
+			want:     false,
+		},
+		{
+			name:     "different function",
+			receiver: baseAcs,
+			other:    &asyncCallState{function: "other", overload: "ov", argVals: []ref.Val{types.Int(1)}},
+			want:     false,
+		},
+		{
+			name:     "different overload",
+			receiver: baseAcs,
+			other:    &asyncCallState{function: "fn", overload: "other", argVals: []ref.Val{types.Int(1)}},
+			want:     false,
+		},
+		{
+			name:     "different arg vals",
+			receiver: baseAcs,
+			other:    &asyncCallState{function: "fn", overload: "ov", argVals: []ref.Val{types.Int(2)}},
+			want:     false,
+		},
+		{
+			name:     "identical",
+			receiver: baseAcs,
+			other:    &asyncCallState{function: "fn", overload: "ov", argVals: []ref.Val{types.Int(1)}},
+			want:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.receiver.equals(tc.other); got != tc.want {
+				t.Errorf("%v.equals(%v) = %v, wanted %v", tc.receiver, tc.other, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFrameAsyncCallContextCancelled(t *testing.T) {
+	frame := NewExecutionFrame(EmptyActivation())
+	defer frame.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	frame.SetContext(ctx, 1)
+	frame.SetAsyncMaxConcurrency(1)
+
+	implSlow := func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
+		return make(chan ref.Val) // blocks forever
+	}
+	// First call acquires the semaphore
+	frame.ComputeResult(200, "fn_slow", "overload", implSlow, nil)
+
+	// Give the first call's goroutine time to acquire the semaphore
+	time.Sleep(5 * time.Millisecond)
+	if len(frame.ctx.semaphore) != 1 {
+		t.Errorf("semaphore length = %d, wanted 1", len(frame.ctx.semaphore))
+	}
+
+	// Second call tries to acquire semaphore but it's full, so it blocks in select
+	frame.ComputeResult(201, "fn_cancel", "overload", implSlow, nil)
+
+	// Cancel the context so the second call's goroutine hits case <-ctx.Done(): when acquiring semaphore,
+	// and the first call's goroutine hits case <-ctx.Done(): when waiting on <-ch.
+	cancel()
+
+	// Wait a bit to let goroutines process cancellation
+	time.Sleep(10 * time.Millisecond)
+
+	// Verify cancellation successfully released resources and interrupted evaluation
+	if len(frame.ctx.semaphore) != 0 {
+		t.Errorf("semaphore length after cancel = %d, wanted 0", len(frame.ctx.semaphore))
+	}
+	if !frame.CheckInterrupt() {
+		t.Errorf("CheckInterrupt() returned false after cancellation")
+	}
+
+	// Call release with nil directly to cover tracker release nil check
+	asyncCallStateTrackerPool.release(nil)
+}

--- a/interpreter/frame_test.go
+++ b/interpreter/frame_test.go
@@ -17,24 +17,67 @@ package interpreter
 import (
 	"context"
 	"testing"
-	"time"
-
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
 )
 
-func TestFrameInterrupt(t *testing.T) {
+func TestFrameCheckInterrupt(t *testing.T) {
 	tests := []struct {
-		name        string
-		concurrency int
+		name     string
+		setupCtx func(ctx context.Context, f *ExecutionFrame) (context.CancelFunc, func(int))
+		checks   []bool
 	}{
 		{
-			name:        "without semaphores",
-			concurrency: 0,
+			name:   "nil context",
+			checks: []bool{false, false},
 		},
 		{
-			name:        "with semaphores",
-			concurrency: 1,
+			name: "zero frequency not canceled",
+			setupCtx: func(ctx context.Context, f *ExecutionFrame) (context.CancelFunc, func(int)) {
+				f.SetContext(ctx, 0)
+				return nil, nil
+			},
+			checks: []bool{false, false},
+		},
+		{
+			name: "frequency one not canceled",
+			setupCtx: func(ctx context.Context, f *ExecutionFrame) (context.CancelFunc, func(int)) {
+				f.SetContext(ctx, 1)
+				return nil, nil
+			},
+			checks: []bool{false, false},
+		},
+		{
+			name: "frequency one canceled dynamically",
+			setupCtx: func(ctx context.Context, f *ExecutionFrame) (context.CancelFunc, func(int)) {
+				c, cancel := context.WithCancel(ctx)
+				f.SetContext(c, 1)
+				return nil, func(step int) {
+					if step == 1 {
+						cancel()
+					}
+				}
+			},
+			checks: []bool{false, true, true},
+		},
+		{
+			name: "frequency two not canceled",
+			setupCtx: func(ctx context.Context, f *ExecutionFrame) (context.CancelFunc, func(int)) {
+				f.SetContext(ctx, 2)
+				return nil, nil
+			},
+			checks: []bool{false, false, false},
+		},
+		{
+			name: "frequency two canceled dynamically",
+			setupCtx: func(ctx context.Context, f *ExecutionFrame) (context.CancelFunc, func(int)) {
+				c, cancel := context.WithCancel(ctx)
+				f.SetContext(c, 2)
+				return nil, func(step int) {
+					if step == 1 {
+						cancel()
+					}
+				}
+			},
+			checks: []bool{false, true, true},
 		},
 	}
 
@@ -43,397 +86,293 @@ func TestFrameInterrupt(t *testing.T) {
 			frame := NewExecutionFrame(EmptyActivation())
 			defer frame.Close()
 
-			// Test CheckInterrupt with nil ctx
-			if frame.CheckInterrupt() {
-				t.Error("CheckInterrupt() returned true for nil ctx")
+			var cleanup context.CancelFunc
+			var stepHook func(int)
+			if tc.setupCtx != nil {
+				cleanup, stepHook = tc.setupCtx(context.Background(), frame)
+			}
+			if cleanup != nil {
+				defer cleanup()
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			frame.SetContext(ctx, 1)
-			frame.SetAsyncMaxConcurrency(tc.concurrency)
-
-			// First check with active context should return false
-			if frame.CheckInterrupt() {
-				t.Error("frame.CheckInterrupt() returned true, wanted false")
-			}
-
-			// Cancel context to trigger interrupt
-			cancel()
-
-			// Second check should observe cancellation and return true
-			if !frame.CheckInterrupt() {
-				t.Error("frame.CheckInterrupt() returned false, wanted true")
-			}
-
-			// Third check should hit the cached/loaded interrupted flag and return true
-			if !frame.CheckInterrupt() {
-				t.Error("frame.CheckInterrupt() (cached) returned false, wanted true")
+			for i, want := range tc.checks {
+				if stepHook != nil {
+					stepHook(i)
+				}
+				got := frame.CheckInterrupt()
+				if got != want {
+					t.Errorf("CheckInterrupt() call %d got %t, want %t", i+1, got, want)
+				}
 			}
 		})
 	}
-
-	t.Run("check frequency not triggered", func(t *testing.T) {
-		frame := NewExecutionFrame(EmptyActivation())
-		defer frame.Close()
-
-		frame.SetContext(context.Background(), 2)
-		// first call adds 1 to count -> 1%2 != 0 -> returns false
-		if frame.CheckInterrupt() {
-			t.Error("CheckInterrupt() returned true unexpectedly")
-		}
-	})
 }
 
-func TestFrameAsyncErrors(t *testing.T) {
-	frame := NewExecutionFrame(EmptyActivation())
-	defer frame.Close()
-
-	// ComputeResult without SetContext should return an error
-	res := frame.ComputeResult(1, "test", "test", nil, nil)
-	if !types.IsError(res) {
-		t.Errorf("ComputeResult() returned %v, wanted error", res)
+func TestFrameResolveName(t *testing.T) {
+	baseAct, err := NewActivation(map[string]any{"x": 1})
+	if err != nil {
+		t.Fatalf("NewActivation(x) failed: %v", err)
 	}
-}
-
-func TestFrameCompletions(t *testing.T) {
-	frame := NewExecutionFrame(EmptyActivation())
-	defer frame.Close()
-
-	ctx := context.Background()
-	frame.SetContext(ctx, 1)
-
-	completionCh := make(chan int64, 1)
-	frame.SetCompletions(completionCh)
-
-	syncCh := make(chan ref.Val, 1)
-	impl := func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
-		return syncCh
+	childAct, err := NewActivation(map[string]any{"y": 2})
+	if err != nil {
+		t.Fatalf("NewActivation(y) failed: %v", err)
 	}
-
-	// First call returns unknown
-	res := frame.ComputeResult(10, "test", "test", impl, nil)
-	if !types.IsUnknown(res) {
-		t.Fatalf("ComputeResult() returned %v, wanted unknown", res)
-	}
-
-	// Send result
-	syncCh <- types.String("done")
-
-	// Wait for completion signal
-	select {
-	case id := <-completionCh:
-		if id != res.(*types.Unknown).IDs()[0] {
-			t.Errorf("completion signal ID mismatch: got %d, wanted %d", id, res.(*types.Unknown).IDs()[0])
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for completion signal")
-	}
-
-	// Second call should return the result
-	res2 := frame.ComputeResult(10, "test", "test", impl, nil)
-	if res2.Equal(types.String("done")) != types.True {
-		t.Errorf("ComputeResult() returned %v, wanted 'done'", res2)
-	}
-}
-
-func TestEvalAsyncFunc(t *testing.T) {
-	frame := NewExecutionFrame(EmptyActivation())
-	defer frame.Close()
-	frame.SetContext(context.Background(), 1)
-
-	impl := func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
-		ch := make(chan ref.Val, 1)
-		ch <- types.Int(args[0].(types.Int) + 1)
-		return ch
-	}
-
-	fn := &evalAsyncFunc{
-		id:       1,
-		function: "inc",
-		overload: "inc_int",
-		args:     []InterpretableV2{NewConstValue(1, types.Int(10))},
-		impl:     impl,
-	}
-
-	// First exec triggers the call
-	res := fn.Exec(frame)
-	if !types.IsUnknown(res) {
-		t.Fatalf("Exec() returned %v, wanted unknown", res)
-	}
-
-	// Test Args()
-	if len(fn.Args()) != 1 {
-		t.Errorf("Args() returned %d, wanted 1", len(fn.Args()))
-	}
-
-	// Wait for async result (it's buffered in the impl channel in this test)
-	time.Sleep(10 * time.Millisecond)
-
-	// Test Eval() returns result
-	res3 := fn.Eval(frame)
-	if res3.Equal(types.Int(11)) != types.True {
-		t.Errorf("Eval() returned %v, wanted 11", res3)
-	}
-}
-
-func TestEvalAsyncFuncShortCircuit(t *testing.T) {
-	frame := NewExecutionFrame(EmptyActivation())
-	defer frame.Close()
-	frame.SetContext(context.Background(), 1)
-
-	fn := &evalAsyncFunc{
-		id:       1,
-		function: "inc",
-		args:     []InterpretableV2{NewConstValue(2, types.NewErr("bad arg"))},
-	}
-
-	res := fn.Exec(frame)
-	if !types.IsError(res) {
-		t.Errorf("Exec() returned %v, wanted error", res)
-	}
-
-	fn.args = []InterpretableV2{NewConstValue(3, types.NewUnknown(4, nil))}
-	res = fn.Exec(frame)
-	if !types.IsUnknown(res) {
-		t.Errorf("Exec() returned %v, wanted unknown", res)
-	}
-}
-
-type testAsyncObserver struct {
-	startedCalls  int
-	finishedCalls int
-}
-
-func (o *testAsyncObserver) OnCallStarted(callID int64, function, overload string, args []ref.Val) {
-	o.startedCalls++
-}
-
-func (o *testAsyncObserver) OnCallFinished(callID int64, function, overload string, res ref.Val) {
-	o.finishedCalls++
-}
-
-func TestFrameActivationMethods(t *testing.T) {
-	baseAct, _ := NewActivation(map[string]any{"x": 1})
-	frame := NewExecutionFrame(baseAct)
-	defer frame.Close()
-
-	childAct, _ := NewActivation(map[string]any{"y": 2})
-	childFrame := frame.push(childAct)
-
-	// Test ResolveName on childFrame
-	if v, ok := childFrame.ResolveName("y"); !ok || v != 2 {
-		t.Errorf("ResolveName('y') got %v, %v", v, ok)
-	}
-	if v, ok := childFrame.ResolveName("x"); !ok || v != 1 {
-		t.Errorf("ResolveName('x') got %v, %v", v, ok)
-	}
-	if _, ok := childFrame.ResolveName("missing"); ok {
-		t.Errorf("ResolveName('missing') unexpectedly found")
-	}
-
-	// Test Parent(), Unwrap(), AsPartialActivation() on childFrame
-	if childFrame.Parent() == nil {
-		t.Errorf("Parent() returned nil")
-	}
-	if childFrame.Unwrap() == nil {
-		t.Errorf("Unwrap() returned nil")
-	}
-	if _, ok := childFrame.AsPartialActivation(); ok {
-		t.Errorf("AsPartialActivation() unexpectedly true")
-	}
-
-	// Pop back to parent
-	popped := childFrame.pop()
-	if popped != frame {
-		t.Errorf("pop() did not return parent frame")
-	}
-
-	// Test AsPartialActivation returning true when frame wraps a PartialActivation
-	partAct, _ := NewPartialActivation(map[string]any{"z": 3})
-	partFrame := NewExecutionFrame(partAct)
-	defer partFrame.Close()
-	if _, ok := partFrame.AsPartialActivation(); !ok {
-		t.Errorf("AsPartialActivation() returned false for PartialActivation")
-	}
-}
-
-func TestFrameAsyncCallAndObserver(t *testing.T) {
-	frame := NewExecutionFrame(EmptyActivation())
-	defer frame.Close()
-
-	// Calling PendingAsyncCalls, AsyncCall, NotifyCompletion with nil ctx/asyncCalls
-	if count := frame.PendingAsyncCalls(); count != 0 {
-		t.Errorf("PendingAsyncCalls() = %d, wanted 0", count)
-	}
-	if call := frame.AsyncCall(1); call != nil {
-		t.Errorf("AsyncCall() = %v, wanted nil", call)
-	}
-	frame.NotifyCompletion(1) // should be no-op
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	frame.SetContext(ctx, 1)
-
-	obs := &testAsyncObserver{}
-	frame.SetAsyncObserver(obs)
-	frame.SetAsyncMaxConcurrency(1)
-
-	syncCh := make(chan ref.Val, 1)
-	impl := func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
-		return syncCh
-	}
-
-	argVals := []ref.Val{types.String("arg")}
-	res := frame.ComputeResult(100, "fn", "overload", impl, argVals)
-	if !types.IsUnknown(res) {
-		t.Fatalf("ComputeResult() = %v, wanted unknown", res)
-	}
-
-	// Call ComputeResult again with identical parameters to hit cached branch in getOrCreate
-	resCached := frame.ComputeResult(100, "fn", "overload", impl, argVals)
-	if !types.IsUnknown(resCached) {
-		t.Fatalf("ComputeResult() cached = %v, wanted unknown", resCached)
-	}
-
-	if count := frame.PendingAsyncCalls(); count != 1 {
-		t.Errorf("PendingAsyncCalls() = %d, wanted 1", count)
-	}
-
-	callID := res.(*types.Unknown).IDs()[0]
-	asyncCall := frame.AsyncCall(callID)
-	if asyncCall == nil {
-		t.Fatalf("AsyncCall() returned nil")
-	}
-	if asyncCall.CallID() != callID {
-		t.Errorf("CallID() = %d, wanted %d", asyncCall.CallID(), callID)
-	}
-	if asyncCall.Function() != "fn" {
-		t.Errorf("Function() = %s, wanted fn", asyncCall.Function())
-	}
-	if asyncCall.Overload() != "overload" {
-		t.Errorf("Overload() = %s, wanted overload", asyncCall.Overload())
-	}
-
-	// Send result to unblock the original async call
-	syncCh <- types.String("success")
-
-	// Wait for observer to see finished call
-	time.Sleep(20 * time.Millisecond)
-	if obs.startedCalls == 0 {
-		t.Errorf("observer OnCallStarted not called")
-	}
-	if obs.finishedCalls == 0 {
-		t.Errorf("observer OnCallFinished not called")
-	}
-
-	// Test SetAsyncMaxConcurrency(0) resets semaphore
-	frame.SetAsyncMaxConcurrency(0)
-	if frame.ctx.semaphore != nil {
-		t.Errorf("semaphore not set to nil")
-	}
-
-	// Test explicit NotifyCompletion
-	frame.NotifyCompletion(callID)
-}
-
-func TestAsyncCallStateEquals(t *testing.T) {
-	baseAcs := &asyncCallState{
-		function: "fn",
-		overload: "ov",
-		argVals:  []ref.Val{types.Int(1)},
-	}
-	var nilAcs *asyncCallState
 
 	tests := []struct {
-		name     string
-		receiver *asyncCallState
-		other    *asyncCallState
-		want     bool
+		name      string
+		setup     func() *ExecutionFrame
+		varName   string
+		wantVal   any
+		wantFound bool
 	}{
 		{
-			name:     "receiver nil",
-			receiver: nilAcs,
-			other:    baseAcs,
-			want:     false,
+			name: "resolve in base activation",
+			setup: func() *ExecutionFrame {
+				return NewExecutionFrame(baseAct)
+			},
+			varName:   "x",
+			wantVal:   1,
+			wantFound: true,
 		},
 		{
-			name:     "other nil",
-			receiver: baseAcs,
-			other:    nil,
-			want:     false,
+			name: "missing in base activation",
+			setup: func() *ExecutionFrame {
+				return NewExecutionFrame(baseAct)
+			},
+			varName:   "y",
+			wantVal:   nil,
+			wantFound: false,
 		},
 		{
-			name:     "different function",
-			receiver: baseAcs,
-			other:    &asyncCallState{function: "other", overload: "ov", argVals: []ref.Val{types.Int(1)}},
-			want:     false,
+			name: "resolve in child activation",
+			setup: func() *ExecutionFrame {
+				f := NewExecutionFrame(baseAct)
+				return f.push(childAct)
+			},
+			varName:   "y",
+			wantVal:   2,
+			wantFound: true,
 		},
 		{
-			name:     "different overload",
-			receiver: baseAcs,
-			other:    &asyncCallState{function: "fn", overload: "other", argVals: []ref.Val{types.Int(1)}},
-			want:     false,
+			name: "resolve in parent activation from child",
+			setup: func() *ExecutionFrame {
+				f := NewExecutionFrame(baseAct)
+				return f.push(childAct)
+			},
+			varName:   "x",
+			wantVal:   1,
+			wantFound: true,
 		},
 		{
-			name:     "different arg vals",
-			receiver: baseAcs,
-			other:    &asyncCallState{function: "fn", overload: "ov", argVals: []ref.Val{types.Int(2)}},
-			want:     false,
-		},
-		{
-			name:     "identical",
-			receiver: baseAcs,
-			other:    &asyncCallState{function: "fn", overload: "ov", argVals: []ref.Val{types.Int(1)}},
-			want:     true,
+			name: "missing in hierarchical activation",
+			setup: func() *ExecutionFrame {
+				f := NewExecutionFrame(baseAct)
+				return f.push(childAct)
+			},
+			varName:   "z",
+			wantVal:   nil,
+			wantFound: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.receiver.equals(tc.other); got != tc.want {
-				t.Errorf("%v.equals(%v) = %v, wanted %v", tc.receiver, tc.other, got, tc.want)
+			frame := tc.setup()
+			defer func() {
+				curr := frame
+				for curr.parent != nil {
+					curr = curr.pop()
+				}
+				curr.Close()
+			}()
+
+			gotVal, gotFound := frame.ResolveName(tc.varName)
+			if gotFound != tc.wantFound || gotVal != tc.wantVal {
+				t.Errorf("ResolveName(%q) got (%v, %t), want (%v, %t)", tc.varName, gotVal, gotFound, tc.wantVal, tc.wantFound)
 			}
 		})
 	}
 }
 
-func TestFrameAsyncCallContextCancelled(t *testing.T) {
-	frame := NewExecutionFrame(EmptyActivation())
+func TestFrameParent(t *testing.T) {
+	baseAct, err := NewActivation(map[string]any{"x": 1})
+	if err != nil {
+		t.Fatalf("NewActivation(x) failed: %v", err)
+	}
+	childAct, err := NewActivation(map[string]any{"y": 2})
+	if err != nil {
+		t.Fatalf("NewActivation(y) failed: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		setup func() (*ExecutionFrame, func())
+		want  Activation
+	}{
+		{
+			name: "base frame has no parent activation",
+			setup: func() (*ExecutionFrame, func()) {
+				f := NewExecutionFrame(baseAct)
+				return f, func() { f.Close() }
+			},
+			want: nil,
+		},
+		{
+			name: "pushed frame returns parent activation",
+			setup: func() (*ExecutionFrame, func()) {
+				f := NewExecutionFrame(baseAct)
+				child := f.push(childAct)
+				return child, func() {
+					child.pop()
+					f.Close()
+				}
+			},
+			want: baseAct,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			frame, cleanup := tc.setup()
+			defer cleanup()
+
+			if got := frame.Parent(); got != tc.want {
+				t.Errorf("Parent() got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFrameUnwrap(t *testing.T) {
+	baseAct, err := NewActivation(map[string]any{"x": 1})
+	if err != nil {
+		t.Fatalf("NewActivation(x) failed: %v", err)
+	}
+	frame := NewExecutionFrame(baseAct)
 	defer frame.Close()
-	ctx, cancel := context.WithCancel(context.Background())
+
+	if got := frame.Unwrap(); got != baseAct {
+		t.Errorf("Unwrap() got %v, want %v", got, baseAct)
+	}
+
+	childAct, err := NewActivation(map[string]any{"y": 2})
+	if err != nil {
+		t.Fatalf("NewActivation(y) failed: %v", err)
+	}
+	childFrame := frame.push(childAct)
+	defer childFrame.pop()
+
+	if got := childFrame.Unwrap(); got != childFrame.Activation {
+		t.Errorf("Unwrap() got %v, want %v", got, childFrame.Activation)
+	}
+}
+
+func TestFrameAsPartialActivation(t *testing.T) {
+	baseAct, err := NewActivation(map[string]any{"x": 1})
+	if err != nil {
+		t.Fatalf("NewActivation(x) failed: %v", err)
+	}
+	partAct, err := NewPartialActivation(map[string]any{"y": 2})
+	if err != nil {
+		t.Fatalf("NewPartialActivation(y) failed: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		setup     func() *ExecutionFrame
+		wantFound bool
+	}{
+		{
+			name: "non-partial activation returns false",
+			setup: func() *ExecutionFrame {
+				return NewExecutionFrame(baseAct)
+			},
+			wantFound: false,
+		},
+		{
+			name: "partial activation returns true",
+			setup: func() *ExecutionFrame {
+				return NewExecutionFrame(partAct)
+			},
+			wantFound: true,
+		},
+		{
+			name: "hierarchical activation wrapping partial activation returns true",
+			setup: func() *ExecutionFrame {
+				f := NewExecutionFrame(partAct)
+				return f.push(baseAct)
+			},
+			wantFound: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			frame := tc.setup()
+			defer func() {
+				curr := frame
+				for curr.parent != nil {
+					curr = curr.pop()
+				}
+				curr.Close()
+			}()
+
+			gotAct, gotFound := frame.AsPartialActivation()
+			if gotFound != tc.wantFound {
+				t.Errorf("AsPartialActivation() got found=%t, want found=%t", gotFound, tc.wantFound)
+			}
+			if tc.wantFound && gotAct == nil {
+				t.Errorf("AsPartialActivation() returned nil for found partial activation")
+			}
+		})
+	}
+}
+
+func TestFramePushPop(t *testing.T) {
+	baseAct, err := NewActivation(map[string]any{"x": 1})
+	if err != nil {
+		t.Fatalf("NewActivation(x) failed: %v", err)
+	}
+	childAct, err := NewActivation(map[string]any{"y": 2})
+	if err != nil {
+		t.Fatalf("NewActivation(y) failed: %v", err)
+	}
+
+	frame := NewExecutionFrame(baseAct)
+	defer frame.Close()
+
+	childFrame := frame.push(childAct)
+	if childFrame == nil {
+		t.Fatal("push() returned nil")
+	}
+	if childFrame.parent != frame {
+		t.Errorf("push() parent got %v, want %v", childFrame.parent, frame)
+	}
+
+	popped := childFrame.pop()
+	if popped != frame {
+		t.Errorf("pop() got %v, want %v", popped, frame)
+	}
+}
+
+func TestFrameClose(t *testing.T) {
+	frame := NewExecutionFrame(EmptyActivation())
+	ctx := context.Background()
 	frame.SetContext(ctx, 1)
-	frame.SetAsyncMaxConcurrency(1)
 
-	implSlow := func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
-		return make(chan ref.Val) // blocks forever
-	}
-	// First call acquires the semaphore
-	frame.ComputeResult(200, "fn_slow", "overload", implSlow, nil)
+	frameCtx := frame.ctx.ctx
 
-	// Give the first call's goroutine time to acquire the semaphore
-	time.Sleep(5 * time.Millisecond)
-	if len(frame.ctx.semaphore) != 1 {
-		t.Errorf("semaphore length = %d, wanted 1", len(frame.ctx.semaphore))
+	select {
+	case <-frameCtx.Done():
+		t.Fatal("context canceled before Close()")
+	default:
 	}
 
-	// Second call tries to acquire semaphore but it's full, so it blocks in select
-	frame.ComputeResult(201, "fn_cancel", "overload", implSlow, nil)
+	frame.Close()
 
-	// Cancel the context so the second call's goroutine hits case <-ctx.Done(): when acquiring semaphore,
-	// and the first call's goroutine hits case <-ctx.Done(): when waiting on <-ch.
-	cancel()
-
-	// Wait a bit to let goroutines process cancellation
-	time.Sleep(10 * time.Millisecond)
-
-	// Verify cancellation successfully released resources and interrupted evaluation
-	if len(frame.ctx.semaphore) != 0 {
-		t.Errorf("semaphore length after cancel = %d, wanted 0", len(frame.ctx.semaphore))
+	select {
+	case <-frameCtx.Done():
+	default:
+		t.Error("context not canceled after Close()")
 	}
-	if !frame.CheckInterrupt() {
-		t.Errorf("CheckInterrupt() returned false after cancellation")
-	}
-
-	// Call release with nil directly to cover tracker release nil check
-	asyncCallStateTrackerPool.release(nil)
 }


### PR DESCRIPTION
There are a lot of concepts present in the `ExecutionFrame`, but it overall introduces the following concepts:

* `ExecutionFrame` is a custom `context.Context` value whose lifecycle is owned entirely by CEL
* `functions.AsyncOp` and `functions.BlockingAsyncOp` are the signature expected for async call management. 

The next PRs will introduce the following changes:

## Interpretation updates

* Integration of `ExecutionFrame` via an `InterpretableV2` interface
* Cleanup of the state tracing and cost tracking logic by hoisting it into `ExecutionFrame`
* Unified `ExecutionFrame` and `Activation` pooling

## Async calls

* Iterative eval with different drain strategies
* Async call caching support

## Checkpoint evaluation

* Determine incrementally re-evaluate from a checkpoint to assist with minimizing expensive computations in response to new async results.