### PR TITLE
parser/unparser: emit valid CEL for doubles in scientific notation

### DIFF
--- a/parser/unparser.go
+++ b/parser/unparser.go
@@ -297,7 +297,7 @@ func (un *unparser) visitConstVal(val ref.Val) error {
 		// represent the float using the minimum required digits
 		d := strconv.FormatFloat(float64(val), 'g', -1, 64)
 		un.str.WriteString(d)
-		if !strings.Contains(d, ".") {
+		if !strings.ContainsAny(d, ".eE") {
 			un.str.WriteString(".0")
 		}
 	case types.Int:

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -123,6 +123,13 @@ func TestUnparse(t *testing.T) {
 		{name: "call_cond_equiv", in: `(a || b ? c : d).e`, out: `((a || b) ? c : d).e`},
 		{name: "lit_quote_bytes_equiv", in: `b'aaa"bbb'`, out: `b"\141\141\141\042\142\142\142"`},
 		{name: "select_equiv", in: `a . b . c`, out: `a.b.c`},
+		// Doubles whose 'g'-format produces scientific notation must
+		// roundtrip without an incorrect trailing ".0". See #1325.
+		{name: "lit_double_sci_small", in: `0.00001`, out: `1e-05`},
+		{name: "lit_double_sci_smaller", in: `0.000000001`, out: `1e-09`},
+		{name: "lit_double_sci_large", in: `1e30`, out: `1e+30`},
+		{name: "lit_double_sci_neg_exp", in: `5e-5`, out: `5e-05`},
+		{name: "lit_double_sci_upper_e", in: `1E7`, out: `1e+07`},
 
 		// These expressions require macro call tracking to be enabled.
 		{


### PR DESCRIPTION
strconv.FormatFloat with 'g' and precision -1 emits scientific notation for doubles of magnitude < 1e-4 or >= 1e+21 (e.g. "1e-05", "1e+30"). The previous guard appended ".0" whenever the formatted string lacked a "." so that the literal would parse as a double rather than an int — but scientific notation already produces a valid double literal, so appending ".0" produced invalid output like "1e-05.0" that the parser rejects.

Treat the exponent marker 'e'/'E' as also indicating a valid double literal, only appending ".0" when neither "." nor "e"/"E" is present.

Adds regression test cases covering small/large magnitudes, negative exponents, and uppercase 'E'.

Fixes #1325

# Pull Requests Guidelines

See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details about when to create
a GitHub [Pull Request][1] and when other kinds of contributions or
consultation might be more desirable.

When creating a new pull request, please fork the repo and work within a
development branch.

## Commit Messages

* Most changes should be accompanied by tests.
* Commit messages should explain _why_ the changes were made.
```
Summary of change in 50 characters or less

Background on why the change is being made with additional detail on
consequences of the changes elsewhere in the code or to the general
functionality of the library. Multiple paragraphs may be used, but
please keep lines to 72 characters or less.
```

## Reviews

* Perform a self-review.
* Make sure the Travis CI build passes.
* Assign a reviewer once both the above have been completed.

## Merging

* If a CEL maintaner approves the change, it may be merged by the author if
  they have write access. Otherwise, the change will be merged by a maintainer.
* Multiple commits should be squashed before merging.
* Please append the line `closes #<issue-num>: description` in the merge message,
  if applicable.

[1]:  https://help.github.com/articles/about-pull-requests