### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ ignored.
 // The `details' var would contain intermediate evaluation state if enabled as
 // a cel.ProgramOption. This can be useful for visualizing how the `out` value
 // was arrive at.
-out, details, err := prg.Eval(map[string]interface{}{
+out, details, err := prg.Eval(map[string]any{
     "name": "/groups/acme.co/documents/secret-stuff",
     "group": "acme.co"})
 fmt.Println(out) // 'true'

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ import "github.com/google/cel-go/cel"
         log.Fatalln(iss.Err())
     }
     prg, err := env.Program(ast)
-    out, _, err := prg.Eval(map[string]interface{}{
+    out, _, err := prg.Eval(map[string]any{
         "name":   "CEL",
     })
     fmt.Println(out)
@@ -62,7 +62,7 @@ method.
         ),
     )
     prg, _ := env.Program(c)
-    out, _, _ := prg.Eval(map[string]interface{}{
+    out, _, _ := prg.Eval(map[string]any{
         "i": "CEL",
         "you": "world",
     })
@@ -101,7 +101,7 @@ of `MemberOverload` in the `Function` option:
         ),
     )
     prg, _ := env.Program(c)
-    out, _, _ := prg.Eval(map[string]interface{}{
+    out, _, _ := prg.Eval(map[string]any{
         "i": "CEL",
         "you": "world",
     })

--- a/parser/gen/cel_base_visitor.go
+++ b/parser/gen/cel_base_visitor.go
@@ -7,146 +7,146 @@ type BaseCELVisitor struct {
 	*antlr.BaseParseTreeVisitor
 }
 
-func (v *BaseCELVisitor) VisitStart(ctx *StartContext) interface{} {
+func (v *BaseCELVisitor) VisitStart(ctx *StartContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitExpr(ctx *ExprContext) interface{} {
+func (v *BaseCELVisitor) VisitExpr(ctx *ExprContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitConditionalOr(ctx *ConditionalOrContext) interface{} {
+func (v *BaseCELVisitor) VisitConditionalOr(ctx *ConditionalOrContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitConditionalAnd(ctx *ConditionalAndContext) interface{} {
+func (v *BaseCELVisitor) VisitConditionalAnd(ctx *ConditionalAndContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitRelation(ctx *RelationContext) interface{} {
+func (v *BaseCELVisitor) VisitRelation(ctx *RelationContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitCalc(ctx *CalcContext) interface{} {
+func (v *BaseCELVisitor) VisitCalc(ctx *CalcContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitMemberExpr(ctx *MemberExprContext) interface{} {
+func (v *BaseCELVisitor) VisitMemberExpr(ctx *MemberExprContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitLogicalNot(ctx *LogicalNotContext) interface{} {
+func (v *BaseCELVisitor) VisitLogicalNot(ctx *LogicalNotContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitNegate(ctx *NegateContext) interface{} {
+func (v *BaseCELVisitor) VisitNegate(ctx *NegateContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitMemberCall(ctx *MemberCallContext) interface{} {
+func (v *BaseCELVisitor) VisitMemberCall(ctx *MemberCallContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitSelect(ctx *SelectContext) interface{} {
+func (v *BaseCELVisitor) VisitSelect(ctx *SelectContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitPrimaryExpr(ctx *PrimaryExprContext) interface{} {
+func (v *BaseCELVisitor) VisitPrimaryExpr(ctx *PrimaryExprContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitIndex(ctx *IndexContext) interface{} {
+func (v *BaseCELVisitor) VisitIndex(ctx *IndexContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitIdent(ctx *IdentContext) interface{} {
+func (v *BaseCELVisitor) VisitIdent(ctx *IdentContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitGlobalCall(ctx *GlobalCallContext) interface{} {
+func (v *BaseCELVisitor) VisitGlobalCall(ctx *GlobalCallContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitNested(ctx *NestedContext) interface{} {
+func (v *BaseCELVisitor) VisitNested(ctx *NestedContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitCreateList(ctx *CreateListContext) interface{} {
+func (v *BaseCELVisitor) VisitCreateList(ctx *CreateListContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitCreateStruct(ctx *CreateStructContext) interface{} {
+func (v *BaseCELVisitor) VisitCreateStruct(ctx *CreateStructContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitCreateMessage(ctx *CreateMessageContext) interface{} {
+func (v *BaseCELVisitor) VisitCreateMessage(ctx *CreateMessageContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitConstantLiteral(ctx *ConstantLiteralContext) interface{} {
+func (v *BaseCELVisitor) VisitConstantLiteral(ctx *ConstantLiteralContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitExprList(ctx *ExprListContext) interface{} {
+func (v *BaseCELVisitor) VisitExprList(ctx *ExprListContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitListInit(ctx *ListInitContext) interface{} {
+func (v *BaseCELVisitor) VisitListInit(ctx *ListInitContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitFieldInitializerList(ctx *FieldInitializerListContext) interface{} {
+func (v *BaseCELVisitor) VisitFieldInitializerList(ctx *FieldInitializerListContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitOptField(ctx *OptFieldContext) interface{} {
+func (v *BaseCELVisitor) VisitOptField(ctx *OptFieldContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitMapInitializerList(ctx *MapInitializerListContext) interface{} {
+func (v *BaseCELVisitor) VisitMapInitializerList(ctx *MapInitializerListContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitSimpleIdentifier(ctx *SimpleIdentifierContext) interface{} {
+func (v *BaseCELVisitor) VisitSimpleIdentifier(ctx *SimpleIdentifierContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitEscapedIdentifier(ctx *EscapedIdentifierContext) interface{} {
+func (v *BaseCELVisitor) VisitEscapedIdentifier(ctx *EscapedIdentifierContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitOptExpr(ctx *OptExprContext) interface{} {
+func (v *BaseCELVisitor) VisitOptExpr(ctx *OptExprContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitInt(ctx *IntContext) interface{} {
+func (v *BaseCELVisitor) VisitInt(ctx *IntContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitUint(ctx *UintContext) interface{} {
+func (v *BaseCELVisitor) VisitUint(ctx *UintContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitDouble(ctx *DoubleContext) interface{} {
+func (v *BaseCELVisitor) VisitDouble(ctx *DoubleContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitString(ctx *StringContext) interface{} {
+func (v *BaseCELVisitor) VisitString(ctx *StringContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitBytes(ctx *BytesContext) interface{} {
+func (v *BaseCELVisitor) VisitBytes(ctx *BytesContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitBoolTrue(ctx *BoolTrueContext) interface{} {
+func (v *BaseCELVisitor) VisitBoolTrue(ctx *BoolTrueContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitBoolFalse(ctx *BoolFalseContext) interface{} {
+func (v *BaseCELVisitor) VisitBoolFalse(ctx *BoolFalseContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCELVisitor) VisitNull(ctx *NullContext) interface{} {
+func (v *BaseCELVisitor) VisitNull(ctx *NullContext) any {
 	return v.VisitChildren(ctx)
 }

--- a/parser/gen/cel_parser.go
+++ b/parser/gen/cel_parser.go
@@ -365,7 +365,7 @@ func (s *StartContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *StartContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *StartContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitStart(s)
@@ -587,7 +587,7 @@ func (s *ExprContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ExprContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ExprContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitExpr(s)
@@ -840,7 +840,7 @@ func (s *ConditionalOrContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ConditionalOrContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ConditionalOrContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitConditionalOr(s)
@@ -1086,7 +1086,7 @@ func (s *ConditionalAndContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ConditionalAndContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ConditionalAndContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitConditionalAnd(s)
@@ -1330,7 +1330,7 @@ func (s *RelationContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *RelationContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *RelationContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitRelation(s)
@@ -1596,7 +1596,7 @@ func (s *CalcContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CalcContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CalcContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitCalc(s)
@@ -1863,7 +1863,7 @@ func (s *LogicalNotContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *LogicalNotContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *LogicalNotContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitLogicalNot(s)
@@ -1919,7 +1919,7 @@ func (s *MemberExprContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *MemberExprContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *MemberExprContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitMemberExpr(s)
@@ -1993,7 +1993,7 @@ func (s *NegateContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *NegateContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *NegateContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitNegate(s)
@@ -2272,7 +2272,7 @@ func (s *MemberCallContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *MemberCallContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *MemberCallContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitMemberCall(s)
@@ -2367,7 +2367,7 @@ func (s *SelectContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *SelectContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *SelectContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitSelect(s)
@@ -2423,7 +2423,7 @@ func (s *PrimaryExprContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *PrimaryExprContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *PrimaryExprContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitPrimaryExpr(s)
@@ -2522,7 +2522,7 @@ func (s *IndexContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *IndexContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *IndexContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitIndex(s)
@@ -2907,7 +2907,7 @@ func (s *CreateListContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CreateListContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CreateListContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitCreateList(s)
@@ -2965,7 +2965,7 @@ func (s *IdentContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *IdentContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *IdentContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitIdent(s)
@@ -3043,7 +3043,7 @@ func (s *CreateStructContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CreateStructContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CreateStructContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitCreateStruct(s)
@@ -3099,7 +3099,7 @@ func (s *ConstantLiteralContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ConstantLiteralContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ConstantLiteralContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitConstantLiteral(s)
@@ -3168,7 +3168,7 @@ func (s *NestedContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *NestedContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *NestedContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitNested(s)
@@ -3287,7 +3287,7 @@ func (s *CreateMessageContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CreateMessageContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CreateMessageContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitCreateMessage(s)
@@ -3379,7 +3379,7 @@ func (s *GlobalCallContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *GlobalCallContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *GlobalCallContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitGlobalCall(s)
@@ -3949,7 +3949,7 @@ func (s *ExprListContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ExprListContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ExprListContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitExprList(s)
@@ -4159,7 +4159,7 @@ func (s *ListInitContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ListInitContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ListInitContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitListInit(s)
@@ -4473,7 +4473,7 @@ func (s *FieldInitializerListContext) ExitRule(listener antlr.ParseTreeListener)
 	}
 }
 
-func (s *FieldInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *FieldInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitFieldInitializerList(s)
@@ -4688,7 +4688,7 @@ func (s *OptFieldContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *OptFieldContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *OptFieldContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitOptField(s)
@@ -4980,7 +4980,7 @@ func (s *MapInitializerListContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *MapInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *MapInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitMapInitializerList(s)
@@ -5190,7 +5190,7 @@ func (s *EscapedIdentifierContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *EscapedIdentifierContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *EscapedIdentifierContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitEscapedIdentifier(s)
@@ -5239,7 +5239,7 @@ func (s *SimpleIdentifierContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *SimpleIdentifierContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *SimpleIdentifierContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitSimpleIdentifier(s)
@@ -5416,7 +5416,7 @@ func (s *OptExprContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *OptExprContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *OptExprContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitOptExpr(s)
@@ -5567,7 +5567,7 @@ func (s *BytesContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *BytesContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *BytesContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitBytes(s)
@@ -5616,7 +5616,7 @@ func (s *UintContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *UintContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *UintContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitUint(s)
@@ -5665,7 +5665,7 @@ func (s *NullContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *NullContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *NullContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitNull(s)
@@ -5714,7 +5714,7 @@ func (s *BoolFalseContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *BoolFalseContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *BoolFalseContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitBoolFalse(s)
@@ -5763,7 +5763,7 @@ func (s *StringContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *StringContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *StringContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitString(s)
@@ -5821,7 +5821,7 @@ func (s *DoubleContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *DoubleContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *DoubleContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitDouble(s)
@@ -5870,7 +5870,7 @@ func (s *BoolTrueContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *BoolTrueContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *BoolTrueContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitBoolTrue(s)
@@ -5928,7 +5928,7 @@ func (s *IntContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *IntContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *IntContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CELVisitor:
 		return t.VisitInt(s)

--- a/parser/gen/cel_visitor.go
+++ b/parser/gen/cel_visitor.go
@@ -8,110 +8,110 @@ type CELVisitor interface {
 	antlr.ParseTreeVisitor
 
 	// Visit a parse tree produced by CELParser#start.
-	VisitStart(ctx *StartContext) interface{}
+	VisitStart(ctx *StartContext) any
 
 	// Visit a parse tree produced by CELParser#expr.
-	VisitExpr(ctx *ExprContext) interface{}
+	VisitExpr(ctx *ExprContext) any
 
 	// Visit a parse tree produced by CELParser#conditionalOr.
-	VisitConditionalOr(ctx *ConditionalOrContext) interface{}
+	VisitConditionalOr(ctx *ConditionalOrContext) any
 
 	// Visit a parse tree produced by CELParser#conditionalAnd.
-	VisitConditionalAnd(ctx *ConditionalAndContext) interface{}
+	VisitConditionalAnd(ctx *ConditionalAndContext) any
 
 	// Visit a parse tree produced by CELParser#relation.
-	VisitRelation(ctx *RelationContext) interface{}
+	VisitRelation(ctx *RelationContext) any
 
 	// Visit a parse tree produced by CELParser#calc.
-	VisitCalc(ctx *CalcContext) interface{}
+	VisitCalc(ctx *CalcContext) any
 
 	// Visit a parse tree produced by CELParser#MemberExpr.
-	VisitMemberExpr(ctx *MemberExprContext) interface{}
+	VisitMemberExpr(ctx *MemberExprContext) any
 
 	// Visit a parse tree produced by CELParser#LogicalNot.
-	VisitLogicalNot(ctx *LogicalNotContext) interface{}
+	VisitLogicalNot(ctx *LogicalNotContext) any
 
 	// Visit a parse tree produced by CELParser#Negate.
-	VisitNegate(ctx *NegateContext) interface{}
+	VisitNegate(ctx *NegateContext) any
 
 	// Visit a parse tree produced by CELParser#MemberCall.
-	VisitMemberCall(ctx *MemberCallContext) interface{}
+	VisitMemberCall(ctx *MemberCallContext) any
 
 	// Visit a parse tree produced by CELParser#Select.
-	VisitSelect(ctx *SelectContext) interface{}
+	VisitSelect(ctx *SelectContext) any
 
 	// Visit a parse tree produced by CELParser#PrimaryExpr.
-	VisitPrimaryExpr(ctx *PrimaryExprContext) interface{}
+	VisitPrimaryExpr(ctx *PrimaryExprContext) any
 
 	// Visit a parse tree produced by CELParser#Index.
-	VisitIndex(ctx *IndexContext) interface{}
+	VisitIndex(ctx *IndexContext) any
 
 	// Visit a parse tree produced by CELParser#Ident.
-	VisitIdent(ctx *IdentContext) interface{}
+	VisitIdent(ctx *IdentContext) any
 
 	// Visit a parse tree produced by CELParser#GlobalCall.
-	VisitGlobalCall(ctx *GlobalCallContext) interface{}
+	VisitGlobalCall(ctx *GlobalCallContext) any
 
 	// Visit a parse tree produced by CELParser#Nested.
-	VisitNested(ctx *NestedContext) interface{}
+	VisitNested(ctx *NestedContext) any
 
 	// Visit a parse tree produced by CELParser#CreateList.
-	VisitCreateList(ctx *CreateListContext) interface{}
+	VisitCreateList(ctx *CreateListContext) any
 
 	// Visit a parse tree produced by CELParser#CreateStruct.
-	VisitCreateStruct(ctx *CreateStructContext) interface{}
+	VisitCreateStruct(ctx *CreateStructContext) any
 
 	// Visit a parse tree produced by CELParser#CreateMessage.
-	VisitCreateMessage(ctx *CreateMessageContext) interface{}
+	VisitCreateMessage(ctx *CreateMessageContext) any
 
 	// Visit a parse tree produced by CELParser#ConstantLiteral.
-	VisitConstantLiteral(ctx *ConstantLiteralContext) interface{}
+	VisitConstantLiteral(ctx *ConstantLiteralContext) any
 
 	// Visit a parse tree produced by CELParser#exprList.
-	VisitExprList(ctx *ExprListContext) interface{}
+	VisitExprList(ctx *ExprListContext) any
 
 	// Visit a parse tree produced by CELParser#listInit.
-	VisitListInit(ctx *ListInitContext) interface{}
+	VisitListInit(ctx *ListInitContext) any
 
 	// Visit a parse tree produced by CELParser#fieldInitializerList.
-	VisitFieldInitializerList(ctx *FieldInitializerListContext) interface{}
+	VisitFieldInitializerList(ctx *FieldInitializerListContext) any
 
 	// Visit a parse tree produced by CELParser#optField.
-	VisitOptField(ctx *OptFieldContext) interface{}
+	VisitOptField(ctx *OptFieldContext) any
 
 	// Visit a parse tree produced by CELParser#mapInitializerList.
-	VisitMapInitializerList(ctx *MapInitializerListContext) interface{}
+	VisitMapInitializerList(ctx *MapInitializerListContext) any
 
 	// Visit a parse tree produced by CELParser#SimpleIdentifier.
-	VisitSimpleIdentifier(ctx *SimpleIdentifierContext) interface{}
+	VisitSimpleIdentifier(ctx *SimpleIdentifierContext) any
 
 	// Visit a parse tree produced by CELParser#EscapedIdentifier.
-	VisitEscapedIdentifier(ctx *EscapedIdentifierContext) interface{}
+	VisitEscapedIdentifier(ctx *EscapedIdentifierContext) any
 
 	// Visit a parse tree produced by CELParser#optExpr.
-	VisitOptExpr(ctx *OptExprContext) interface{}
+	VisitOptExpr(ctx *OptExprContext) any
 
 	// Visit a parse tree produced by CELParser#Int.
-	VisitInt(ctx *IntContext) interface{}
+	VisitInt(ctx *IntContext) any
 
 	// Visit a parse tree produced by CELParser#Uint.
-	VisitUint(ctx *UintContext) interface{}
+	VisitUint(ctx *UintContext) any
 
 	// Visit a parse tree produced by CELParser#Double.
-	VisitDouble(ctx *DoubleContext) interface{}
+	VisitDouble(ctx *DoubleContext) any
 
 	// Visit a parse tree produced by CELParser#String.
-	VisitString(ctx *StringContext) interface{}
+	VisitString(ctx *StringContext) any
 
 	// Visit a parse tree produced by CELParser#Bytes.
-	VisitBytes(ctx *BytesContext) interface{}
+	VisitBytes(ctx *BytesContext) any
 
 	// Visit a parse tree produced by CELParser#BoolTrue.
-	VisitBoolTrue(ctx *BoolTrueContext) interface{}
+	VisitBoolTrue(ctx *BoolTrueContext) any
 
 	// Visit a parse tree produced by CELParser#BoolFalse.
-	VisitBoolFalse(ctx *BoolFalseContext) interface{}
+	VisitBoolFalse(ctx *BoolFalseContext) any
 
 	// Visit a parse tree produced by CELParser#Null.
-	VisitNull(ctx *NullContext) interface{}
+	VisitNull(ctx *NullContext) any
 }

--- a/parser/unescape_test.go
+++ b/parser/unescape_test.go
@@ -23,7 +23,7 @@ import (
 func TestUnescape(t *testing.T) {
 	tests := []struct {
 		in      string
-		out     interface{}
+		out     any
 		isBytes bool
 	}{
 		// Simple string unescaping tests.

--- a/parser/unparser_test.go
+++ b/parser/unparser_test.go
@@ -32,7 +32,7 @@ func TestUnparse(t *testing.T) {
 	tests := []struct {
 		name               string
 		in                 string
-		out                interface{}
+		out                any
 		requiresMacroCalls bool
 		unparserOptions    []UnparserOption
 	}{
@@ -480,7 +480,7 @@ func TestUnparse(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unparse(%s) failed: %v", tc.in, err)
 			}
-			var want interface{} = tc.in
+			var want any = tc.in
 			if tc.out != nil {
 				want = tc.out
 			}

--- a/repl/parser/commands_base_visitor.go
+++ b/repl/parser/commands_base_visitor.go
@@ -7,226 +7,226 @@ type BaseCommandsVisitor struct {
 	*antlr.BaseParseTreeVisitor
 }
 
-func (v *BaseCommandsVisitor) VisitStartCommand(ctx *StartCommandContext) interface{} {
+func (v *BaseCommandsVisitor) VisitStartCommand(ctx *StartCommandContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitCommand(ctx *CommandContext) interface{} {
+func (v *BaseCommandsVisitor) VisitCommand(ctx *CommandContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitHelp(ctx *HelpContext) interface{} {
+func (v *BaseCommandsVisitor) VisitHelp(ctx *HelpContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitLet(ctx *LetContext) interface{} {
+func (v *BaseCommandsVisitor) VisitLet(ctx *LetContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitDeclare(ctx *DeclareContext) interface{} {
+func (v *BaseCommandsVisitor) VisitDeclare(ctx *DeclareContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitVarDecl(ctx *VarDeclContext) interface{} {
+func (v *BaseCommandsVisitor) VisitVarDecl(ctx *VarDeclContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitFnDecl(ctx *FnDeclContext) interface{} {
+func (v *BaseCommandsVisitor) VisitFnDecl(ctx *FnDeclContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitParam(ctx *ParamContext) interface{} {
+func (v *BaseCommandsVisitor) VisitParam(ctx *ParamContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitDelete(ctx *DeleteContext) interface{} {
+func (v *BaseCommandsVisitor) VisitDelete(ctx *DeleteContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitSimple(ctx *SimpleContext) interface{} {
+func (v *BaseCommandsVisitor) VisitSimple(ctx *SimpleContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitEmpty(ctx *EmptyContext) interface{} {
+func (v *BaseCommandsVisitor) VisitEmpty(ctx *EmptyContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitCompile(ctx *CompileContext) interface{} {
+func (v *BaseCommandsVisitor) VisitCompile(ctx *CompileContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitParse(ctx *ParseContext) interface{} {
+func (v *BaseCommandsVisitor) VisitParse(ctx *ParseContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitExprCmd(ctx *ExprCmdContext) interface{} {
+func (v *BaseCommandsVisitor) VisitExprCmd(ctx *ExprCmdContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitQualId(ctx *QualIdContext) interface{} {
+func (v *BaseCommandsVisitor) VisitQualId(ctx *QualIdContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitStartType(ctx *StartTypeContext) interface{} {
+func (v *BaseCommandsVisitor) VisitStartType(ctx *StartTypeContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitType(ctx *TypeContext) interface{} {
+func (v *BaseCommandsVisitor) VisitType(ctx *TypeContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitTypeId(ctx *TypeIdContext) interface{} {
+func (v *BaseCommandsVisitor) VisitTypeId(ctx *TypeIdContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitParamId(ctx *ParamIdContext) interface{} {
+func (v *BaseCommandsVisitor) VisitParamId(ctx *ParamIdContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitTypeParamList(ctx *TypeParamListContext) interface{} {
+func (v *BaseCommandsVisitor) VisitTypeParamList(ctx *TypeParamListContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitStart(ctx *StartContext) interface{} {
+func (v *BaseCommandsVisitor) VisitStart(ctx *StartContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitExpr(ctx *ExprContext) interface{} {
+func (v *BaseCommandsVisitor) VisitExpr(ctx *ExprContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitConditionalOr(ctx *ConditionalOrContext) interface{} {
+func (v *BaseCommandsVisitor) VisitConditionalOr(ctx *ConditionalOrContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitConditionalAnd(ctx *ConditionalAndContext) interface{} {
+func (v *BaseCommandsVisitor) VisitConditionalAnd(ctx *ConditionalAndContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitRelation(ctx *RelationContext) interface{} {
+func (v *BaseCommandsVisitor) VisitRelation(ctx *RelationContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitCalc(ctx *CalcContext) interface{} {
+func (v *BaseCommandsVisitor) VisitCalc(ctx *CalcContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitMemberExpr(ctx *MemberExprContext) interface{} {
+func (v *BaseCommandsVisitor) VisitMemberExpr(ctx *MemberExprContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitLogicalNot(ctx *LogicalNotContext) interface{} {
+func (v *BaseCommandsVisitor) VisitLogicalNot(ctx *LogicalNotContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitNegate(ctx *NegateContext) interface{} {
+func (v *BaseCommandsVisitor) VisitNegate(ctx *NegateContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitMemberCall(ctx *MemberCallContext) interface{} {
+func (v *BaseCommandsVisitor) VisitMemberCall(ctx *MemberCallContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitSelect(ctx *SelectContext) interface{} {
+func (v *BaseCommandsVisitor) VisitSelect(ctx *SelectContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitPrimaryExpr(ctx *PrimaryExprContext) interface{} {
+func (v *BaseCommandsVisitor) VisitPrimaryExpr(ctx *PrimaryExprContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitIndex(ctx *IndexContext) interface{} {
+func (v *BaseCommandsVisitor) VisitIndex(ctx *IndexContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitIdent(ctx *IdentContext) interface{} {
+func (v *BaseCommandsVisitor) VisitIdent(ctx *IdentContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitGlobalCall(ctx *GlobalCallContext) interface{} {
+func (v *BaseCommandsVisitor) VisitGlobalCall(ctx *GlobalCallContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitNested(ctx *NestedContext) interface{} {
+func (v *BaseCommandsVisitor) VisitNested(ctx *NestedContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitCreateList(ctx *CreateListContext) interface{} {
+func (v *BaseCommandsVisitor) VisitCreateList(ctx *CreateListContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitCreateStruct(ctx *CreateStructContext) interface{} {
+func (v *BaseCommandsVisitor) VisitCreateStruct(ctx *CreateStructContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitCreateMessage(ctx *CreateMessageContext) interface{} {
+func (v *BaseCommandsVisitor) VisitCreateMessage(ctx *CreateMessageContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitConstantLiteral(ctx *ConstantLiteralContext) interface{} {
+func (v *BaseCommandsVisitor) VisitConstantLiteral(ctx *ConstantLiteralContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitExprList(ctx *ExprListContext) interface{} {
+func (v *BaseCommandsVisitor) VisitExprList(ctx *ExprListContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitListInit(ctx *ListInitContext) interface{} {
+func (v *BaseCommandsVisitor) VisitListInit(ctx *ListInitContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitFieldInitializerList(ctx *FieldInitializerListContext) interface{} {
+func (v *BaseCommandsVisitor) VisitFieldInitializerList(ctx *FieldInitializerListContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitOptField(ctx *OptFieldContext) interface{} {
+func (v *BaseCommandsVisitor) VisitOptField(ctx *OptFieldContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitMapInitializerList(ctx *MapInitializerListContext) interface{} {
+func (v *BaseCommandsVisitor) VisitMapInitializerList(ctx *MapInitializerListContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitSimpleIdentifier(ctx *SimpleIdentifierContext) interface{} {
+func (v *BaseCommandsVisitor) VisitSimpleIdentifier(ctx *SimpleIdentifierContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitEscapedIdentifier(ctx *EscapedIdentifierContext) interface{} {
+func (v *BaseCommandsVisitor) VisitEscapedIdentifier(ctx *EscapedIdentifierContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitOptExpr(ctx *OptExprContext) interface{} {
+func (v *BaseCommandsVisitor) VisitOptExpr(ctx *OptExprContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitInt(ctx *IntContext) interface{} {
+func (v *BaseCommandsVisitor) VisitInt(ctx *IntContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitUint(ctx *UintContext) interface{} {
+func (v *BaseCommandsVisitor) VisitUint(ctx *UintContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitDouble(ctx *DoubleContext) interface{} {
+func (v *BaseCommandsVisitor) VisitDouble(ctx *DoubleContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitString(ctx *StringContext) interface{} {
+func (v *BaseCommandsVisitor) VisitString(ctx *StringContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitBytes(ctx *BytesContext) interface{} {
+func (v *BaseCommandsVisitor) VisitBytes(ctx *BytesContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitBoolTrue(ctx *BoolTrueContext) interface{} {
+func (v *BaseCommandsVisitor) VisitBoolTrue(ctx *BoolTrueContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitBoolFalse(ctx *BoolFalseContext) interface{} {
+func (v *BaseCommandsVisitor) VisitBoolFalse(ctx *BoolFalseContext) any {
 	return v.VisitChildren(ctx)
 }
 
-func (v *BaseCommandsVisitor) VisitNull(ctx *NullContext) interface{} {
+func (v *BaseCommandsVisitor) VisitNull(ctx *NullContext) any {
 	return v.VisitChildren(ctx)
 }

--- a/repl/parser/commands_parser.go
+++ b/repl/parser/commands_parser.go
@@ -477,7 +477,7 @@ func (s *StartCommandContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *StartCommandContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *StartCommandContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitStartCommand(s)
@@ -735,7 +735,7 @@ func (s *CommandContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CommandContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CommandContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitCommand(s)
@@ -897,7 +897,7 @@ func (s *HelpContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *HelpContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *HelpContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitHelp(s)
@@ -1097,7 +1097,7 @@ func (s *LetContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *LetContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *LetContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitLet(s)
@@ -1305,7 +1305,7 @@ func (s *DeclareContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *DeclareContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *DeclareContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitDeclare(s)
@@ -1495,7 +1495,7 @@ func (s *VarDeclContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *VarDeclContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *VarDeclContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitVarDecl(s)
@@ -1768,7 +1768,7 @@ func (s *FnDeclContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *FnDeclContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *FnDeclContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitFnDecl(s)
@@ -2000,7 +2000,7 @@ func (s *ParamContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ParamContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ParamContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitParam(s)
@@ -2175,7 +2175,7 @@ func (s *DeleteContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *DeleteContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *DeleteContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitDelete(s)
@@ -2373,7 +2373,7 @@ func (s *SimpleContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *SimpleContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *SimpleContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitSimple(s)
@@ -2530,7 +2530,7 @@ func (s *EmptyContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *EmptyContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *EmptyContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitEmpty(s)
@@ -2651,7 +2651,7 @@ func (s *CompileContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CompileContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CompileContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitCompile(s)
@@ -2787,7 +2787,7 @@ func (s *ParseContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ParseContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ParseContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitParse(s)
@@ -2955,7 +2955,7 @@ func (s *ExprCmdContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ExprCmdContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ExprCmdContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitExprCmd(s)
@@ -3197,7 +3197,7 @@ func (s *QualIdContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *QualIdContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *QualIdContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitQualId(s)
@@ -3393,7 +3393,7 @@ func (s *StartTypeContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *StartTypeContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *StartTypeContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitStartType(s)
@@ -3563,7 +3563,7 @@ func (s *TypeContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *TypeContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *TypeContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitType(s)
@@ -3768,7 +3768,7 @@ func (s *TypeIdContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *TypeIdContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *TypeIdContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitTypeId(s)
@@ -3943,7 +3943,7 @@ func (s *ParamIdContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ParamIdContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ParamIdContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitParamId(s)
@@ -4129,7 +4129,7 @@ func (s *TypeParamListContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *TypeParamListContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *TypeParamListContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitTypeParamList(s)
@@ -4323,7 +4323,7 @@ func (s *StartContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *StartContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *StartContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitStart(s)
@@ -4545,7 +4545,7 @@ func (s *ExprContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ExprContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ExprContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitExpr(s)
@@ -4798,7 +4798,7 @@ func (s *ConditionalOrContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ConditionalOrContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ConditionalOrContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitConditionalOr(s)
@@ -5044,7 +5044,7 @@ func (s *ConditionalAndContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ConditionalAndContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ConditionalAndContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitConditionalAnd(s)
@@ -5288,7 +5288,7 @@ func (s *RelationContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *RelationContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *RelationContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitRelation(s)
@@ -5554,7 +5554,7 @@ func (s *CalcContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CalcContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CalcContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitCalc(s)
@@ -5821,7 +5821,7 @@ func (s *LogicalNotContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *LogicalNotContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *LogicalNotContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitLogicalNot(s)
@@ -5877,7 +5877,7 @@ func (s *MemberExprContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *MemberExprContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *MemberExprContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitMemberExpr(s)
@@ -5951,7 +5951,7 @@ func (s *NegateContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *NegateContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *NegateContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitNegate(s)
@@ -6230,7 +6230,7 @@ func (s *MemberCallContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *MemberCallContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *MemberCallContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitMemberCall(s)
@@ -6325,7 +6325,7 @@ func (s *SelectContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *SelectContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *SelectContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitSelect(s)
@@ -6381,7 +6381,7 @@ func (s *PrimaryExprContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *PrimaryExprContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *PrimaryExprContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitPrimaryExpr(s)
@@ -6480,7 +6480,7 @@ func (s *IndexContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *IndexContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *IndexContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitIndex(s)
@@ -6865,7 +6865,7 @@ func (s *CreateListContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CreateListContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CreateListContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitCreateList(s)
@@ -6923,7 +6923,7 @@ func (s *IdentContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *IdentContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *IdentContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitIdent(s)
@@ -7001,7 +7001,7 @@ func (s *CreateStructContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CreateStructContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CreateStructContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitCreateStruct(s)
@@ -7057,7 +7057,7 @@ func (s *ConstantLiteralContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ConstantLiteralContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ConstantLiteralContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitConstantLiteral(s)
@@ -7126,7 +7126,7 @@ func (s *NestedContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *NestedContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *NestedContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitNested(s)
@@ -7245,7 +7245,7 @@ func (s *CreateMessageContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *CreateMessageContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *CreateMessageContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitCreateMessage(s)
@@ -7337,7 +7337,7 @@ func (s *GlobalCallContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *GlobalCallContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *GlobalCallContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitGlobalCall(s)
@@ -7907,7 +7907,7 @@ func (s *ExprListContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ExprListContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ExprListContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitExprList(s)
@@ -8117,7 +8117,7 @@ func (s *ListInitContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *ListInitContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *ListInitContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitListInit(s)
@@ -8431,7 +8431,7 @@ func (s *FieldInitializerListContext) ExitRule(listener antlr.ParseTreeListener)
 	}
 }
 
-func (s *FieldInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *FieldInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitFieldInitializerList(s)
@@ -8646,7 +8646,7 @@ func (s *OptFieldContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *OptFieldContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *OptFieldContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitOptField(s)
@@ -8938,7 +8938,7 @@ func (s *MapInitializerListContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *MapInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *MapInitializerListContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitMapInitializerList(s)
@@ -9148,7 +9148,7 @@ func (s *EscapedIdentifierContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *EscapedIdentifierContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *EscapedIdentifierContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitEscapedIdentifier(s)
@@ -9197,7 +9197,7 @@ func (s *SimpleIdentifierContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *SimpleIdentifierContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *SimpleIdentifierContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitSimpleIdentifier(s)
@@ -9374,7 +9374,7 @@ func (s *OptExprContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *OptExprContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *OptExprContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitOptExpr(s)
@@ -9525,7 +9525,7 @@ func (s *BytesContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *BytesContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *BytesContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitBytes(s)
@@ -9574,7 +9574,7 @@ func (s *UintContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *UintContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *UintContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitUint(s)
@@ -9623,7 +9623,7 @@ func (s *NullContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *NullContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *NullContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitNull(s)
@@ -9672,7 +9672,7 @@ func (s *BoolFalseContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *BoolFalseContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *BoolFalseContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitBoolFalse(s)
@@ -9721,7 +9721,7 @@ func (s *StringContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *StringContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *StringContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitString(s)
@@ -9779,7 +9779,7 @@ func (s *DoubleContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *DoubleContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *DoubleContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitDouble(s)
@@ -9828,7 +9828,7 @@ func (s *BoolTrueContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *BoolTrueContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *BoolTrueContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitBoolTrue(s)
@@ -9886,7 +9886,7 @@ func (s *IntContext) ExitRule(listener antlr.ParseTreeListener) {
 	}
 }
 
-func (s *IntContext) Accept(visitor antlr.ParseTreeVisitor) interface{} {
+func (s *IntContext) Accept(visitor antlr.ParseTreeVisitor) any {
 	switch t := visitor.(type) {
 	case CommandsVisitor:
 		return t.VisitInt(s)

--- a/repl/parser/commands_visitor.go
+++ b/repl/parser/commands_visitor.go
@@ -8,170 +8,170 @@ type CommandsVisitor interface {
 	antlr.ParseTreeVisitor
 
 	// Visit a parse tree produced by CommandsParser#startCommand.
-	VisitStartCommand(ctx *StartCommandContext) interface{}
+	VisitStartCommand(ctx *StartCommandContext) any
 
 	// Visit a parse tree produced by CommandsParser#command.
-	VisitCommand(ctx *CommandContext) interface{}
+	VisitCommand(ctx *CommandContext) any
 
 	// Visit a parse tree produced by CommandsParser#help.
-	VisitHelp(ctx *HelpContext) interface{}
+	VisitHelp(ctx *HelpContext) any
 
 	// Visit a parse tree produced by CommandsParser#let.
-	VisitLet(ctx *LetContext) interface{}
+	VisitLet(ctx *LetContext) any
 
 	// Visit a parse tree produced by CommandsParser#declare.
-	VisitDeclare(ctx *DeclareContext) interface{}
+	VisitDeclare(ctx *DeclareContext) any
 
 	// Visit a parse tree produced by CommandsParser#varDecl.
-	VisitVarDecl(ctx *VarDeclContext) interface{}
+	VisitVarDecl(ctx *VarDeclContext) any
 
 	// Visit a parse tree produced by CommandsParser#fnDecl.
-	VisitFnDecl(ctx *FnDeclContext) interface{}
+	VisitFnDecl(ctx *FnDeclContext) any
 
 	// Visit a parse tree produced by CommandsParser#param.
-	VisitParam(ctx *ParamContext) interface{}
+	VisitParam(ctx *ParamContext) any
 
 	// Visit a parse tree produced by CommandsParser#delete.
-	VisitDelete(ctx *DeleteContext) interface{}
+	VisitDelete(ctx *DeleteContext) any
 
 	// Visit a parse tree produced by CommandsParser#simple.
-	VisitSimple(ctx *SimpleContext) interface{}
+	VisitSimple(ctx *SimpleContext) any
 
 	// Visit a parse tree produced by CommandsParser#empty.
-	VisitEmpty(ctx *EmptyContext) interface{}
+	VisitEmpty(ctx *EmptyContext) any
 
 	// Visit a parse tree produced by CommandsParser#compile.
-	VisitCompile(ctx *CompileContext) interface{}
+	VisitCompile(ctx *CompileContext) any
 
 	// Visit a parse tree produced by CommandsParser#parse.
-	VisitParse(ctx *ParseContext) interface{}
+	VisitParse(ctx *ParseContext) any
 
 	// Visit a parse tree produced by CommandsParser#exprCmd.
-	VisitExprCmd(ctx *ExprCmdContext) interface{}
+	VisitExprCmd(ctx *ExprCmdContext) any
 
 	// Visit a parse tree produced by CommandsParser#qualId.
-	VisitQualId(ctx *QualIdContext) interface{}
+	VisitQualId(ctx *QualIdContext) any
 
 	// Visit a parse tree produced by CommandsParser#startType.
-	VisitStartType(ctx *StartTypeContext) interface{}
+	VisitStartType(ctx *StartTypeContext) any
 
 	// Visit a parse tree produced by CommandsParser#type.
-	VisitType(ctx *TypeContext) interface{}
+	VisitType(ctx *TypeContext) any
 
 	// Visit a parse tree produced by CommandsParser#typeId.
-	VisitTypeId(ctx *TypeIdContext) interface{}
+	VisitTypeId(ctx *TypeIdContext) any
 
 	// Visit a parse tree produced by CommandsParser#paramId.
-	VisitParamId(ctx *ParamIdContext) interface{}
+	VisitParamId(ctx *ParamIdContext) any
 
 	// Visit a parse tree produced by CommandsParser#typeParamList.
-	VisitTypeParamList(ctx *TypeParamListContext) interface{}
+	VisitTypeParamList(ctx *TypeParamListContext) any
 
 	// Visit a parse tree produced by CommandsParser#start.
-	VisitStart(ctx *StartContext) interface{}
+	VisitStart(ctx *StartContext) any
 
 	// Visit a parse tree produced by CommandsParser#expr.
-	VisitExpr(ctx *ExprContext) interface{}
+	VisitExpr(ctx *ExprContext) any
 
 	// Visit a parse tree produced by CommandsParser#conditionalOr.
-	VisitConditionalOr(ctx *ConditionalOrContext) interface{}
+	VisitConditionalOr(ctx *ConditionalOrContext) any
 
 	// Visit a parse tree produced by CommandsParser#conditionalAnd.
-	VisitConditionalAnd(ctx *ConditionalAndContext) interface{}
+	VisitConditionalAnd(ctx *ConditionalAndContext) any
 
 	// Visit a parse tree produced by CommandsParser#relation.
-	VisitRelation(ctx *RelationContext) interface{}
+	VisitRelation(ctx *RelationContext) any
 
 	// Visit a parse tree produced by CommandsParser#calc.
-	VisitCalc(ctx *CalcContext) interface{}
+	VisitCalc(ctx *CalcContext) any
 
 	// Visit a parse tree produced by CommandsParser#MemberExpr.
-	VisitMemberExpr(ctx *MemberExprContext) interface{}
+	VisitMemberExpr(ctx *MemberExprContext) any
 
 	// Visit a parse tree produced by CommandsParser#LogicalNot.
-	VisitLogicalNot(ctx *LogicalNotContext) interface{}
+	VisitLogicalNot(ctx *LogicalNotContext) any
 
 	// Visit a parse tree produced by CommandsParser#Negate.
-	VisitNegate(ctx *NegateContext) interface{}
+	VisitNegate(ctx *NegateContext) any
 
 	// Visit a parse tree produced by CommandsParser#MemberCall.
-	VisitMemberCall(ctx *MemberCallContext) interface{}
+	VisitMemberCall(ctx *MemberCallContext) any
 
 	// Visit a parse tree produced by CommandsParser#Select.
-	VisitSelect(ctx *SelectContext) interface{}
+	VisitSelect(ctx *SelectContext) any
 
 	// Visit a parse tree produced by CommandsParser#PrimaryExpr.
-	VisitPrimaryExpr(ctx *PrimaryExprContext) interface{}
+	VisitPrimaryExpr(ctx *PrimaryExprContext) any
 
 	// Visit a parse tree produced by CommandsParser#Index.
-	VisitIndex(ctx *IndexContext) interface{}
+	VisitIndex(ctx *IndexContext) any
 
 	// Visit a parse tree produced by CommandsParser#Ident.
-	VisitIdent(ctx *IdentContext) interface{}
+	VisitIdent(ctx *IdentContext) any
 
 	// Visit a parse tree produced by CommandsParser#GlobalCall.
-	VisitGlobalCall(ctx *GlobalCallContext) interface{}
+	VisitGlobalCall(ctx *GlobalCallContext) any
 
 	// Visit a parse tree produced by CommandsParser#Nested.
-	VisitNested(ctx *NestedContext) interface{}
+	VisitNested(ctx *NestedContext) any
 
 	// Visit a parse tree produced by CommandsParser#CreateList.
-	VisitCreateList(ctx *CreateListContext) interface{}
+	VisitCreateList(ctx *CreateListContext) any
 
 	// Visit a parse tree produced by CommandsParser#CreateStruct.
-	VisitCreateStruct(ctx *CreateStructContext) interface{}
+	VisitCreateStruct(ctx *CreateStructContext) any
 
 	// Visit a parse tree produced by CommandsParser#CreateMessage.
-	VisitCreateMessage(ctx *CreateMessageContext) interface{}
+	VisitCreateMessage(ctx *CreateMessageContext) any
 
 	// Visit a parse tree produced by CommandsParser#ConstantLiteral.
-	VisitConstantLiteral(ctx *ConstantLiteralContext) interface{}
+	VisitConstantLiteral(ctx *ConstantLiteralContext) any
 
 	// Visit a parse tree produced by CommandsParser#exprList.
-	VisitExprList(ctx *ExprListContext) interface{}
+	VisitExprList(ctx *ExprListContext) any
 
 	// Visit a parse tree produced by CommandsParser#listInit.
-	VisitListInit(ctx *ListInitContext) interface{}
+	VisitListInit(ctx *ListInitContext) any
 
 	// Visit a parse tree produced by CommandsParser#fieldInitializerList.
-	VisitFieldInitializerList(ctx *FieldInitializerListContext) interface{}
+	VisitFieldInitializerList(ctx *FieldInitializerListContext) any
 
 	// Visit a parse tree produced by CommandsParser#optField.
-	VisitOptField(ctx *OptFieldContext) interface{}
+	VisitOptField(ctx *OptFieldContext) any
 
 	// Visit a parse tree produced by CommandsParser#mapInitializerList.
-	VisitMapInitializerList(ctx *MapInitializerListContext) interface{}
+	VisitMapInitializerList(ctx *MapInitializerListContext) any
 
 	// Visit a parse tree produced by CommandsParser#SimpleIdentifier.
-	VisitSimpleIdentifier(ctx *SimpleIdentifierContext) interface{}
+	VisitSimpleIdentifier(ctx *SimpleIdentifierContext) any
 
 	// Visit a parse tree produced by CommandsParser#EscapedIdentifier.
-	VisitEscapedIdentifier(ctx *EscapedIdentifierContext) interface{}
+	VisitEscapedIdentifier(ctx *EscapedIdentifierContext) any
 
 	// Visit a parse tree produced by CommandsParser#optExpr.
-	VisitOptExpr(ctx *OptExprContext) interface{}
+	VisitOptExpr(ctx *OptExprContext) any
 
 	// Visit a parse tree produced by CommandsParser#Int.
-	VisitInt(ctx *IntContext) interface{}
+	VisitInt(ctx *IntContext) any
 
 	// Visit a parse tree produced by CommandsParser#Uint.
-	VisitUint(ctx *UintContext) interface{}
+	VisitUint(ctx *UintContext) any
 
 	// Visit a parse tree produced by CommandsParser#Double.
-	VisitDouble(ctx *DoubleContext) interface{}
+	VisitDouble(ctx *DoubleContext) any
 
 	// Visit a parse tree produced by CommandsParser#String.
-	VisitString(ctx *StringContext) interface{}
+	VisitString(ctx *StringContext) any
 
 	// Visit a parse tree produced by CommandsParser#Bytes.
-	VisitBytes(ctx *BytesContext) interface{}
+	VisitBytes(ctx *BytesContext) any
 
 	// Visit a parse tree produced by CommandsParser#BoolTrue.
-	VisitBoolTrue(ctx *BoolTrueContext) interface{}
+	VisitBoolTrue(ctx *BoolTrueContext) any
 
 	// Visit a parse tree produced by CommandsParser#BoolFalse.
-	VisitBoolFalse(ctx *BoolFalseContext) interface{}
+	VisitBoolFalse(ctx *BoolFalseContext) any
 
 	// Visit a parse tree produced by CommandsParser#Null.
-	VisitNull(ctx *NullContext) interface{}
+	VisitNull(ctx *NullContext) any
 }

--- a/test/compare.go
+++ b/test/compare.go
@@ -26,7 +26,7 @@ func Compare(a string, e string) bool {
 }
 
 // DiffMessage creates a diff dump message for test failures.
-func DiffMessage(context string, actual interface{}, expected interface{}) string {
+func DiffMessage(context string, actual any, expected any) string {
 	return fmt.Sprintf("%s: \ngot %v, \nwanted %v", context, actual, expected)
 }
 


### PR DESCRIPTION
Replace `interface{}` with `any` (Go 1.18+ type alias).

11 files changed via code search.

Fixes type literal usage only (not interface definitions).