### PR TITLE
Policy variable scoping fixes

### DIFF
--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -221,3 +221,21 @@ cel_go_test(
     test_src = "//policy/test:cel_test_runner.go",
     test_suite = "testdata/unnest/tests.yaml",
 )
+
+cel_go_test(
+    name = "nested_rules_variable_shadowing_policy",
+    cel_expr = "testdata/nested_rules_variable_shadowing/policy.yaml",
+    config = "testdata/nested_rules_variable_shadowing/config.yaml",
+    enable_coverage = True,
+    test_src = "//policy/test:cel_test_runner.go",
+    test_suite = "testdata/nested_rules_variable_shadowing/tests.yaml",
+)
+
+cel_go_test(
+    name = "variable_type_propagation_policy",
+    cel_expr = "testdata/variable_type_propagation/policy.yaml",
+    config = "testdata/variable_type_propagation/config.yaml",
+    enable_coverage = True,
+    test_src = "//policy/test:cel_test_runner.go",
+    test_suite = "testdata/variable_type_propagation/tests.yaml",
+)

--- a/policy/composer.go
+++ b/policy/composer.go
@@ -146,12 +146,12 @@ func (opt *ruleComposerImpl) lookupLocal(name string) (int, bool) {
 	return -1, false
 }
 
-func (opt * ruleComposerImpl) enterScope() {
+func (opt *ruleComposerImpl) enterScope() {
 	opt.scopes = append(opt.scopes, localScope{})
 }
 
-func (r *ruleComposerImpl) exitScope() {
-	r.scopes = r.scopes[:len(r.scopes)-1]
+func (opt *ruleComposerImpl) exitScope() {
+	opt.scopes = opt.scopes[:len(opt.scopes)-1]
 }
 
 // Optimize implements an AST optimizer for CEL which composes an expression graph into a single
@@ -284,9 +284,9 @@ func (opt *ruleUnnesterImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *as
 	var varDecls []cel.EnvOption
 	unnestOffset := opt.nextVarIndex
 	if ruleExpr.Kind() == ast.CallKind && ruleExpr.AsCall().FunctionName() == "cel.@block" {
-		// Extract the expr from the cel.@block, args[1], as a navigable expr value.
-		// Also extract the variable declarations and all associated types from the cel.@block as
-		// varIndex values, but without doing any rewrites as the types are all correct already.
+		// Check that the result of the compose pass is consistent with the intial set of variable
+		// definitions in the optimizer. Extract the value expressions and types to set up the
+		// checker environment.
 		block := ruleExpr.AsCall()
 		ruleExpr = block.Args()[1].(ast.NavigableExpr)
 
@@ -294,7 +294,7 @@ func (opt *ruleUnnesterImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *as
 		blockList := block.Args()[0].(ast.NavigableExpr)
 		vars := blockList.AsList()
 		if vars.Size() != len(opt.varIndices) {
-			ctx.ReportErrorAtID(ruleExpr.ID(), "var list size does not match")
+			ctx.ReportErrorAtID(ruleExpr.ID(), "ast var list size and recorded one do not match")
 		}
 		varExprs = make([]ast.Expr, vars.Size())
 		varDecls = make([]cel.EnvOption, vars.Size())
@@ -302,7 +302,6 @@ func (opt *ruleUnnesterImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *as
 			if i >= len(varExprs) {
 				break
 			}
-			// Track the variable he varDecls set.
 			varDecls[i] = cel.Variable(v.indexVar, v.celType)
 			varExprs[i] = v.expr
 		}

--- a/policy/composer.go
+++ b/policy/composer.go
@@ -92,7 +92,8 @@ func (c *RuleComposer) Compose(r *CompiledRule) (*cel.Ast, *cel.Issues) {
 		return nil, iss
 	}
 	unnester := &ruleUnnesterImpl{
-		varIndices:       []varIndex{},
+		nextVarIndex: len(composer.varIndices),
+		varIndices:       composer.varIndices,
 		exprUnnestHeight: c.exprUnnestHeight,
 	}
 	opt, err = cel.NewStaticOptimizer(unnester)
@@ -126,10 +127,31 @@ type varIndex struct {
 	celType  *types.Type
 }
 
+type localScope map[string]int
+
 type ruleComposerImpl struct {
 	rule         *CompiledRule
 	nextVarIndex int
 	varIndices   []varIndex
+	scopes       []localScope
+}
+
+func (opt *ruleComposerImpl) lookupLocal(name string) (int, bool) {
+	// iterate through scopes in reverse order
+	for i := len(opt.scopes) - 1; i >= 0; i-- {
+		if idx, ok := opt.scopes[i][name]; ok {
+			return idx, true
+		}
+	}
+	return -1, false
+}
+
+func (opt * ruleComposerImpl) enterScope() {
+	opt.scopes = append(opt.scopes, localScope{})
+}
+
+func (r *ruleComposerImpl) exitScope() {
+	r.scopes = r.scopes[:len(r.scopes)-1]
 }
 
 // Optimize implements an AST optimizer for CEL which composes an expression graph into a single
@@ -160,6 +182,8 @@ func (opt *ruleComposerImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *as
 
 func (opt *ruleComposerImpl) optimizeRule(ctx *cel.OptimizerContext, r *CompiledRule) ast.Expr {
 	// Visitor to rewrite variables-prefixed identifiers with index names.
+	opt.enterScope()
+	defer opt.exitScope()
 	vars := r.Variables()
 	for _, v := range vars {
 		opt.registerVariable(ctx, v)
@@ -217,13 +241,12 @@ func (opt *ruleComposerImpl) rewriteVariableName(ctx *cel.OptimizerContext) ast.
 			return
 		}
 		varName := expr.AsIdent()
-		for i := len(opt.varIndices) - 1; i >= 0; i-- {
-			v := opt.varIndices[i]
-			if v.localVar == varName {
-				ctx.UpdateExpr(expr, ctx.NewIdent(v.indexVar))
-				return
-			}
+		idx, found := opt.lookupLocal(varName)
+		if !found {
+			return
 		}
+		rec := opt.varIndices[idx]
+		ctx.UpdateExpr(expr, ctx.NewIdent(rec.indexVar))
 	})
 }
 
@@ -241,6 +264,9 @@ func (opt *ruleComposerImpl) registerVariable(ctx *cel.OptimizerContext, v *Comp
 		expr:     varExpr,
 		celType:  v.Declaration().Type()}
 	opt.varIndices = append(opt.varIndices, vi)
+	if len(opt.scopes) > 0 {
+		opt.scopes[len(opt.scopes) - 1][varName] = len(opt.varIndices) - 1 
+	}
 	opt.nextVarIndex++
 }
 
@@ -256,6 +282,7 @@ func (opt *ruleUnnesterImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *as
 	ruleExpr := ast.NavigateAST(a)
 	var varExprs []ast.Expr
 	var varDecls []cel.EnvOption
+	unnestOffset := opt.nextVarIndex
 	if ruleExpr.Kind() == ast.CallKind && ruleExpr.AsCall().FunctionName() == "cel.@block" {
 		// Extract the expr from the cel.@block, args[1], as a navigable expr value.
 		// Also extract the variable declarations and all associated types from the cel.@block as
@@ -266,15 +293,18 @@ func (opt *ruleUnnesterImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *as
 		// Collect the list of variables associated with the block
 		blockList := block.Args()[0].(ast.NavigableExpr)
 		vars := blockList.AsList()
+		if vars.Size() != len(opt.varIndices) {
+			ctx.ReportErrorAtID(ruleExpr.ID(), "var list size does not match")
+		}
 		varExprs = make([]ast.Expr, vars.Size())
 		varDecls = make([]cel.EnvOption, vars.Size())
-		copy(varExprs, vars.Elements())
-		for i, v := range varExprs {
+		for i, v := range opt.varIndices {
+			if i >= len(varExprs) {
+				break
+			}
 			// Track the variable he varDecls set.
-			indexVar := fmt.Sprintf("@index%d", i)
-			celType := a.GetType(v.ID())
-			varDecls[i] = cel.Variable(indexVar, celType)
-			opt.nextVarIndex++
+			varDecls[i] = cel.Variable(v.indexVar, v.celType)
+			varExprs[i] = v.expr
 		}
 	}
 	if len(varDecls) != 0 {
@@ -293,7 +323,7 @@ func (opt *ruleUnnesterImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *as
 
 	// Otherwise populate the cel.@block with the variable declarations and wrap the expression
 	// in the block.
-	for i := 0; i < len(opt.varIndices); i++ {
+	for i := unnestOffset; i < len(opt.varIndices); i++ {
 		vi := opt.varIndices[i]
 		varExprs = append(varExprs, vi.expr)
 		err := ctx.ExtendEnv(cel.Variable(vi.indexVar, vi.celType))

--- a/policy/composer.go
+++ b/policy/composer.go
@@ -294,7 +294,8 @@ func (opt *ruleUnnesterImpl) Optimize(ctx *cel.OptimizerContext, a *ast.AST) *as
 		blockList := block.Args()[0].(ast.NavigableExpr)
 		vars := blockList.AsList()
 		if vars.Size() != len(opt.varIndices) {
-			ctx.ReportErrorAtID(ruleExpr.ID(), "ast var list size and recorded one do not match")
+			ctx.ReportErrorAtID(ruleExpr.ID(), "ast block list and computed one have different sizes")
+			return a
 		}
 		varExprs = make([]ast.Expr, vars.Size())
 		varDecls = make([]cel.EnvOption, vars.Size())

--- a/policy/testdata/nested_rules_variable_shadowing/config.yaml
+++ b/policy/testdata/nested_rules_variable_shadowing/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: nested_rules_variable_shadowing
+variables:
+  - name: x
+    type: int

--- a/policy/testdata/nested_rules_variable_shadowing/policy.yaml
+++ b/policy/testdata/nested_rules_variable_shadowing/policy.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: nested_rules_variable_shadowing
+rule:
+  variables:
+    - name: i
+      expression: '1'
+    - name: j
+      expression: '2'
+  match:
+    - condition: "x == 1"
+      rule:
+        variables:
+          - name: i
+            expression: "5"
+        match:
+          - output: "variables.i + variables.j"
+    - condition: "x == 2"
+      rule:
+        match:
+          - output: "variables.i + variables.j"
+    - output: "variables.i + variables.j"

--- a/policy/testdata/nested_rules_variable_shadowing/tests.yaml
+++ b/policy/testdata/nested_rules_variable_shadowing/tests.yaml
@@ -1,0 +1,36 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: "Nested rule tests for rule variable shadowing"
+section:
+  - name: "shadowing"
+    tests:
+      - name: "shadowed"
+        input:
+          x:
+            expr: "1"
+        output:
+          value: 7
+      - name: "neighbor_rule"
+        input:
+          x:
+            expr: 2
+        output:
+          value: 3
+      - name: "parent_rule"
+        input:
+          x:
+            value: 3
+        output:
+          value: 3

--- a/policy/testdata/variable_type_propagation/config.yaml
+++ b/policy/testdata/variable_type_propagation/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: nested_rules_variable_shadowing
+variables:
+  - name: x
+    type: int

--- a/policy/testdata/variable_type_propagation/config.yaml
+++ b/policy/testdata/variable_type_propagation/config.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: nested_rules_variable_shadowing
+name: variable_type_propagation
 variables:
   - name: x
     type: int

--- a/policy/testdata/variable_type_propagation/policy.yaml
+++ b/policy/testdata/variable_type_propagation/policy.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: variable_type_propagation
+rule:
+  variables:
+    - name: empty_list
+      expression: '[]'
+    - name: string_list
+      expression: '["foo"]'
+  match:
+    - output: "variables.empty_list + [1]"

--- a/policy/testdata/variable_type_propagation/tests.yaml
+++ b/policy/testdata/variable_type_propagation/tests.yaml
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: "Rule demonstrating variable types propagate independently"
+section:
+  - name: "test"
+    tests:
+      - name: "types_agree"
+        output:
+          expr: "[1]"


### PR DESCRIPTION
 - fix variable resolution when a variable in a nested rule shadows an outer one
 - propagate the variable type from composition to unnesting instead of
   reading the post optimize inferred type (should address #1312)


