### PR TITLE
feat(ext): add json encoder

### DIFF
--- a/ext/BUILD.bazel
+++ b/ext/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//common/types/traits:go_default_library",
         "//interpreter:go_default_library",
         "//parser:go_default_library",
+        "@org_golang_google_protobuf//encoding/protojson:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
         "@org_golang_google_protobuf//types/known/structpb",

--- a/ext/README.md
+++ b/ext/README.md
@@ -55,6 +55,20 @@ Example:
 
     base64.encode(b'hello') // return 'aGVsbG8='
 
+### JSON.Encode
+
+Introduced at version: 1
+
+Encodes a CEL value to a JSON string.
+
+    json.encode(<dyn>) -> <string>
+
+Examples:
+
+    json.encode('hello')                      // return '"hello"'
+    json.encode([1, 'two', true])             // return '[1,"two",true]'
+    json.encode({'items': [1, 'two', false]}) // return '{"items":[1,"two",false]}'
+
 ## Math
 
 Math helper macros and functions.

--- a/ext/encoders.go
+++ b/ext/encoders.go
@@ -54,6 +54,8 @@ import (
 //
 // # JSON.Encode
 //
+// Introduced at version: 1
+//
 // Encodes a CEL value to a JSON string.
 //
 //	json.encode(<dyn>) -> <string>
@@ -88,8 +90,8 @@ func (*encoderLib) LibraryName() string {
 	return "cel.lib.ext.encoders"
 }
 
-func (*encoderLib) CompileOptions() []cel.EnvOption {
-	return []cel.EnvOption{
+func (lib *encoderLib) CompileOptions() []cel.EnvOption {
+	opts := []cel.EnvOption{
 		cel.Function("base64.decode",
 			cel.Overload("base64_decode_string", []*cel.Type{cel.StringType}, cel.BytesType,
 				cel.UnaryBinding(func(str ref.Val) ref.Val {
@@ -102,12 +104,17 @@ func (*encoderLib) CompileOptions() []cel.EnvOption {
 					b := bytes.(types.Bytes)
 					return stringOrError(base64EncodeBytes([]byte(b)))
 				}))),
-		cel.Function("json.encode",
-			cel.Overload("json_encode_dyn", []*cel.Type{cel.DynType}, cel.StringType,
-				cel.UnaryBinding(func(val ref.Val) ref.Val {
-					return stringOrError(jsonEncodeValue(val))
-				}))),
 	}
+	if lib.version >= 1 {
+		opts = append(opts,
+			cel.Function("json.encode",
+				cel.Overload("json_encode_dyn", []*cel.Type{cel.DynType}, cel.StringType,
+					cel.UnaryBinding(func(val ref.Val) ref.Val {
+						return stringOrError(jsonEncodeValue(val))
+					}))),
+		)
+	}
+	return opts
 }
 
 func (*encoderLib) ProgramOptions() []cel.ProgramOption {

--- a/ext/encoders.go
+++ b/ext/encoders.go
@@ -16,11 +16,14 @@ package ext
 
 import (
 	"encoding/base64"
+	"fmt"
 	"math"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // Encoders returns a cel.EnvOption to configure extended functions for string, byte, and object
@@ -48,6 +51,16 @@ import (
 // Examples:
 //
 //	base64.encode(b'hello') // return b'aGVsbG8='
+//
+// # JSON.Encode
+//
+// Encodes a CEL value to a JSON string.
+//
+//	json.encode(<dyn>) -> <string>
+//
+// Examples:
+//
+//	json.encode({'hello': 'world'}) // return '{"hello":"world"}'
 func Encoders(options ...EncodersOption) cel.EnvOption {
 	l := &encoderLib{version: math.MaxUint32}
 	for _, o := range options {
@@ -89,6 +102,11 @@ func (*encoderLib) CompileOptions() []cel.EnvOption {
 					b := bytes.(types.Bytes)
 					return stringOrError(base64EncodeBytes([]byte(b)))
 				}))),
+		cel.Function("json.encode",
+			cel.Overload("json_encode_dyn", []*cel.Type{cel.DynType}, cel.StringType,
+				cel.UnaryBinding(func(val ref.Val) ref.Val {
+					return stringOrError(jsonEncodeValue(val))
+				}))),
 	}
 }
 
@@ -109,4 +127,20 @@ func base64DecodeString(str string) ([]byte, error) {
 
 func base64EncodeBytes(bytes []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(bytes), nil
+}
+
+func jsonEncodeValue(val ref.Val) (string, error) {
+	native, err := val.ConvertToNative(types.JSONValueType)
+	if err != nil {
+		return "", err
+	}
+	jsonValue, ok := native.(*structpb.Value)
+	if !ok {
+		return "", fmt.Errorf("cannot convert %T to JSON value", native)
+	}
+	jsonBytes, err := protojson.Marshal(jsonValue)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonBytes), nil
 }

--- a/ext/encoders_test.go
+++ b/ext/encoders_test.go
@@ -91,8 +91,22 @@ func TestEncoders(t *testing.T) {
 }
 
 func TestEncodersVersion(t *testing.T) {
-	_, err := cel.NewEnv(Encoders(EncodersVersion(0)))
+	env, err := cel.NewEnv(Encoders(EncodersVersion(0)))
 	if err != nil {
 		t.Fatalf("EncodersVersion(0) failed: %v", err)
+	}
+	if _, iss := env.Compile("base64.encode(b'hello')"); iss.Err() != nil {
+		t.Fatalf("base64.encode() got %v, wanted no error", iss.Err())
+	}
+	if _, iss := env.Compile("json.encode('hello')"); iss.Err() == nil {
+		t.Fatal("json.encode() got no error, wanted version-gated function to be unavailable")
+	}
+
+	env, err = cel.NewEnv(Encoders(EncodersVersion(1)))
+	if err != nil {
+		t.Fatalf("EncodersVersion(1) failed: %v", err)
+	}
+	if _, iss := env.Compile("json.encode('hello')"); iss.Err() != nil {
+		t.Fatalf("json.encode() got %v, wanted no error", iss.Err())
 	}
 }

--- a/ext/encoders_test.go
+++ b/ext/encoders_test.go
@@ -42,8 +42,8 @@ func TestEncoders(t *testing.T) {
 			parseOnly: true,
 		},
 		{expr: "json.encode('hello') == '\"hello\"'"},
-		{expr: "json.encode([1, 'two', true]) == '[1,\"two\",true]'"},
-		{expr: "json.encode({'items': [1, 'two', false]}) == '{\"items\":[1,\"two\",false]}'"},
+		{expr: "json.encode([1, 'two', true]) == '[1, \"two\", true]'"},
+		{expr: "json.encode({'items': [1, 'two', false]}) == '{\"items\":[1, \"two\", false]}'"},
 	}
 
 	env, err := cel.NewEnv(Encoders())

--- a/ext/encoders_test.go
+++ b/ext/encoders_test.go
@@ -42,8 +42,8 @@ func TestEncoders(t *testing.T) {
 			parseOnly: true,
 		},
 		{expr: "json.encode('hello') == '\"hello\"'"},
-		{expr: "json.encode([1, 'two', true]) == '[1, \"two\", true]'"},
-		{expr: "json.encode({'items': [1, 'two', false]}) == '{\"items\":[1, \"two\", false]}'"},
+		{expr: "json.encode([1, 'two', true]) == '[1,\"two\",true]'"},
+		{expr: "json.encode({'items': [1, 'two', false]}) == '{\"items\":[1,\"two\",false]}'"},
 	}
 
 	env, err := cel.NewEnv(Encoders())

--- a/ext/encoders_test.go
+++ b/ext/encoders_test.go
@@ -41,6 +41,9 @@ func TestEncoders(t *testing.T) {
 			err:       "no such overload",
 			parseOnly: true,
 		},
+		{expr: "json.encode('hello') == '\"hello\"'"},
+		{expr: "json.encode([1, 'two', true]) == '[1, \"two\", true]'"},
+		{expr: "json.encode({'items': [1, 'two', false]}) == '{\"items\":[1, \"two\", false]}'"},
 	}
 
 	env, err := cel.NewEnv(Encoders())


### PR DESCRIPTION
## What changed
- Added `json.encode(dyn) -> string` to `ext.Encoders()`.
- Uses the existing CEL `JSONValueType` conversion and `protojson` marshaling.
- Added tests for string, list, and object values.

## Why
This adds a small JSON serialization helper without pulling YAML or decoding into the same change.

Part of #1245.

## Testing
- go test ./ext -run 'TestEncoders'
