### PR TITLE
Update documentation for nested first-match rules

### DIFF
--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -233,6 +233,26 @@ cel_go_test(
 )
 
 cel_go_test(
+    name = "nested_rules_unconditional_chaining_policy",
+    cel_expr = "testdata/nested_rules_unconditional_chaining/policy.yaml",
+    config = "testdata/nested_rules_unconditional_chaining/config.yaml",
+    enable_coverage = True,
+    test_src = "//policy/test:cel_test_runner.go",
+    test_suite = "testdata/nested_rules_unconditional_chaining/tests.yaml",
+)
+
+cel_go_test(
+    name = "nested_rules_unconditional_chaining_optional_policy",
+    cel_expr = "testdata/nested_rules_unconditional_chaining_optional/policy.yaml",
+    config = "testdata/nested_rules_unconditional_chaining_optional/config.yaml",
+    enable_coverage = True,
+    test_src = "//policy/test:cel_test_runner.go",
+    test_suite = "testdata/nested_rules_unconditional_chaining_optional/tests.yaml",
+)
+
+
+
+cel_go_test(
     name = "variable_type_propagation_policy",
     cel_expr = "testdata/variable_type_propagation/policy.yaml",
     config = "testdata/variable_type_propagation/config.yaml",

--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -250,6 +250,16 @@ cel_go_test(
     test_suite = "testdata/nested_rules_unconditional_chaining_optional/tests.yaml",
 )
 
+cel_go_test(
+    name = "nested_rules_unwrap_rewrap_policy",
+    cel_expr = "testdata/nested_rules_unwrap_rewrap/policy.yaml",
+    config = "testdata/nested_rules_unwrap_rewrap/config.yaml",
+    enable_coverage = True,
+    test_src = "//policy/test:cel_test_runner.go",
+    test_suite = "testdata/nested_rules_unwrap_rewrap/tests.yaml",
+)
+
+
 
 
 cel_go_test(

--- a/policy/BUILD.bazel
+++ b/policy/BUILD.bazel
@@ -259,9 +259,6 @@ cel_go_test(
     test_suite = "testdata/nested_rules_unwrap_rewrap/tests.yaml",
 )
 
-
-
-
 cel_go_test(
     name = "variable_type_propagation_policy",
     cel_expr = "testdata/variable_type_propagation/policy.yaml",

--- a/policy/README.md
+++ b/policy/README.md
@@ -194,6 +194,10 @@ of the parent rule (otherwise, it would leave subsequent matches unreachable).
 Example:
 
 ```
+# Policy is a string (not wrapped)
+# input -> output
+# 3 -> 'b'
+# 2 -> 'c'
 rule:
   match:
     - rule:
@@ -201,9 +205,9 @@ rule:
         - name: "foo"
           value: 1 + 2
       match:
-        - condition: "input.foo > variables.foo"
+        - condition: "input > variables.foo"
           output: '"a"'
-        - condition: "input.foo == variables.foo"
+        - condition: "input == variables.foo"
           output: '"b"'
     - output: '"c"'
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -201,14 +201,14 @@ Example:
 rule:
   match:
     - rule:
-      variables:
-        - name: "foo"
-          value: 1 + 2
-      match:
-        - condition: "input > variables.foo"
-          output: '"a"'
-        - condition: "input == variables.foo"
-          output: '"b"'
+        variables:
+          - name: "foo"
+            expression: "3"
+        match:
+          - condition: "input > variables.foo"
+            output: '"a"'
+          - condition: "input == variables.foo"
+            output: '"b"'
     - output: '"c"'
 
 ```

--- a/policy/README.md
+++ b/policy/README.md
@@ -184,6 +184,32 @@ rule:
     - output: "'outer_default'"
 ```
 
+Nested first-match rules may be unconditional (i.e. the condition is omited or
+is the literal `true`). Unconditional rules can be used as a scoping or
+grouping mechanism. The matches of the parent rule "chain" after an
+unconditional rule. This allows for unwrapping optionals from an inexhaustive
+sub rule. An uncondtional nested rule that is exhaustive must be the last match
+of the parent rule (otherwise, it would leave subsequent matches unreachable).
+
+Example:
+
+```
+rule:
+  match:
+    - rule:
+      variables:
+        - name: "foo"
+          value: 1 + 2
+      match:
+        - condition: "input.foo > variables.foo"
+          output: '"a"'
+        - condition: "input.foo == variables.foo"
+          output: '"b"'
+    - output: '"c"'
+
+```
+
+
 ### Imports
 
 When constructing complex object types such as protocol buffers, `imports` can

--- a/policy/README.md
+++ b/policy/README.md
@@ -184,12 +184,32 @@ rule:
     - output: "'outer_default'"
 ```
 
-Nested first-match rules may be unconditional (i.e. the condition is omited or
-is the literal `true`). Unconditional rules can be used as a scoping or
-grouping mechanism. The matches of the parent rule "chain" after an
-unconditional rule. This allows for unwrapping optionals from an inexhaustive
-sub rule. An uncondtional nested rule that is exhaustive must be the last match
-of the parent rule (otherwise, it would leave subsequent matches unreachable).
+##### Using Unconditional Nested Rules
+
+In a first-match policy, a nested rule may be specified without an
+explicit condition (or the condition set as exactly `true`). This is an
+unconditional rule.
+
+Unconditional rules are useful for two primary purposes:
+
+_Scoping Variables_
+
+Unconditional rules may declare variables (like foo in the example below) that
+only apply to a specific group of matches. This avoids cluttering the global
+scope.
+
+_Fallback Behavior (Chaining)_
+
+The inner matches inside an unconditional rule do not need to cover every
+possible scenario. If an input runs through the inner conditions and doesn't
+find a match, the engine doesn't fail or return an optional none value.
+Instead, it steps back out to the parent rule and continues down the list.
+
+Important: if an unconditional nested rule covers every possible scenario
+(meaning it is exhaustive and will always generate an output), it must be the
+last item in the parent rule's match list. Placing it anywhere else will
+create dead code, as the engine can never reach the matches written beneath
+it.
 
 Example:
 

--- a/policy/compiler.go
+++ b/policy/compiler.go
@@ -72,6 +72,8 @@ func (r *CompiledRule) HasOptionalOutput() bool {
 	optionalOutput := false
 	for _, m := range r.Matches() {
 		if m.NestedRule() != nil && m.NestedRule().HasOptionalOutput() {
+			// If the nested rule is unconditional, the matching may fallthrough to the next match
+			// in this context (unwrapping the optional value from the nested rule).
 			if !m.ConditionIsLiteral(types.True) {
 				return true
 			}
@@ -445,15 +447,16 @@ func (c *compiler) checkMatchOutputTypesAgree(rule *CompiledRule, iss *cel.Issue
 }
 
 func (c *compiler) checkUnreachableCode(rule *CompiledRule, iss *cel.Issues) {
-	ruleHasOptional := rule.HasOptionalOutput()
 	compiledMatches := rule.Matches()
 	matchCount := len(compiledMatches)
 	for i := matchCount - 1; i >= 0; i-- {
 		m := compiledMatches[i]
 		triviallyTrue := m.ConditionIsLiteral(types.True)
 
-		isExhaustive := triviallyTrue && !(m.NestedRule() != nil && m.NestedRule().HasOptionalOutput())
-		if isExhaustive && !ruleHasOptional && i != matchCount-1 {
+		// If the match is a single output or a nested rule that always returns a value, it is
+		// exhaustive. If the condition is trivially true, then all subsequent branches are unreachable.
+		isExhaustive := triviallyTrue && (m.NestedRule() == nil || !m.NestedRule().HasOptionalOutput())
+		if isExhaustive && i != matchCount-1 {
 			if m.Output() != nil {
 				iss.ReportErrorAtID(m.SourceID(), "match creates unreachable outputs")
 			}

--- a/policy/compiler.go
+++ b/policy/compiler.go
@@ -72,7 +72,7 @@ func (r *CompiledRule) HasOptionalOutput() bool {
 	optionalOutput := false
 	for _, m := range r.Matches() {
 		if m.NestedRule() != nil && m.NestedRule().HasOptionalOutput() {
-		  if !m.ConditionIsLiteral(types.True) {
+			if !m.ConditionIsLiteral(types.True) {
 				return true
 			}
 			optionalOutput = true

--- a/policy/compiler.go
+++ b/policy/compiler.go
@@ -72,12 +72,15 @@ func (r *CompiledRule) HasOptionalOutput() bool {
 	optionalOutput := false
 	for _, m := range r.Matches() {
 		if m.NestedRule() != nil && m.NestedRule().HasOptionalOutput() {
-			return true
-		}
-		if m.ConditionIsLiteral(types.True) {
+		  if !m.ConditionIsLiteral(types.True) {
+				return true
+			}
+			optionalOutput = true
+		} else if m.ConditionIsLiteral(types.True) {
 			return false
+		} else {
+			optionalOutput = true
 		}
-		optionalOutput = true
 	}
 	return optionalOutput
 }
@@ -449,7 +452,8 @@ func (c *compiler) checkUnreachableCode(rule *CompiledRule, iss *cel.Issues) {
 		m := compiledMatches[i]
 		triviallyTrue := m.ConditionIsLiteral(types.True)
 
-		if triviallyTrue && !ruleHasOptional && i != matchCount-1 {
+		isExhaustive := triviallyTrue && !(m.NestedRule() != nil && m.NestedRule().HasOptionalOutput())
+		if isExhaustive && !ruleHasOptional && i != matchCount-1 {
 			if m.Output() != nil {
 				iss.ReportErrorAtID(m.SourceID(), "match creates unreachable outputs")
 			}

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -139,6 +139,20 @@ func TestCompiledRuleHasOptionalOutput(t *testing.T) {
 			},
 			optional: true,
 		},
+		{
+			rule: &CompiledRule{
+				matches: []*CompiledMatch{
+					{
+						cond: mustCompileExpr(t, env, "true"),
+						nestedRule: &CompiledRule{
+							matches: []*CompiledMatch{{cond: mustCompileExpr(t, env, "1 > 0")}},
+						},
+					},
+					{cond: mustCompileExpr(t, env, "true")},
+				},
+			},
+			optional: false,
+		},
 	}
 	for _, tst := range tests {
 		got := tst.rule.HasOptionalOutput()

--- a/policy/compiler_test.go
+++ b/policy/compiler_test.go
@@ -398,6 +398,9 @@ func (r *runner) run(t *testing.T) {
 				} else if tc.Output.Value != nil {
 					testOut = r.env.CELTypeAdapter().NativeToValue(tc.Output.Value)
 				}
+				if testOut.Equal(out) == types.True {
+					return
+				}
 				if optOut, ok := out.(*types.Optional); ok {
 					if optOut.Equal(types.OptionalNone) == types.True {
 						if testOut.Equal(types.OptionalNone) != types.True {
@@ -406,7 +409,7 @@ func (r *runner) run(t *testing.T) {
 					} else if testOut.Equal(optOut.GetValue()) != types.True {
 						t.Errorf("policy eval got %v, wanted %v", out, testOut)
 					}
-				} else if testOut.Equal(out) != types.True {
+				} else {
 					t.Errorf("policy eval got %v, wanted %v", out, testOut)
 				}
 			})

--- a/policy/helper_test.go
+++ b/policy/helper_test.go
@@ -210,6 +210,20 @@ var (
 			: optional.none())))
 	  : optional.of(@index3.format([@index0, @index2])))`,
 		},
+		{
+			name: "nested_rules_unconditional_chaining",
+			expr: `
+	cel.@block([3],
+	((x > @index0) ? optional.of("a") : ((x == @index0) ? optional.of("b") : optional.none()))
+	  .orValue("c"))`,
+		},
+		{
+			name: "nested_rules_unconditional_chaining_optional",
+			expr: `
+	cel.@block([3],
+	((x > @index0) ? optional.of("a") : ((x == @index0) ? optional.of("b") : optional.none()))
+	  .or((x == 1) ? optional.of("c") : optional.none()))`,
+		},
 	}
 
 	composerUnnestTests = []struct {

--- a/policy/helper_test.go
+++ b/policy/helper_test.go
@@ -224,6 +224,13 @@ var (
 	((x > @index0) ? optional.of("a") : ((x == @index0) ? optional.of("b") : optional.none()))
 	  .or((x == 1) ? optional.of("c") : optional.none()))`,
 		},
+		{
+			name: "nested_rules_unwrap_rewrap",
+			expr: `
+	(x == 1)
+	  ? optional.of(((y == 1) ? optional.of("a") : optional.none()).orValue("b"))
+	  : optional.none()`,
+		},
 	}
 
 	composerUnnestTests = []struct {

--- a/policy/testdata/nested_rules_unconditional_chaining/config.yaml
+++ b/policy/testdata/nested_rules_unconditional_chaining/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: nested_rules_unconditional_chaining
+variables:
+  - name: x
+    type: int

--- a/policy/testdata/nested_rules_unconditional_chaining/policy.yaml
+++ b/policy/testdata/nested_rules_unconditional_chaining/policy.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: nested_rules_unconditional_chaining
+rule:
+  match:
+    - rule:
+        variables:
+          - name: foo
+            expression: "3"
+        match:
+          - condition: "x > variables.foo"
+            output: "'a'"
+          - condition: "x == variables.foo"
+            output: "'b'"
+    - output: "'c'"

--- a/policy/testdata/nested_rules_unconditional_chaining/tests.yaml
+++ b/policy/testdata/nested_rules_unconditional_chaining/tests.yaml
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: "Nested rule tests for unconditional chaining"
+section:
+  - name: "chaining"
+    tests:
+      - name: "sub_rule_match_greater"
+        input:
+          x:
+            expr: "4"
+        output:
+          value: "a"
+      - name: "sub_rule_match_equal"
+        input:
+          x:
+            expr: "3"
+        output:
+          value: "b"
+      - name: "parent_rule_fallback"
+        input:
+          x:
+            expr: "2"
+        output:
+          value: "c"

--- a/policy/testdata/nested_rules_unconditional_chaining_optional/config.yaml
+++ b/policy/testdata/nested_rules_unconditional_chaining_optional/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: nested_rules_unconditional_chaining_optional
+variables:
+  - name: x
+    type: int

--- a/policy/testdata/nested_rules_unconditional_chaining_optional/policy.yaml
+++ b/policy/testdata/nested_rules_unconditional_chaining_optional/policy.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: nested_rules_unconditional_chaining_optional
+rule:
+  match:
+    - rule:
+        variables:
+          - name: foo
+            expression: "3"
+        match:
+          - condition: "x > variables.foo"
+            output: "'a'"
+          - condition: "x == variables.foo"
+            output: "'b'"
+    - condition: "x == 1"
+      output: "'c'"

--- a/policy/testdata/nested_rules_unconditional_chaining_optional/tests.yaml
+++ b/policy/testdata/nested_rules_unconditional_chaining_optional/tests.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: "Nested rule tests for unconditional chaining where parent is optional"
+section:
+  - name: "chaining"
+    tests:
+      - name: "sub_rule_match_greater"
+        input:
+          x:
+            expr: "4"
+        output:
+          value: "a"
+      - name: "sub_rule_match_equal"
+        input:
+          x:
+            expr: "3"
+        output:
+          value: "b"
+      - name: "parent_rule_match"
+        input:
+          x:
+            expr: "1"
+        output:
+          value: "c"
+      - name: "parent_rule_fallback_none"
+        input:
+          x:
+            expr: "2"
+        output:
+          expr: "optional.none()"

--- a/policy/testdata/nested_rules_unwrap_rewrap/config.yaml
+++ b/policy/testdata/nested_rules_unwrap_rewrap/config.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: nested_rules_unwrap_rewrap
+variables:
+  - name: x
+    type: int
+  - name: y
+    type: int

--- a/policy/testdata/nested_rules_unwrap_rewrap/policy.yaml
+++ b/policy/testdata/nested_rules_unwrap_rewrap/policy.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: nested_rules_unwrap_rewrap
+rule:
+  match:
+    - condition: "x == 1"
+      rule:
+        match:
+          - rule:
+              match:
+                - condition: "y == 1"
+                  output: "'a'"
+          - output: "'b'"

--- a/policy/testdata/nested_rules_unwrap_rewrap/tests.yaml
+++ b/policy/testdata/nested_rules_unwrap_rewrap/tests.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: "Nested rule tests for unwrapping optional child and rewrapping into optional parent"
+section:
+  - name: "unwrap_rewrap"
+    tests:
+      - name: "outer_rule_no_match"
+        input:
+          x:
+            expr: "2"
+          y:
+            expr: "1"
+        output:
+          expr: "optional.none()"
+      - name: "outer_match_innter_match"
+        input:
+          x:
+            expr: "1"
+          y:
+            expr: "1"
+        output:
+          expr: "optional.of('a')"
+      - name: "outer_match_inner_fallthrough"
+        input:
+          x:
+            expr: "1"
+          y:
+            expr: "2"
+        output:
+          expr: "optional.of('b')"


### PR DESCRIPTION
First match rules have an implicit unwrap behavior if they are unconditional. This wasn't documented and behaved inconsistently depending on where the rule was in the policy tree.
