### PR TITLE
Fix has() unknown propagation during partial evaluation

### DIFF
--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -194,7 +194,7 @@ func (q *testOnlyQualifier) Qualify(vars Activation, obj any) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	if unk, isUnk := out.(types.Unknown); isUnk {
+	if unk, isUnk := out.(*types.Unknown); isUnk {
 		return unk, nil
 	}
 	return present, nil

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -1542,6 +1542,16 @@ func testData(t testing.TB) []testCase {
 			out: types.NewUnknown(2, types.QualifyAttribute[int64](types.NewAttributeTrail("a"), 0)),
 		},
 		{
+			name: "macro_has_map_key_unknown_propagates",
+			expr: `has(a.b)`,
+			vars: []*decls.VariableDecl{
+				decls.NewVariable("a", types.NewMapType(types.StringType, types.BoolType)),
+			},
+			attrs: NewPartialAttributeFactory(testContainer(""), types.DefaultTypeAdapter, types.NewEmptyRegistry()),
+			in:    newTestPartialActivation(t, map[string]any{}, NewAttributePattern("a")),
+			out:   types.NewUnknown(4, types.NewAttributeTrail("a")),
+		},
+		{
 			name: "unknown_attribute_mixed_qualifier",
 			expr: `a[dyn(0u)]`,
 			vars: []*decls.VariableDecl{


### PR DESCRIPTION
# Fix has() unknown propagation during partial evaluation

## Summary

This patch fixes stale unknown-type handling in `testOnlyQualifier.Qualify`.

`types.Unknown` is represented as `*types.Unknown`, but this code path still checks for the old value type:

```go
out.(types.Unknown)
```

As a result, when `QualifyIfPresent` returns a `*types.Unknown`, the assertion fails and `has()` can incorrectly return a definite boolean instead of propagating `Unknown`.

## Change

Update the type assertion from:

```go
if unk, isUnk := out.(types.Unknown); isUnk {
```

to:

```go
if unk, isUnk := out.(*types.Unknown); isUnk {
```

This allows `Unknown` values to be propagated correctly during partial evaluation.

## Impact

This restores the expected behavior for expressions such as:

```cel
has(request.auth.claims.admin)
```

when an intermediate qualifier resolves to `*types.Unknown`.

Instead of converting the result into a definite boolean, the evaluator now preserves the unknown value so the caller can defer evaluation as intended.

## Notes

This is a minimal compatibility fix for a stale type assertion left behind after the migration of `types.Unknown` to pointer-based usage.