### PR TITLE
fix(containers): allow aliases for simple names

### DIFF
--- a/common/containers/container.go
+++ b/common/containers/container.go
@@ -227,7 +227,7 @@ func Abbrevs(qualifiedNames ...string) ContainerOption {
 			}
 			alias := qn[ind+1:]
 			var err error
-			c, err = aliasAs("abbreviation", qn, alias)(c)
+			c, err = aliasAs("abbreviation", qn, alias, true)(c)
 			if err != nil {
 				return nil, err
 			}
@@ -236,31 +236,32 @@ func Abbrevs(qualifiedNames ...string) ContainerOption {
 	}
 }
 
-// Alias associates a fully-qualified name with a user-defined alias.
+// Alias associates a name with a user-defined alias.
 //
 // In general, Abbrevs is preferred to Alias since the names generated from the Abbrevs option
 // are more easily traced back to source code. The Alias option is useful for propagating alias
 // configuration from one Container instance to another, and may also be useful for remapping
 // poorly chosen protobuf message / package names.
-//
-// Note: all of the rules that apply to Abbrevs also apply to Alias.
 func Alias(qualifiedName, alias string) ContainerOption {
-	return aliasAs("alias", qualifiedName, alias)
+	return aliasAs("alias", qualifiedName, alias, false)
 }
 
-func aliasAs(kind, qualifiedName, alias string) ContainerOption {
+func aliasAs(kind, qualifiedName, alias string, requireQualified bool) ContainerOption {
 	return func(c *Container) (*Container, error) {
 		if len(alias) == 0 || strings.Contains(alias, ".") {
 			return nil, fmt.Errorf(
 				"%s must be non-empty and simple (not qualified): %s=%s", kind, kind, alias)
 		}
 
+		if len(qualifiedName) == 0 {
+			return nil, fmt.Errorf("%s must refer to a valid name: %s", kind, qualifiedName)
+		}
 		if qualifiedName[0:1] == "." {
 			return nil, fmt.Errorf("qualified name must not begin with a leading '.': %s",
 				qualifiedName)
 		}
 		ind := strings.LastIndex(qualifiedName, ".")
-		if ind <= 0 || ind == len(qualifiedName)-1 {
+		if ind == len(qualifiedName)-1 || (requireQualified && ind <= 0) {
 			return nil, fmt.Errorf("%s must refer to a valid qualified name: %s",
 				kind, qualifiedName)
 		}

--- a/common/containers/container_test.go
+++ b/common/containers/container_test.go
@@ -70,6 +70,17 @@ func TestContainers_Alias(t *testing.T) {
 	if !reflect.DeepEqual(cont.ResolveCandidateNames("bigex.Execute"), []string{"my.example.pkg.verbose.Execute"}) {
 		t.Errorf("ResolveCandidateNames() got %s, wanted %s", cont.ResolveCandidateNames("bigex.Execute"), "my.example.pkg.verbose.Execute")
 	}
+
+	cont, err = DefaultContainer.Extend(Alias("really_long_package_name", "short"))
+	if err != nil {
+		t.Fatalf("Extend() failed: %v", err)
+	}
+	if !reflect.DeepEqual(cont.ResolveCandidateNames("short"), []string{"really_long_package_name"}) {
+		t.Errorf("ResolveCandidateNames() got %s, wanted %s", cont.ResolveCandidateNames("short"), "really_long_package_name")
+	}
+	if !reflect.DeepEqual(cont.ResolveCandidateNames("short.field"), []string{"really_long_package_name.field"}) {
+		t.Errorf("ResolveCandidateNames() got %s, wanted %s", cont.ResolveCandidateNames("short.field"), "really_long_package_name.field")
+	}
 }
 
 func TestContainers_Abbrevs(t *testing.T) {
@@ -151,10 +162,6 @@ func TestContainers_Aliasing_Errors(t *testing.T) {
 		{
 			abbrevs: []string{"   bad.alias!  "},
 			err:     "invalid qualified name: bad.alias!, wanted name of the form 'qualified.name'",
-		},
-		{
-			aliases: []aliasDef{{name: "a", alias: "b"}},
-			err:     "alias must refer to a valid qualified name: a",
 		},
 		{
 			aliases: []aliasDef{{name: "my.alias", alias: "b.c"}},


### PR DESCRIPTION
Fixes #1306

## Summary
This allows `containers.Alias` to point at a simple name, not only a dotted qualified name.

## Why
Before this change, `Alias("really_long_package_name", "short")` failed validation even though explicit aliases should be able to abbreviate a name without a field selection. `Abbrevs` still requires a dotted qualified name, so the stricter abbreviation behavior is preserved.

## Test plan
- `go test ./common/containers`
- `go test ./common/containers ./cel ./checker ./interpreter`
