### PR TITLE
validate offset on empty-string path in indexOf and lastIndexOf

### DIFF
--- a/ext/strings.go
+++ b/ext/strings.go
@@ -669,9 +669,9 @@ func indexOfOffset(str, substr string, offset int64) (int64, error) {
 	}
 	runes := []rune(str)
 	if substr == "" {
-		// The empty string matches at the search offset, which must fall within the string.
+		// The empty string matches at the search offset, clamped to the end of the string.
 		if off > len(runes) {
-			return -1, nil
+			return int64(len(runes)), nil
 		}
 		return offset, nil
 	}
@@ -714,9 +714,9 @@ func lastIndexOfOffset(str, substr string, offset int64) (int64, error) {
 	}
 	runes := []rune(str)
 	if substr == "" {
-		// The empty string matches at the search offset, which must fall within the string.
+		// The empty string matches at the search offset, clamped to the end of the string.
 		if off > len(runes) {
-			return -1, nil
+			return int64(len(runes)), nil
 		}
 		return offset, nil
 	}

--- a/ext/strings.go
+++ b/ext/strings.go
@@ -663,15 +663,19 @@ func indexOf(str, substr string) (int64, error) {
 }
 
 func indexOfOffset(str, substr string, offset int64) (int64, error) {
-	if substr == "" {
-		return offset, nil
-	}
 	off := int(offset)
-	runes := []rune(str)
-	subrunes := []rune(substr)
 	if off < 0 {
 		return -1, fmt.Errorf("index out of range: %d", off)
 	}
+	runes := []rune(str)
+	if substr == "" {
+		// The empty string matches at the search offset, which must fall within the string.
+		if off > len(runes) {
+			return -1, nil
+		}
+		return offset, nil
+	}
+	subrunes := []rune(substr)
 	// If the offset exceeds the length, return -1 rather than error.
 	if off >= len(runes) {
 		return -1, nil
@@ -704,15 +708,19 @@ func lastIndexOf(str, substr string) (int64, error) {
 }
 
 func lastIndexOfOffset(str, substr string, offset int64) (int64, error) {
-	if substr == "" {
-		return offset, nil
-	}
 	off := int(offset)
-	runes := []rune(str)
-	subrunes := []rune(substr)
 	if off < 0 {
 		return -1, fmt.Errorf("index out of range: %d", off)
 	}
+	runes := []rune(str)
+	if substr == "" {
+		// The empty string matches at the search offset, which must fall within the string.
+		if off > len(runes) {
+			return -1, nil
+		}
+		return offset, nil
+	}
+	subrunes := []rune(substr)
 	// If the offset is far greater than the length return -1
 	if off >= len(runes) {
 		return -1, nil

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -147,7 +147,7 @@ var stringTests = []struct {
 	},
 	{expr: `'tacocat'.indexOf('a', 30) == -1`},
 	{expr: `'tacocat'.indexOf('', 7) == 7`},
-	{expr: `'tacocat'.indexOf('', 30) == -1`},
+	{expr: `'tacocat'.indexOf('', 30) == 7`},
 	{
 		expr: `'tacocat'.indexOf('', -1) == 0`,
 		err:  "index out of range: -1",
@@ -158,7 +158,7 @@ var stringTests = []struct {
 	},
 	{expr: `'tacocat'.lastIndexOf('a', 30) == -1`},
 	{expr: `'tacocat'.lastIndexOf('', 7) == 7`},
-	{expr: `'tacocat'.lastIndexOf('', 30) == -1`},
+	{expr: `'tacocat'.lastIndexOf('', 30) == 7`},
 	{
 		expr: `'tacocat'.lastIndexOf('', -1) == 0`,
 		err:  "index out of range: -1",

--- a/ext/strings_test.go
+++ b/ext/strings_test.go
@@ -146,11 +146,23 @@ var stringTests = []struct {
 		err:  "index out of range: 30",
 	},
 	{expr: `'tacocat'.indexOf('a', 30) == -1`},
+	{expr: `'tacocat'.indexOf('', 7) == 7`},
+	{expr: `'tacocat'.indexOf('', 30) == -1`},
+	{
+		expr: `'tacocat'.indexOf('', -1) == 0`,
+		err:  "index out of range: -1",
+	},
 	{
 		expr: `'tacocat'.lastIndexOf('a', -1) == -1`,
 		err:  "index out of range: -1",
 	},
 	{expr: `'tacocat'.lastIndexOf('a', 30) == -1`},
+	{expr: `'tacocat'.lastIndexOf('', 7) == 7`},
+	{expr: `'tacocat'.lastIndexOf('', 30) == -1`},
+	{
+		expr: `'tacocat'.lastIndexOf('', -1) == 0`,
+		err:  "index out of range: -1",
+	},
 	{
 		expr: `"tacocat".substring(40) == "cat"`,
 		err:  "index out of range: 40",


### PR DESCRIPTION
`indexOfOffset` and `lastIndexOfOffset` validate the start offset only after the empty-search-string short circuit, so an empty needle skips the check. `'tacocat'.indexOf('', -1)` returns `-1` and `'tacocat'.indexOf('', 30)` returns `30`, whereas `'tacocat'.indexOf('a', -1)` errors with `index out of range` and `'tacocat'.indexOf('a', 30)` reports `-1`. `lastIndexOf` behaves the same way.

Move the offset bounds check ahead of the empty-string branch in both functions so a negative offset errors and an offset past the end reports `-1`, while a valid offset (including the end position) still returns the offset. Keeping the check in the callee means every `indexOf`/`lastIndexOf` overload shares one rule rather than depending on the search string being non-empty.