### PR TITLE
reject out-of-range minutes in timezone offset parsing

### DIFF
--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -302,6 +302,9 @@ func timeZone(tz ref.Val, visitor timestampVisitor) timestampVisitor {
 		if err != nil {
 			return WrapErr(err)
 		}
+		if min < 0 || min > 59 {
+			return WrapErr(fmt.Errorf("timezone offset minutes out of range [0, 59]: %s", val))
+		}
 		var offset int
 		if string(val[0]) == "-" {
 			offset = hr*60 - min

--- a/common/types/timestamp_test.go
+++ b/common/types/timestamp_test.go
@@ -454,6 +454,19 @@ func TestTimestampGetMinutes(t *testing.T) {
 	if !minTz.Equal(Int(5)).(Bool) {
 		t.Errorf("ts.getMinutes('America/Phoenix') got %v, wanted 5 minutes", min)
 	}
+	// A valid offset still resolves: -08:30 shifts 1970-01-01T02:05:06Z back to 17:35.
+	minTz = ts.Receive(overloads.TimeGetMinutes, overloads.TimestampToMinutesWithTz,
+		[]ref.Val{String("-08:30")})
+	if !minTz.Equal(Int(35)).(Bool) {
+		t.Errorf("ts.getMinutes('-08:30') got %v, wanted 35 minutes", minTz)
+	}
+	// Out-of-range and signed minute offsets are rejected rather than silently accepted.
+	for _, tz := range []string{"+00:99", "-00:90", "+05:-30"} {
+		if got := ts.Receive(overloads.TimeGetMinutes, overloads.TimestampToMinutesWithTz,
+			[]ref.Val{String(tz)}); !IsError(got) {
+			t.Errorf("ts.getMinutes(%q) got %v, wanted error", tz, got)
+		}
+	}
 }
 
 func TestTimestampGetSeconds(t *testing.T) {


### PR DESCRIPTION
Repro: `timestamp(...).getMinutes("+00:99")`, `getMinutes("-00:90")`, or a signed minute such as `getMinutes("+05:-30")`.
Cause: `timeZone` parses the minute field of a numeric `±HH:MM` offset with a bare `strconv.Atoi` and never bounds it, so a minute `>= 60` (or a negative/signed one) is accepted and shifts the resolved local time by an arbitrary amount across every `getX(tz)` accessor.
Fix: reject a parsed minute outside `[0, 59]` in the callee before the offset is computed. Valid offsets like `-08:30` and the existing `+23:00` hour case are unaffected.