### PR TITLE
fix: provide ResultSize for string.format() cost estimate

### DIFF
--- a/checker/cost.go
+++ b/checker/cost.go
@@ -752,9 +752,9 @@ func (c *coster) functionCost(e ast.Expr, function, overloadID string, target *A
 	// O(n) functions
 	case overloads.ExtFormatString:
 		if target != nil {
-			// ResultSize not calculated because we can't bound the max size.
+			// ResultSize is bounded: since precision is capped by StringsMaxPrecision, 			// the output cannot exceed the format string size plus the sum of 			// argument string sizes (each numeric arg expands by at most 			// maxPrecision + fixed overhead characters).
 			return CallEstimate{
-				CostEstimate: c.sizeOrUnknown(*target).MultiplyByCostFactor(common.StringTraversalCostFactor).Add(argCostSum())}
+				targetSz := c.sizeOrUnknown(*target) 			argsSz := c.sizeOrUnknown(args[0]) 			resultSize := targetSz.Add(argsSz) 			return CallEstimate{ 				CostEstimate: targetSz.MultiplyByCostFactor(common.StringTraversalCostFactor).Add(argCostSum()), 				ResultSize:   &resultSize}
 		}
 	case overloads.StringToBytes:
 		if len(args) == 1 {


### PR DESCRIPTION
Prior to this fix, the ExtFormatString cost case returned no ResultSize, with the comment "ResultSize not calculated because we can't bound the max size."

Since PR #1292 introduced StringsMaxPrecision (defaulting to 100 for v5+), the output size of string.format() is now bounded: each format clause expands an argument by at most maxPrecision + small constant characters. The output is therefore bounded by the format string size plus the sum of argument string sizes.

This change computes ResultSize = targetSize + argsSize, enabling downstream cost-tracking expressions (e.g. format output passed to contains(), size(), or string concatenation) to have accurate cost estimates, which is important for enforcing compute limits in security-sensitive CEL evaluation contexts.

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests