### PR TITLE
Update lists library cost computations for improved accuracy

### DIFF
--- a/ext/lists.go
+++ b/ext/lists.go
@@ -349,13 +349,15 @@ func (lib listsLib) CompileOptions() []cel.EnvOption {
 	if lib.version >= 3 {
 		estimators := []checker.CostOption{
 			checker.OverloadCostEstimate("list_slice", estimateListSlice),
-			checker.OverloadCostEstimate("list_flatten", estimateListFlatten),
-			checker.OverloadCostEstimate("list_flatten_int", estimateListFlatten),
 			checker.OverloadCostEstimate("lists_range", estimateListsRange),
 			checker.OverloadCostEstimate("list_reverse", estimateListReverse),
 		}
 		if lib.version == 3 {
-			estimators = append(estimators, checker.OverloadCostEstimate("list_distinct", estimateListDistinctLegacy))
+			estimators = append(estimators,
+				checker.OverloadCostEstimate("list_flatten", estimateListFlattenLegacy),
+				checker.OverloadCostEstimate("list_flatten_int", estimateListFlattenLegacy),
+				checker.OverloadCostEstimate("list_distinct", estimateListDistinctLegacy),
+			)
 			for _, t := range comparableTypes {
 				estimators = append(estimators,
 					checker.OverloadCostEstimate(
@@ -369,7 +371,11 @@ func (lib listsLib) CompileOptions() []cel.EnvOption {
 				)
 			}
 		} else {
-			estimators = append(estimators, checker.OverloadCostEstimate("list_distinct", estimateListDistinct))
+			estimators = append(estimators,
+				checker.OverloadCostEstimate("list_flatten", estimateListFlatten),
+				checker.OverloadCostEstimate("list_flatten_int", estimateListFlatten),
+				checker.OverloadCostEstimate("list_distinct", estimateListDistinct),
+			)
 			for _, t := range comparableTypes {
 				estimators = append(estimators,
 					checker.OverloadCostEstimate(
@@ -393,14 +399,22 @@ func (lib listsLib) CompileOptions() []cel.EnvOption {
 func (lib *listsLib) ProgramOptions() []cel.ProgramOption {
 	var opts []cel.ProgramOption
 	if lib.version >= 3 {
-		// TODO: Add cost trackers for list operations
 		trackers := []interpreter.CostTrackerOption{
 			interpreter.OverloadCostTracker("list_slice", trackListOutputSize),
-			interpreter.OverloadCostTracker("list_flatten", trackListFlatten),
-			interpreter.OverloadCostTracker("list_flatten_int", trackListFlatten),
 			interpreter.OverloadCostTracker("lists_range", trackListOutputSize),
 			interpreter.OverloadCostTracker("list_reverse", trackListOutputSize),
 			interpreter.OverloadCostTracker("list_distinct", trackListDistinct),
+		}
+		if lib.version == 3 {
+			trackers = append(trackers,
+				interpreter.OverloadCostTracker("list_flatten", trackListFlattenLegacy),
+				interpreter.OverloadCostTracker("list_flatten_int", trackListFlattenLegacy),
+			)
+		} else {
+			trackers = append(trackers,
+				interpreter.OverloadCostTracker("list_flatten", trackListFlatten),
+				interpreter.OverloadCostTracker("list_flatten_int", trackListFlatten),
+			)
 		}
 		for _, t := range comparableTypes {
 			trackers = append(trackers,
@@ -653,7 +667,7 @@ func estimateListReverse(estimator checker.CostEstimator, target *checker.AstNod
 	return estimateAllocatingListCall(1, estimateSize(estimator, *target))
 }
 
-// estimateListFlatten computes an O(n) flatten operation with a cost factor proportional to the flatten depth.
+// estimateListFlatten computes an O(n) flatten operation with a cost factor proportional to the total number of flattened items.
 func estimateListFlatten(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
 	if target == nil || len(args) > 1 {
 		return nil
@@ -662,7 +676,62 @@ func estimateListFlatten(estimator checker.CostEstimator, target *checker.AstNod
 	if len(args) == 1 {
 		depth = nodeAsUintValue(args[0], math.MaxUint)
 	}
+	var resSize checker.SizeEstimate
+	if (*target).Expr() != nil && (*target).Expr().Kind() == ast.ListKind {
+		szVal := estimateLiteralFlattenSize((*target).Expr(), depth)
+		resSize = checker.FixedSizeEstimate(szVal)
+	} else {
+		resSize = estimateFlattenSize(estimator, *target, depth)
+	}
+	cost := resSize.AsCost()
+	return estimateListCallWithDirectCost(cost, resSize, true)
+}
+
+func estimateListFlattenLegacy(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+	if target == nil || len(args) > 1 {
+		return nil
+	}
+	depth := uint64(1)
+	if len(args) == 1 {
+		depth = nodeAsUintValue(args[0], math.MaxUint)
+	}
 	return estimateAllocatingListCall(float64(depth), estimateSize(estimator, *target))
+}
+
+func estimateFlattenSize(estimator checker.CostEstimator, node checker.AstNode, depth uint64) checker.SizeEstimate {
+	sz := estimateSize(estimator, node)
+	if depth == 0 {
+		return sz
+	}
+	tType := node.Type()
+	if tType.Kind() != types.ListKind || len(tType.Parameters()) == 0 {
+		return sz
+	}
+	elemType := tType.Parameters()[0]
+	elemNode := pathAstNode{
+		path: append(append([]string(nil), node.Path()...), "@items"),
+		t:    elemType,
+	}
+	flatElemSize := estimateFlattenSize(estimator, elemNode, depth-1)
+	return sz.Multiply(flatElemSize)
+}
+
+func estimateLiteralFlattenSize(expr ast.Expr, depth uint64) uint64 {
+	if depth == 0 {
+		if expr.Kind() == ast.ListKind {
+			return uint64(expr.AsList().Size())
+		}
+		return 1
+	}
+	if expr.Kind() != ast.ListKind {
+		return 1
+	}
+	listExpr := expr.AsList()
+	totalSize := uint64(0)
+	for _, el := range listExpr.Elements() {
+		totalSize += estimateLiteralFlattenSize(el, depth-1)
+	}
+	return totalSize
 }
 
 // Compute an O(n^2) with a cost factor of 2, equivalent to sets.contains with a result list
@@ -763,9 +832,13 @@ func trackListOutputSize(_ []ref.Val, result ref.Val) *uint64 {
 	return trackAllocatingListCall(1, actualSize(result))
 }
 
-// trackListFlatten computes cost as a function of the size of the result list and the depth of
-// the flatten operation.
-func trackListFlatten(args []ref.Val, _ ref.Val) *uint64 {
+// trackListFlatten computes cost as a function of the size of the result list.
+func trackListFlatten(args []ref.Val, result ref.Val) *uint64 {
+	resSize := actualSize(result)
+	return trackAllocatingListCall(1.0, resSize)
+}
+
+func trackListFlattenLegacy(args []ref.Val, _ ref.Val) *uint64 {
 	depth := 1.0
 	if len(args) == 2 {
 		depth = float64(args[1].(types.Int))

--- a/ext/lists.go
+++ b/ext/lists.go
@@ -353,19 +353,35 @@ func (lib listsLib) CompileOptions() []cel.EnvOption {
 			checker.OverloadCostEstimate("list_flatten_int", estimateListFlatten),
 			checker.OverloadCostEstimate("lists_range", estimateListsRange),
 			checker.OverloadCostEstimate("list_reverse", estimateListReverse),
-			checker.OverloadCostEstimate("list_distinct", estimateListDistinct),
 		}
-		for _, t := range comparableTypes {
-			estimators = append(estimators,
-				checker.OverloadCostEstimate(
-					fmt.Sprintf("list_%s_sort", t.TypeName()),
-					estimateListSort(t),
-				),
-				checker.OverloadCostEstimate(
-					fmt.Sprintf("list_%s_sortByAssociatedKeys", t.TypeName()),
-					estimateListSortBy(t),
-				),
-			)
+		if lib.version == 3 {
+			estimators = append(estimators, checker.OverloadCostEstimate("list_distinct", estimateListDistinctLegacy))
+			for _, t := range comparableTypes {
+				estimators = append(estimators,
+					checker.OverloadCostEstimate(
+						fmt.Sprintf("list_%s_sort", t.TypeName()),
+						estimateListSortLegacy(t),
+					),
+					checker.OverloadCostEstimate(
+						fmt.Sprintf("list_%s_sortByAssociatedKeys", t.TypeName()),
+						estimateListSortByLegacy(t),
+					),
+				)
+			}
+		} else {
+			estimators = append(estimators, checker.OverloadCostEstimate("list_distinct", estimateListDistinct))
+			for _, t := range comparableTypes {
+				estimators = append(estimators,
+					checker.OverloadCostEstimate(
+						fmt.Sprintf("list_%s_sort", t.TypeName()),
+						estimateListSort(t),
+					),
+					checker.OverloadCostEstimate(
+						fmt.Sprintf("list_%s_sortByAssociatedKeys", t.TypeName()),
+						estimateListSortBy(t),
+					),
+				)
+			}
 		}
 		opts = append(opts, cel.CostEstimatorOptions(estimators...))
 	}
@@ -656,8 +672,23 @@ func estimateListDistinct(estimator checker.CostEstimator, target *checker.AstNo
 		return nil
 	}
 	sz := estimateSize(estimator, *target)
-	costFactor := 2.0
-	return estimateAllocatingListCall(costFactor, sz.Multiply(sz))
+	elemType := types.DynType
+	tType := (*target).Type()
+	if tType.Kind() == types.ListKind && len(tType.Parameters()) > 0 {
+		elemType = tType.Parameters()[0]
+	}
+	itemSize := estimateItemSize(estimator, *target)
+	elemCost := estimateElementEqualityCost(estimator, elemType, itemSize)
+
+	costSize := sz.Multiply(sz)
+	cost := costSize.MultiplyByCost(elemCost).MultiplyByCostFactor(2.0)
+
+	minSize := uint64(0)
+	if sz.Min > 0 {
+		minSize = 1
+	}
+	resultSize := checker.SizeEstimate{Min: minSize, Max: sz.Max}
+	return estimateListCallWithDirectCost(cost, resultSize, true)
 }
 
 // estimateListSort computes an O(n^2) sort operation with a cost factor of 2 for the equality
@@ -678,37 +709,53 @@ func estimateListSortBy(u *types.Type) checker.FunctionEstimator {
 		if target == nil || len(args) != 1 {
 			return nil
 		}
-		// Estimate the size of the list used as the sort index
-		return estimateListSortCost(estimator, args[0], u)
+		// Estimate the size of the list used as the sort index, using target to resolve item size hints.
+		return estimateListSortByCost(estimator, *target, args[0], u)
 	}
+}
+
+func estimateListSortByCost(estimator checker.CostEstimator, target checker.AstNode, keysNode checker.AstNode, elemType *types.Type) *checker.CallEstimate {
+	sz := estimateSize(estimator, keysNode)
+	itemSize := estimateItemSize(estimator, target)
+	elemCost := estimateElementEqualityCost(estimator, elemType, itemSize)
+
+	costSize := sz.Multiply(sz)
+	cost := costSize.MultiplyByCost(elemCost).MultiplyByCostFactor(2.0)
+	return estimateListCallWithDirectCost(cost, sz, true)
 }
 
 // estimateListSortCost estimates an O(n^2) sort operation with a cost factor of 2 for the equality
 // operations which occur during the sort computation.
 func estimateListSortCost(estimator checker.CostEstimator, node checker.AstNode, elemType *types.Type) *checker.CallEstimate {
 	sz := estimateSize(estimator, node)
-	costFactor := 2.0
-	switch elemType {
-	case types.StringType, types.BytesType:
-		costFactor += common.StringTraversalCostFactor
-	}
-	return estimateAllocatingListCall(costFactor, sz.Multiply(sz))
+	itemSize := estimateItemSize(estimator, node)
+	elemCost := estimateElementEqualityCost(estimator, elemType, itemSize)
+
+	costSize := sz.Multiply(sz)
+	cost := costSize.MultiplyByCost(elemCost).MultiplyByCostFactor(2.0)
+	return estimateListCallWithDirectCost(cost, sz, true)
 }
 
 // estimateAllocatingListCall computes cost as a function of the size of the result list with a
 // baseline cost for the call dispatch and the associated list allocation.
 func estimateAllocatingListCall(costFactor float64, listSize checker.SizeEstimate) *checker.CallEstimate {
-	return estimateListCall(costFactor, listSize, true)
+	return estimateListCallWithResultSize(costFactor, listSize, listSize, true)
 }
 
-// estimateListCall computes cost as a function of the size of the target list and whether the
-// call allocates memory.
-func estimateListCall(costFactor float64, listSize checker.SizeEstimate, allocates bool) *checker.CallEstimate {
-	cost := listSize.MultiplyByCostFactor(costFactor).Add(callCostEstimate)
+// estimateListCallWithResultSize computes cost as a function of the size of the target list and whether the
+// call allocates memory, using a separate result size estimate for the output list.
+func estimateListCallWithResultSize(costFactor float64, costSize checker.SizeEstimate, resultSize checker.SizeEstimate, allocates bool) *checker.CallEstimate {
+	cost := costSize.MultiplyByCostFactor(costFactor)
+	return estimateListCallWithDirectCost(cost, resultSize, allocates)
+}
+
+// estimateListCallWithDirectCost computes cost using a pre-calculated CostEstimate and a separate result size estimate.
+func estimateListCallWithDirectCost(cost checker.CostEstimate, resultSize checker.SizeEstimate, allocates bool) *checker.CallEstimate {
 	if allocates {
 		cost = cost.Add(checker.FixedCostEstimate(common.ListCreateBaseCost))
 	}
-	return &checker.CallEstimate{CostEstimate: cost, ResultSize: &listSize}
+	cost = cost.Add(callCostEstimate)
+	return &checker.CallEstimate{CostEstimate: cost, ResultSize: &resultSize}
 }
 
 // trackListOutputSize computes cost as a function of the size of the result list.
@@ -761,4 +808,100 @@ func trackListSelfCompare(l traits.Lister) *uint64 {
 func trackAllocatingListCall(costFactor float64, size uint64) *uint64 {
 	cost := safeAdd(uint64(float64(size)*costFactor), callCost, common.ListCreateBaseCost)
 	return &cost
+}
+
+func estimateListDistinctLegacy(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+	if target == nil || len(args) != 0 {
+		return nil
+	}
+	sz := estimateSize(estimator, *target)
+	costFactor := 2.0
+	tType := (*target).Type()
+	if tType.Kind() == types.ListKind && len(tType.Parameters()) > 0 {
+		elemType := tType.Parameters()[0]
+		if elemType.Kind() == types.StringKind || elemType.Kind() == types.BytesKind {
+			costFactor += common.StringTraversalCostFactor
+		}
+	}
+	return estimateAllocatingListCall(costFactor, sz.Multiply(sz))
+}
+
+func estimateListSortLegacy(t *types.Type) checker.FunctionEstimator {
+	return func(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+		if target == nil || len(args) != 0 {
+			return nil
+		}
+		return estimateListSortCostLegacy(estimator, *target, t)
+	}
+}
+
+func estimateListSortByLegacy(u *types.Type) checker.FunctionEstimator {
+	return func(estimator checker.CostEstimator, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+		if target == nil || len(args) != 1 {
+			return nil
+		}
+		return estimateListSortCostLegacy(estimator, args[0], u)
+	}
+}
+
+func estimateListSortCostLegacy(estimator checker.CostEstimator, node checker.AstNode, elemType *types.Type) *checker.CallEstimate {
+	sz := estimateSize(estimator, node)
+	costFactor := 2.0
+	switch elemType {
+	case types.StringType, types.BytesType:
+		costFactor += common.StringTraversalCostFactor
+	}
+	return estimateAllocatingListCall(costFactor, sz.Multiply(sz))
+}
+
+type pathAstNode struct {
+	path []string
+	t    *types.Type
+}
+
+func (p pathAstNode) Path() []string {
+	return p.path
+}
+
+func (p pathAstNode) Type() *types.Type {
+	return p.t
+}
+
+func (p pathAstNode) Expr() ast.Expr {
+	return nil
+}
+
+func (p pathAstNode) ComputedSize() *checker.SizeEstimate {
+	return nil
+}
+
+func estimateItemSize(estimator checker.CostEstimator, node checker.AstNode) checker.SizeEstimate {
+	path := node.Path()
+	if len(path) == 0 {
+		return checker.SizeEstimate{Min: 0, Max: math.MaxUint64}
+	}
+	elemType := types.DynType
+	tType := node.Type()
+	if tType.Kind() == types.ListKind && len(tType.Parameters()) > 0 {
+		elemType = tType.Parameters()[0]
+	}
+	itemNode := pathAstNode{
+		path: append(append([]string(nil), path...), "@items"),
+		t:    elemType,
+	}
+	if l := estimator.EstimateSize(itemNode); l != nil {
+		return *l
+	}
+	return checker.SizeEstimate{Min: 0, Max: math.MaxUint64}
+}
+
+func estimateElementEqualityCost(estimator checker.CostEstimator, elemType *types.Type, itemSize checker.SizeEstimate) checker.CostEstimate {
+	switch elemType.Kind() {
+	case types.StringKind, types.BytesKind:
+		return itemSize.MultiplyByCostFactor(common.StringTraversalCostFactor)
+	case types.ListKind, types.MapKind, types.StructKind:
+		return checker.UnknownCostEstimate()
+	default:
+		return checker.FixedCostEstimate(1)
+	}
 }

--- a/ext/lists_test.go
+++ b/ext/lists_test.go
@@ -269,6 +269,13 @@ func TestListsCosts(t *testing.T) {
 			expr:          `[[1, 2], 3].flatten(1) == [1, 2, 3]`,
 			estimatedCost: checker.FixedCostEstimate(44),
 			actualCost:    44,
+			version:       3,
+		},
+		{
+			name:          "list_flatten_depth_one_v4",
+			expr:          `[[1, 2], 3].flatten(1) == [1, 2, 3]`,
+			estimatedCost: checker.FixedCostEstimate(45),
+			actualCost:    45,
 		},
 		{
 			// (3 array allocs + internal alloc) * 10 + size(list) * 2 + 2 calls
@@ -276,6 +283,13 @@ func TestListsCosts(t *testing.T) {
 			expr:          `[[1, 2], 3].flatten(2) == [1, 2, 3]`,
 			estimatedCost: checker.FixedCostEstimate(46),
 			actualCost:    46,
+			version:       3,
+		},
+		{
+			name:          "list_flatten_depth_two_v4",
+			expr:          `[[1, 2], 3].flatten(2) == [1, 2, 3]`,
+			estimatedCost: checker.FixedCostEstimate(45),
+			actualCost:    45,
 		},
 		{
 			// (3 array allocs + internal alloc) * 10 + size(list) * 3 + 2 calls
@@ -283,9 +297,23 @@ func TestListsCosts(t *testing.T) {
 			expr:          `[[1, 2], 3].flatten(3) == [1, 2, 3]`,
 			estimatedCost: checker.FixedCostEstimate(48),
 			actualCost:    48,
+			version:       3,
+		},
+		{
+			name:          "list_flatten_depth_three_v4",
+			expr:          `[[1, 2], 3].flatten(3) == [1, 2, 3]`,
+			estimatedCost: checker.FixedCostEstimate(45),
+			actualCost:    45,
 		},
 		{
 			name:          "list_flatten",
+			expr:          `[[1], 2, 3].flatten() == [1, 2, 3]`,
+			estimatedCost: checker.FixedCostEstimate(45),
+			actualCost:    45,
+			version:       3,
+		},
+		{
+			name:          "list_flatten_v4",
 			expr:          `[[1], 2, 3].flatten() == [1, 2, 3]`,
 			estimatedCost: checker.FixedCostEstimate(45),
 			actualCost:    45,
@@ -298,6 +326,25 @@ func TestListsCosts(t *testing.T) {
 			hints:         map[string]uint64{"x": 3},
 			estimatedCost: checker.CostEstimate{Min: 23, Max: 26},
 			actualCost:    26,
+			version:       3,
+		},
+		{
+			name:          "list_flatten_var_v4_no_item_hint",
+			expr:          `x.flatten() == [1, 2, 3]`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.DynType))},
+			in:            map[string]any{"x": []any{[]any{1}, 2, 3}},
+			hints:         map[string]uint64{"x": 3},
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 18446744073709551615},
+			actualCost:    26,
+		},
+		{
+			name:          "list_flatten_var_v4_with_item_hint",
+			expr:          `x.flatten() == [1, 2, 3]`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.DynType))},
+			in:            map[string]any{"x": []any{[]any{1}, 2, 3}},
+			hints:         map[string]uint64{"x": 3, "x.@items": 5},
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 38},
+			actualCost:    26,
 		},
 		{
 			name:          "list_flatten_depth_var",
@@ -307,6 +354,16 @@ func TestListsCosts(t *testing.T) {
 			hints:         map[string]uint64{"x": 10},
 			estimatedCost: checker.FixedCostEstimate(18446744073709551615),
 			actualCost:    53,
+			version:       3,
+		},
+		{
+			name:          "list_flatten_depth_var_v4",
+			expr:          `[[1, 2], 3].flatten(x) == [1, 2, 3]`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.IntType)},
+			in:            map[string]any{"x": 5},
+			hints:         map[string]uint64{"x": 10},
+			estimatedCost: checker.FixedCostEstimate(46),
+			actualCost:    46,
 		},
 		{
 			// (2 array allocs + 1 internal) * 10

--- a/ext/lists_test.go
+++ b/ext/lists_test.go
@@ -76,7 +76,7 @@ func TestLists(t *testing.T) {
 		{expr: `[ExampleType{name: 'a'}, ExampleType{name: 'b'}, ExampleType{name: 'a'}].distinct() == [ExampleType{name: 'a'}, ExampleType{name: 'b'}]`},
 	}
 
-	env := testListsEnv(t)
+	env := testListsEnv(t, 0)
 	for i, tst := range listsTests {
 		tc := tst
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -237,6 +237,7 @@ func TestListsCosts(t *testing.T) {
 		hints         map[string]uint64
 		estimatedCost checker.CostEstimate
 		actualCost    uint64
+		version       int
 	}{
 		{
 			// (1 array alloc + internal alloc) * 10
@@ -334,7 +335,7 @@ func TestListsCosts(t *testing.T) {
 			expr:          `x.distinct() == ['hello']`,
 			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
 			in:            map[string]any{"x": []string{"hello", "hello"}},
-			hints:         map[string]uint64{"x": 3},
+			hints:         map[string]uint64{"x": 3, "x.@items": 5},
 			estimatedCost: checker.CostEstimate{Min: 23, Max: 41},
 			actualCost:    31,
 		},
@@ -444,8 +445,8 @@ func TestListsCosts(t *testing.T) {
 			expr:          `x.sort() == ["a", "a", "b", "b", "c", "c"]`,
 			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
 			in:            map[string]any{"x": []string{"b", "a", "b", "a", "c", "c"}},
-			hints:         map[string]uint64{"x": 10},
-			estimatedCost: checker.CostEstimate{Min: 23, Max: 233},
+			hints:         map[string]uint64{"x": 10, "x.@items": 1},
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 223},
 			actualCost:    98,
 		},
 		{
@@ -477,8 +478,147 @@ func TestListsCosts(t *testing.T) {
 			expr:          `x.sortBy(m, m['x']) == [{'x': 'a'}, {'x': 'b'}, {'x': 'c'}]`,
 			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.MapType(cel.StringType, cel.StringType)))},
 			in:            map[string]any{"x": []any{map[string]any{"x": "b"}, map[string]any{"x": "c"}, map[string]any{"x": "a"}}},
+			hints:         map[string]uint64{"x": 3, "x.@items": 1},
+			estimatedCost: checker.CostEstimate{Min: 136, Max: 196},
+			actualCost:    196,
+		},
+		{
+			name: "list_sort_concat_cost",
+			expr: `(x.sort() + y).size() == 20`,
+			vars: []cel.EnvOption{
+				cel.Variable("x", cel.ListType(cel.IntType)),
+				cel.Variable("y", cel.ListType(cel.IntType)),
+			},
+			in: map[string]any{
+				"x": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				"y": []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			},
+			hints: map[string]uint64{
+				"x": 10,
+				"y": 10,
+			},
+			estimatedCost: checker.CostEstimate{Min: 16, Max: 216},
+			actualCost:    216,
+		},
+		{
+			name: "list_distinct_concat_cost_with_item_hint",
+			expr: `(x.distinct() + y).size() == 20`,
+			vars: []cel.EnvOption{
+				cel.Variable("x", cel.ListType(cel.StringType)),
+				cel.Variable("y", cel.ListType(cel.StringType)),
+			},
+			in: map[string]any{
+				"x": []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+				"y": []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+			},
+			hints: map[string]uint64{
+				"x":        10,
+				"x.@items": 1,
+				"y":        10,
+			},
+			estimatedCost: checker.CostEstimate{Min: 16, Max: 216},
+			actualCost:    226,
+		},
+		{
+			name: "list_distinct_concat_cost",
+			expr: `(x.distinct() + y).size() == 20`,
+			vars: []cel.EnvOption{
+				cel.Variable("x", cel.ListType(cel.StringType)),
+				cel.Variable("y", cel.ListType(cel.StringType)),
+			},
+			in: map[string]any{
+				"x": []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+				"y": []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+			},
+			hints: map[string]uint64{
+				"x": 10,
+				"y": 10,
+			},
+			estimatedCost: checker.CostEstimate{Min: 16, Max: 18446744073709551615},
+			actualCost:    226,
+		},
+		{
+			name:          "list_distinct_var_v3",
+			expr:          `x.distinct() == ['hello']`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
+			in:            map[string]any{"x": []string{"hello", "hello"}},
+			hints:         map[string]uint64{"x": 3},
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 42},
+			actualCost:    31,
+			version:       3,
+		},
+		{
+			name:          "list_distinct_var_v4_no_item_hint",
+			expr:          `x.distinct() == ['hello']`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
+			in:            map[string]any{"x": []string{"hello", "hello"}},
+			hints:         map[string]uint64{"x": 3},
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 18446744073709551615},
+			actualCost:    31,
+		},
+		{
+			name:          "list_distinct_var_v4_with_item_hint",
+			expr:          `x.distinct() == ['hello']`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
+			in:            map[string]any{"x": []string{"hello", "hello"}},
+			hints:         map[string]uint64{"x": 3, "x.@items": 5},
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 41},
+			actualCost:    31,
+		},
+		{
+			name:          "list_sort_var_string_v3",
+			expr:          `x.sort() == ["a", "a", "b", "b", "c", "c"]`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
+			in:            map[string]any{"x": []string{"b", "a", "b", "a", "c", "c"}},
+			hints:         map[string]uint64{"x": 10},
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 233},
+			actualCost:    98,
+			version:       3,
+		},
+		{
+			name:          "list_sort_var_string_v4_no_item_hint",
+			expr:          `x.sort() == ["a", "a", "b", "b", "c", "c"]`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
+			in:            map[string]any{"x": []string{"b", "a", "b", "a", "c", "c"}},
+			hints:         map[string]uint64{"x": 10},
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 18446744073709551615},
+			actualCost:    98,
+		},
+		{
+			name:          "list_sort_var_string_v4_with_item_hint",
+			expr:          `x.sort() == ["a", "a", "b", "b", "c", "c"]`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.StringType))},
+			in:            map[string]any{"x": []string{"b", "a", "b", "a", "c", "c"}},
+			hints:         map[string]uint64{"x": 10, "x.@items": 1},
+			estimatedCost: checker.CostEstimate{Min: 23, Max: 223},
+			actualCost:    98,
+		},
+		{
+			name:          "list_sortBy_var_string_v3",
+			expr:          `x.sortBy(m, m['x']) == [{'x': 'a'}, {'x': 'b'}, {'x': 'c'}]`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.MapType(cel.StringType, cel.StringType)))},
+			in:            map[string]any{"x": []any{map[string]any{"x": "b"}, map[string]any{"x": "c"}, map[string]any{"x": "a"}}},
 			hints:         map[string]uint64{"x": 3},
 			estimatedCost: checker.CostEstimate{Min: 136, Max: 197},
+			actualCost:    196,
+			version:       3,
+		},
+		{
+			name:          "list_sortBy_var_string_v4_no_item_hint",
+			expr:          `x.sortBy(m, m['x']) == [{'x': 'a'}, {'x': 'b'}, {'x': 'c'}]`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.MapType(cel.StringType, cel.StringType)))},
+			in:            map[string]any{"x": []any{map[string]any{"x": "b"}, map[string]any{"x": "c"}, map[string]any{"x": "a"}}},
+			hints:         map[string]uint64{"x": 3},
+			estimatedCost: checker.CostEstimate{Min: 136, Max: 18446744073709551615},
+			actualCost:    196,
+		},
+		{
+			name:          "list_sortBy_var_string_v4_with_item_hint",
+			expr:          `x.sortBy(m, m['x']) == [{'x': 'a'}, {'x': 'b'}, {'x': 'c'}]`,
+			vars:          []cel.EnvOption{cel.Variable("x", cel.ListType(cel.MapType(cel.StringType, cel.StringType)))},
+			in:            map[string]any{"x": []any{map[string]any{"x": "b"}, map[string]any{"x": "c"}, map[string]any{"x": "a"}}},
+			hints:         map[string]uint64{"x": 3, "x.@items": 1},
+			estimatedCost: checker.CostEstimate{Min: 136, Max: 196},
 			actualCost:    196,
 		},
 	}
