### PR TITLE
Prevent indexing on sentinel json field '-'

### DIFF
--- a/ext/native.go
+++ b/ext/native.go
@@ -164,6 +164,10 @@ func fieldNameByTag(structTagToParse string) func(field reflect.StructField) str
 	}
 }
 
+func isSkippedFieldName(name string) bool {
+	return name == "" || name == "-"
+}
+
 type nativeTypeOptions struct {
 	// fieldNameHandler controls how CEL should perform struct field renames.
 	// This is most commonly used for switching to parsing based off the struct field tag,
@@ -286,9 +290,13 @@ func toFieldName(fieldNameHandler NativeTypesFieldNameHandler, f reflect.StructF
 func (tp *nativeTypeProvider) FindStructFieldNames(typeName string) ([]string, bool) {
 	if t, found := tp.nativeTypes[typeName]; found {
 		fieldCount := t.refType.NumField()
-		fields := make([]string, fieldCount)
+		fields := make([]string, 0, fieldCount)
 		for i := 0; i < fieldCount; i++ {
-			fields[i] = toFieldName(tp.options.fieldNameHandler, t.refType.Field(i))
+			fieldName := toFieldName(tp.options.fieldNameHandler, t.refType.Field(i))
+			if isSkippedFieldName(fieldName) {
+				continue
+			}
+			fields = append(fields, fieldName)
 		}
 		return fields, true
 	}
@@ -509,6 +517,9 @@ func (o *nativeObj) ConvertToNative(typeDesc reflect.Type) (any, error) {
 				continue
 			}
 			fieldName := toFieldName(o.valType.fieldNameHandler, fieldType)
+			if isSkippedFieldName(fieldName) {
+				continue
+			}
 			fieldCELVal := o.NativeToValue(fieldValue.Interface())
 			fieldJSONVal, err := fieldCELVal.ConvertToNative(jsonValueType)
 			if err != nil {
@@ -667,7 +678,9 @@ func newNativeType(fieldNameHandler NativeTypesFieldNameHandler, rawType reflect
 		for idx := 0; idx < refType.NumField(); idx++ {
 			field := refType.Field(idx)
 			fieldName := toFieldName(fieldNameHandler, field)
-
+			if isSkippedFieldName(fieldName) {
+				continue
+			}
 			if _, found := fieldNames[fieldName]; found {
 				return nil, fmt.Errorf("invalid field name `%s` in struct `%s`: %w", fieldName, refType.Name(), errDuplicatedFieldName)
 			} else {
@@ -737,6 +750,10 @@ func (t *nativeType) Value() any {
 // fieldByName returns the corresponding reflect.StructField for the give name either by matching
 // field tag or field name.
 func (t *nativeType) fieldByName(fieldName string) (reflect.StructField, bool) {
+	if isSkippedFieldName(fieldName) {
+		return reflect.StructField{}, false
+	}
+
 	if t.fieldNameHandler == nil {
 		return t.refType.FieldByName(fieldName)
 	}

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -933,19 +933,44 @@ func TestNativeStructEmbedded(t *testing.T) {
 	var nativeTests = []struct {
 		expr string
 		in   any
+		out  any
 	}{
 		{
 			expr: `test.embedded.custom_name == "name"`,
 			in: map[string]any{
-				"test": &TestEmbeddedTypes{TestNestedType{NestedCustomName: "name"}},
+				"test": &TestEmbeddedTypes{
+					TestNestedType: TestNestedType{NestedCustomName: "name"},
+					Skipped:        "should-be-hidden",
+				},
 			},
+			out: true,
+		},
+		{
+			expr: `dyn(test.embedded)["-"] == "error"`,
+			in: map[string]any{
+				"test": &TestEmbeddedTypes{
+					TestNestedType: TestNestedType{NestedCustomName: "name"},
+					Skipped:        "should-be-hidden",
+				},
+			},
+			out: errors.New("no such field: -"),
+		},
+		{
+			expr: `test.embedded == ext.TestNestedType{custom_name: "name"}`,
+			in: map[string]any{
+				"test": &TestEmbeddedTypes{
+					TestNestedType: TestNestedType{NestedCustomName: "name"},
+					Skipped:        "should-be-hidden",
+				},
+			},
+			out: true,
 		},
 	}
 
 	envOpts := []cel.EnvOption{
 		NativeTypes(
-			reflect.TypeOf(&TestEmbeddedTypes{}),
-			reflect.TypeOf(&TestNestedType{}),
+			reflect.TypeFor[*TestEmbeddedTypes](),
+			reflect.TypeFor[*TestNestedType](),
 			ParseStructTag("json"),
 		),
 		cel.Variable("test", cel.ObjectType("ext.TestEmbeddedTypes")),
@@ -977,13 +1002,59 @@ func TestNativeStructEmbedded(t *testing.T) {
 				}
 				out, _, err := prg.Eval(tc.in)
 				if err != nil {
-					t.Fatal(err)
+					if !errors.Is(err, tc.out.(error)) {
+						t.Fatalf("got %v, wanted %v for expr: %s", err, tc.out, tc.expr)
+					}
+					continue
 				}
-				if !reflect.DeepEqual(out.Value(), true) {
-					t.Errorf("got %v, wanted true for expr: %s", out.Value(), tc.expr)
+				if !reflect.DeepEqual(out.Value(), tc.out) {
+					t.Errorf("got %v, wanted %v for expr: %s", out.Value(), tc.out, tc.expr)
 				}
 			}
 		})
+	}
+}
+
+func TestNativeStructHiddenField(t *testing.T) {
+	envOpts := []cel.EnvOption{
+		NativeTypes(
+			reflect.TypeFor[*TestEmbeddedTypes](),
+			ParseStructTag("json"),
+		),
+		cel.Variable("test", cel.ObjectType("ext.TestEmbeddedTypes")),
+	}
+
+	env, err := cel.NewEnv(envOpts...)
+	if err != nil {
+		t.Fatalf("cel.NewEnv(NativeTypes()) failed: %v", err)
+	}
+
+	// 1. Static reference compilation failure case
+	// Attempting to compile `test.Password` should fail static analysis because the field is skipped/hidden.
+	_, iss := env.Compile("test.Password")
+	if iss.Err() == nil {
+		t.Error("env.Compile('test.Password') succeeded, expected a compilation/check error")
+	}
+
+	// 2. Dynamic reference runtime evaluation failure case
+	// Using dyn(test).Password should compile successfully (since dyn disables static type checks),
+	// but it must fail at runtime during evaluation because the field is not exposed.
+	ast, iss := env.Compile("dyn(test).Password")
+	if iss.Err() != nil {
+		t.Fatalf("env.Compile('dyn(test).Password') failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("env.Program() failed: %v", err)
+	}
+	in := map[string]any{
+		"test": &TestEmbeddedTypes{
+			Skipped: "sensitive_password",
+		},
+	}
+	out, _, err := prg.Eval(in)
+	if err == nil {
+		t.Errorf("prg.Eval() succeeded and returned %v, expected runtime error accessing hidden field", out)
 	}
 }
 
@@ -1198,6 +1269,7 @@ type TestMapVal struct {
 
 type TestEmbeddedTypes struct {
 	TestNestedType `json:"embedded,omitempty"`
+	Skipped        string `json:"-"`
 }
 
 type TestRefValFieldType struct {


### PR DESCRIPTION
The current native.go implementation does not skip over sentinel tags like '-' 
leading to additional fields being indexed which should be ignored.