### PR TITLE
startsWith / endsWith runtime cost agreement with checked cost

### DIFF
--- a/ext/comprehensions_test.go
+++ b/ext/comprehensions_test.go
@@ -339,7 +339,7 @@ func TestTwoVarComprehensionsCost(t *testing.T) {
 				"m.@values.@items": 2,
 			},
 			estimatedCost: checker.CostEstimate{Min: 73, Max: 173},
-			actualCost:    100,
+			actualCost:    98,
 		},
 		{
 			name:          "transformMapEntry literal input",

--- a/interpreter/runtimecost.go
+++ b/interpreter/runtimecost.go
@@ -260,7 +260,9 @@ func (c *CostTracker) costCall(call InterpretableCall, args []ref.Val, result re
 	// if user has their own implementation of ActualCostEstimator, make sure to cover the mapping between overloadId and cost calculation
 	switch call.OverloadID() {
 	// O(n) functions
-	case overloads.StartsWithString, overloads.EndsWithString, overloads.StringToBytes, overloads.BytesToString, overloads.ExtQuoteString, overloads.ExtFormatString:
+	case overloads.StartsWithString, overloads.EndsWithString:
+		cost += uint64(math.Ceil(float64(actualSize(args[1])) * common.StringTraversalCostFactor))
+	case overloads.StringToBytes, overloads.BytesToString, overloads.ExtQuoteString, overloads.ExtFormatString:
 		cost += uint64(math.Ceil(float64(actualSize(args[0])) * common.StringTraversalCostFactor))
 	case overloads.InList:
 		// If a list is composed entirely of constant values this is O(1), but we don't account for that here.

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -613,7 +613,7 @@ func TestRuntimeCost(t *testing.T) {
 				decls.NewVariable("input", types.StringType),
 				decls.NewVariable("arg1", types.StringType),
 			},
-			want: 3,
+			want: 52,
 			in:   map[string]any{"input": "idc", "arg1": string(randSeq(500))},
 		},
 		{
@@ -623,7 +623,7 @@ func TestRuntimeCost(t *testing.T) {
 				decls.NewVariable("input", types.StringType),
 				decls.NewVariable("arg1", types.StringType),
 			},
-			want: 3,
+			want: 52,
 			in:   map[string]any{"input": "idc", "arg1": string(randSeq(500))},
 		},
 		{


### PR DESCRIPTION
Ensure both checker estimates and runtime cost tracking use the same
argument as the basis for cost / estimation.