@@ -486,7 +626,7 @@ func TestListsCosts(t *testing.T) {
 	for _, tst := range tests {
 		tc := tst
 		t.Run(tc.name, func(t *testing.T) {
-			env := testListsEnv(t, tc.vars...)
+			env := testListsEnv(t, tc.version, tc.vars...)
 			var asts []*cel.Ast
 			pAst, iss := env.Parse(tc.expr)
 			if iss.Err() != nil {
@@ -507,10 +647,16 @@ func TestListsCosts(t *testing.T) {
 	}
 }
 
-func testListsEnv(t *testing.T, opts ...cel.EnvOption) *cel.Env {
+func testListsEnv(t *testing.T, version int, opts ...cel.EnvOption) *cel.Env {
 	t.Helper()
+	var listsOpt cel.EnvOption
+	if version > 0 {
+		listsOpt = Lists(ListsVersion(uint32(version)))
+	} else {
+		listsOpt = Lists()
+	}
 	baseOpts := []cel.EnvOption{
-		Lists(),
+		listsOpt,
 		cel.Container("google.expr.proto2.test"),
 		cel.Types(&proto2pb.ExampleType{},
 			&proto2pb.ExternalMessageType{},


### PR DESCRIPTION
Provide better estimates for distinct / sort / flatten calls using the item hint structure expected elsewhere within the cost
estimation library. 

These changes are introduced in v4 of the `ext/lists.go` library.