### PR TITLE
Test Runner usability improvements

### DIFF
--- a/test/proto2pb/BUILD.bazel
+++ b/test/proto2pb/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/test/proto3pb/BUILD.bazel
+++ b/test/proto3pb/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/tools/celtest/BUILD.bazel
+++ b/tools/celtest/BUILD.bazel
@@ -33,6 +33,8 @@ go_library(
         "//common/operators:go_default_library",
         "//common/types:go_default_library",
         "//common/types/ref:go_default_library",
+        "//common/env:go_default_library",
+        "//common/debug:go_default_library",
         "//interpreter:go_default_library",
         "//parser:go_default_library",
         "//test:go_default_library",

--- a/tools/celtest/test_runner.go
+++ b/tools/celtest/test_runner.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/debug"
+	"github.com/google/cel-go/common/env"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -57,6 +59,7 @@ var (
 	configPath            string
 	baseConfigPath        string
 	enableCoverage        bool
+	enableDebug           bool
 )
 
 func init() {
@@ -66,6 +69,7 @@ func init() {
 	flag.StringVar(&baseConfigPath, "base_config_path", "", "path to a base config file")
 	flag.StringVar(&celExpression, "cel_expr", "", "CEL expression to test")
 	flag.BoolVar(&enableCoverage, "enable_coverage", false, "Enable coverage calculation and reporting.")
+	flag.BoolVar(&enableDebug, "celtest_debug", false, "Enables verbose logging of test case execution.")
 }
 
 func updateRunfilesPathForFlags(testResourcesDir string) error {
@@ -315,6 +319,31 @@ func TestSuiteParserOption(p TestSuiteParser) TestRunnerOption {
 	}
 }
 
+type typeAdorner struct {
+	ast *cel.Ast
+}
+
+// Implements type.Adorner
+func (a *typeAdorner) GetMetadata(ctx any) string {
+	e, ok := ctx.(ast.Expr)
+	if !ok {
+		return ""
+	}
+	t := a.ast.NativeRep().GetType(e.ID())
+	if t != nil {
+		return " : " + env.SerializeTypeDesc(t).SpecifierFormat()
+	}
+	return " : <no type inferred>"
+}
+
+func DebugAST(ast *cel.Ast) string {
+	if ast == nil {
+		return "<nil>"
+	}
+	adorner := &typeAdorner{ast: ast}
+	return debug.ToAdornedDebugString(ast.NativeRep().Expr(), adorner)
+}
+
 // TestRunner provides a structure to hold the different components required to execute tests for
 // a list of Input Expressions. The TestRunner can be configured with the following options:
 // - Compiler: The compiler used for parsing and compiling the input expressions.
@@ -550,6 +579,9 @@ func (tr *TestRunner) Programs(t *testing.T, opts ...cel.ProgramOption) ([]Progr
 			}
 			return nil, err
 		}
+		if enableDebug {
+			t.Logf("Loaded AST:\n%s", DebugAST(ast))
+		}
 		prg, err := e.Program(ast, opts...)
 		if err != nil {
 			return nil, err
@@ -709,26 +741,32 @@ func (tr *TestRunner) createResultMatcherFromPB(t *testing.T, testCase *conforma
 			return successResult
 		}, nil
 	case *conformancepb.TestOutput_ResultExpr:
-		return func(val ref.Val, err error) TestResult {
+		return func(got ref.Val, err error) TestResult {
 			if err != nil {
 				return TestResult{Success: false, Error: err}
 			}
-			testOut, err := tr.eval(testOutput.ResultExpr)
+			want, err := tr.eval(testOutput.ResultExpr)
 			if err != nil {
 				return TestResult{Success: false, Error: fmt.Errorf("eval(%q) failed: %v", testOutput.ResultExpr, err)}
 			}
-			if optOut, ok := val.(*types.Optional); ok {
-				if optOut.Equal(types.OptionalNone) == types.True {
-					if testOut.Equal(types.OptionalNone) != types.True {
-						return TestResult{Success: false, Wanted: fmt.Sprintf("optional value %v", testOut), Error: fmt.Errorf("policy eval got %v", val)}
+			if gotOpt, ok := got.(*types.Optional); ok {
+				if gotOpt.Equal(types.OptionalNone) == types.True {
+					if want.Equal(types.OptionalNone) == types.True {
+						return successResult
 					}
-				} else if testOut.Equal(optOut.GetValue()) != types.True {
-					return TestResult{Success: false, Wanted: fmt.Sprintf("optional value %v", testOut), Error: fmt.Errorf("policy eval got %v", val)}
+					return TestResult{Success: false, Wanted: fmt.Sprintf("optional value %v", want), Error: fmt.Errorf("policy eval got %v", got)}
 				}
-			} else if val.Equal(testOut) != types.True {
-				return TestResult{Success: false, Wanted: fmt.Sprintf("optional value %v", testOut), Error: fmt.Errorf("policy eval got %v", val)}
+				if want.Equal(gotOpt.GetValue()) == types.True {
+					if enableDebug {
+						t.Log("result implicitly unwrapped optional\n")
+					}
+					return successResult
+				}
 			}
-			return successResult
+			if got.Equal(want) == types.True {
+				return successResult
+			}
+			return TestResult{Success: false, Wanted: fmt.Sprintf("optional value %v", want), Error: fmt.Errorf("policy eval got %v", got)}
 		}, nil
 	case *conformancepb.TestOutput_EvalError:
 		return func(val ref.Val, err error) TestResult {
@@ -900,17 +938,19 @@ func (tr *TestRunner) createResultMatcher(t *testing.T, testOutput *test.Output)
 	if testOutput.Value != nil {
 		want := e.CELTypeAdapter().NativeToValue(testOutput.Value)
 		return func(out ref.Val, err error) TestResult {
-			if err == nil {
-				if out.Equal(want) == types.True {
+			if err != nil {
+				return TestResult{Success: false, Wanted: fmt.Sprintf("simple value %v", want), Error: err}
+			}
+			if out.Equal(want) == types.True {
+				return successResult
+			}
+			if optOut, ok := out.(*types.Optional); ok {
+				if optOut.HasValue() && optOut.GetValue().Equal(want) == types.True {
 					return successResult
 				}
-				if optOut, ok := out.(*types.Optional); ok {
-					if optOut.HasValue() && optOut.GetValue().Equal(want) == types.True {
-						return successResult
-					}
-				}
 			}
-			return TestResult{Success: false, Wanted: fmt.Sprintf("simple value %v", want), Error: err}
+			return TestResult{Success: false, Wanted: fmt.Sprintf("simple value %v", want), Error: fmt.Errorf("policy eval got %v", out)}
+
 		}, nil
 	}
 	if testOutput.Expr != "" {
@@ -919,17 +959,19 @@ func (tr *TestRunner) createResultMatcher(t *testing.T, testOutput *test.Output)
 			return nil, fmt.Errorf("eval(%q) failed: %w", testOutput.Expr, err)
 		}
 		return func(out ref.Val, err error) TestResult {
-			if err == nil {
-				if out.Equal(want) == types.True {
+			if err != nil {
+				return TestResult{Success: false, Wanted: fmt.Sprintf("simple value %v", want), Error: err}
+			}
+			if out.Equal(want) == types.True {
+				return successResult
+			}
+			if optOut, ok := out.(*types.Optional); ok {
+				if optOut.HasValue() && optOut.GetValue().Equal(want) == types.True {
 					return successResult
 				}
-				if optOut, ok := out.(*types.Optional); ok {
-					if optOut.HasValue() && optOut.GetValue().Equal(want) == types.True {
-						return successResult
-					}
-				}
 			}
-			return TestResult{Success: false, Wanted: fmt.Sprintf("simple value %v", want), Error: err}
+			return TestResult{Success: false, Wanted: fmt.Sprintf("simple value %v", want), Error: fmt.Errorf("policy eval got %v", out)}
+
 		}, nil
 	}
 	if testOutput.ErrorSet != nil {
@@ -972,6 +1014,9 @@ func (tr *TestRunner) ExecuteTest(t *testing.T, programs []Program, test *Test) 
 			return fmt.Errorf("CEL program not set")
 		}
 		out, details, err := pr.Eval(test.input)
+		if enableDebug {
+			t.Logf("Eval result: %v (err: %v)", out, err)
+		}
 		if testResult := test.resultMatcher(out, err); !testResult.Success {
 			return fmt.Errorf("test: %s \n wanted: %v \n failed: %v", test.name, testResult.Wanted, testResult.Error)
 		}


### PR DESCRIPTION
- Fixes unintentional fallthrough in matchers which led to poor error messages 
- Add a flag for printing the AST under test and the output of evaluation
- load proto_library rules for bazel 9x