### PR TITLE
Async function execution internals

### DIFF
--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -16,6 +16,7 @@
 package decls
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -342,6 +343,7 @@ func (f *FunctionDecl) Bindings() ([]*functions.Overload, error) {
 				Unary:        o.guardedUnaryOp(f.Name(), f.disableTypeGuards),
 				Binary:       o.guardedBinaryOp(f.Name(), f.disableTypeGuards),
 				Function:     o.guardedFunctionOp(f.Name(), f.disableTypeGuards),
+				Async:        o.guardedAsyncOp(f.Name(), f.disableTypeGuards),
 				OperandTrait: o.OperandTrait(),
 				NonStrict:    o.IsNonStrict(),
 			}
@@ -362,6 +364,7 @@ func (f *FunctionDecl) Bindings() ([]*functions.Overload, error) {
 				Unary:        f.singleton.Unary,
 				Binary:       f.singleton.Binary,
 				Function:     f.singleton.Function,
+				Async:        f.singleton.Async,
 				OperandTrait: f.singleton.OperandTrait,
 			},
 		}
@@ -380,6 +383,7 @@ func (f *FunctionDecl) Bindings() ([]*functions.Overload, error) {
 			Unary:        overloads[0].Unary,
 			Binary:       overloads[0].Binary,
 			Function:     overloads[0].Function,
+			Async:        overloads[0].Async,
 			NonStrict:    overloads[0].NonStrict,
 			OperandTrait: overloads[0].OperandTrait,
 		}), nil
@@ -538,6 +542,30 @@ func SingletonFunctionBinding(fn functions.FunctionOp, traits ...int) FunctionOp
 	}
 }
 
+// SingletonAsyncBinding creates a singleton async function definition to be used with all function overloads.
+// The provided function is called in its own goroutine with the provided context. The function should
+// block until the result is available, and the framework manages goroutine and channel lifecycle.
+//
+// Note, this approach works well if operand is expected to have a specific trait which it implements,
+// e.g. traits.ContainerType. Otherwise, prefer per-overload async bindings.
+func SingletonAsyncBinding(fn functions.BlockingAsyncOp, traits ...int) FunctionOpt {
+	trait := 0
+	for _, t := range traits {
+		trait = trait | t
+	}
+	return func(f *FunctionDecl) (*FunctionDecl, error) {
+		if f.singleton != nil {
+			return nil, fmt.Errorf("function already has a singleton binding: %s", f.Name())
+		}
+		f.singleton = &functions.Overload{
+			Operator:     f.Name(),
+			Async:        wrapAsyncOp(fn),
+			OperandTrait: trait,
+		}
+		return f, nil
+	}
+}
+
 // Overload defines a new global overload with an overload id, argument types, and result type. Through the
 // use of OverloadOpt options, the overload may also be configured with a binding, an operand trait, and to
 // be non-strict.
@@ -622,6 +650,8 @@ type OverloadDecl struct {
 	binaryOp functions.BinaryOp
 	// functionOp is a catch-all for zero-arity and three-plus arity functions.
 	functionOp functions.FunctionOp
+	// asyncOp is an asynchronous function binding that returns a channel.
+	asyncOp functions.AsyncOp
 }
 
 // Examples returns a list of string examples for the overload.
@@ -750,7 +780,7 @@ func (o *OverloadDecl) SignatureOverlaps(other *OverloadDecl) bool {
 
 // HasBinding indicates whether the overload already has a definition.
 func (o *OverloadDecl) HasBinding() bool {
-	return o != nil && (o.unaryOp != nil || o.binaryOp != nil || o.functionOp != nil)
+	return o != nil && (o.unaryOp != nil || o.binaryOp != nil || o.functionOp != nil || o.asyncOp != nil)
 }
 
 // guardedUnaryOp creates an invocation guard around the provided unary operator, if one is defined.
@@ -789,6 +819,22 @@ func (o *OverloadDecl) guardedFunctionOp(funcName string, disableTypeGuards bool
 			return MaybeNoSuchOverload(funcName, args...)
 		}
 		return o.functionOp(args...)
+	}
+}
+
+// guardedAsyncOp creates an invocation guard around the provided async function binding, if one is provided.
+func (o *OverloadDecl) guardedAsyncOp(funcName string, disableTypeGuards bool) functions.AsyncOp {
+	if o.asyncOp == nil {
+		return nil
+	}
+	return func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
+		if !o.matchesRuntimeSignature(disableTypeGuards, args...) {
+			ch := make(chan ref.Val, 1)
+			ch <- MaybeNoSuchOverload(funcName, args...)
+			close(ch)
+			return ch
+		}
+		return o.asyncOp(ctx, args...)
 	}
 }
 
@@ -894,6 +940,40 @@ func FunctionBinding(binding functions.FunctionOp) OverloadOpt {
 		}
 		o.functionOp = binding
 		return o, nil
+	}
+}
+
+// AsyncBinding provides the implementation of an asynchronous overload. The provided function
+// is called in its own goroutine with the provided context. The function should block until
+// the result is available, and the framework manages goroutine and channel lifecycle.
+//
+// This follows the same pattern used by gRPC-Go and other major Go frameworks where user
+// code is synchronous and the framework manages concurrency.
+func AsyncBinding(fn functions.BlockingAsyncOp) OverloadOpt {
+	return func(o *OverloadDecl) (*OverloadDecl, error) {
+		if o.HasBinding() {
+			return nil, fmt.Errorf("overload already has a binding: %s", o.ID())
+		}
+		if o.hasLateBinding {
+			return nil, fmt.Errorf("overload already has a late binding: %s", o.ID())
+		}
+		o.asyncOp = wrapAsyncOp(fn)
+		return o, nil
+	}
+}
+
+// wrapAsyncOp adapts a blocking function into the channel-based AsyncOp used internally.
+//
+// The blocking function is invoked synchronously and its result delivered on a buffered channel.
+// The interpreter always invokes an AsyncOp from a dedicated goroutine, so running the blocking
+// call inline here keeps the framework to a single goroutine per async call rather than spawning
+// an additional one to bridge blocking-to-channel.
+func wrapAsyncOp(fn functions.BlockingAsyncOp) functions.AsyncOp {
+	return func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
+		ch := make(chan ref.Val, 1)
+		ch <- fn(ctx, args...)
+		close(ch)
+		return ch
 	}
 }
 

--- a/common/decls/decls_test.go
+++ b/common/decls/decls_test.go
@@ -15,6 +15,7 @@
 package decls
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -1368,6 +1369,149 @@ func TestNilVariable(t *testing.T) {
 	}
 	if v.Documentation() != nil {
 		t.Errorf("v.Documentation() got %v, wanted nil", v.Documentation())
+	}
+}
+
+func TestAsyncBinding(t *testing.T) {
+	fn, err := NewFunction("async_fn",
+		Overload("async_fn_int", []*types.Type{types.IntType}, types.IntType,
+			AsyncBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+				return args[0]
+			}),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewFunction() failed: %v", err)
+	}
+	for _, od := range fn.OverloadDecls() {
+		if !od.HasBinding() {
+			t.Errorf("Overload %s does not have binding, wanted async binding", od.ID())
+		}
+	}
+	bindings, err := fn.Bindings()
+	if err != nil {
+		t.Fatalf("fn.Bindings() produced an err: %v", err)
+	}
+	if len(bindings) != 2 {
+		t.Errorf("fn.Bindings() produced %d bindings, wanted 2", len(bindings))
+	}
+	for _, binding := range bindings {
+		if binding.Async == nil {
+			t.Fatal("binding missing Async implementation")
+		}
+
+		ctx := context.Background()
+		ch := binding.Async(ctx, types.Int(42))
+		select {
+		case res := <-ch:
+			if res.Equal(types.Int(42)) != types.True {
+				t.Errorf("async binding returned %v, wanted 42", res)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("async binding timed out")
+		}
+	}
+}
+
+func TestAsyncBindingTypeGuards(t *testing.T) {
+	fn, err := NewFunction("async_fn",
+		Overload("async_fn_int", []*types.Type{types.IntType}, types.IntType,
+			AsyncBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+				return args[0]
+			}),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewFunction() failed: %v", err)
+	}
+	bindings, err := fn.Bindings()
+	if err != nil {
+		t.Fatalf("fn.Bindings() produced an err: %v", err)
+	}
+	if len(bindings) != 2 {
+		t.Errorf("fn.Bindings() produced %d bindings, wanted 2", len(bindings))
+	}
+	for _, binding := range bindings {
+		if binding.Async == nil {
+			t.Fatal("binding missing Async implementation")
+		}
+
+		ctx := context.Background()
+		ch := binding.Async(ctx, types.String("hello"))
+		select {
+		case res := <-ch:
+			if !types.IsError(res) {
+				t.Errorf("async binding returned %v, wanted error", res)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("async binding timed out")
+		}
+	}
+}
+
+func TestSingletonAsyncBinding(t *testing.T) {
+	fn, err := NewFunction("async_fn",
+		Overload("async_fn_int", []*types.Type{types.IntType}, types.IntType),
+		Overload("async_fn_string", []*types.Type{types.StringType}, types.StringType),
+		SingletonAsyncBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+			return args[0]
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewFunction() failed: %v", err)
+	}
+	bindings, err := fn.Bindings()
+	if err != nil {
+		t.Fatalf("fn.Bindings() produced an err: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Errorf("fn.Bindings() produced %d bindings, wanted one", len(bindings))
+	}
+	binding := bindings[0]
+	if binding.Async == nil {
+		t.Fatal("binding missing Async implementation")
+	}
+
+	ctx := context.Background()
+	ch := binding.Async(ctx, types.String("hello"))
+	select {
+	case res := <-ch:
+		if res.Equal(types.String("hello")) != types.True {
+			t.Errorf("async binding returned %v, wanted hello", res)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("async binding timed out")
+	}
+}
+
+func TestAsyncBindingRedefinition(t *testing.T) {
+	_, err := NewFunction("async_fn",
+		Overload("async_fn_int", []*types.Type{types.IntType}, types.IntType,
+			AsyncBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+				return args[0]
+			}),
+			AsyncBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+				return args[0]
+			}),
+		),
+	)
+	if err == nil || !strings.Contains(err.Error(), "already has a binding") {
+		t.Errorf("NewFunction() got %v, wanted already has a binding", err)
+	}
+}
+
+func TestSingletonAsyncBindingRedefinition(t *testing.T) {
+	_, err := NewFunction("async_fn",
+		Overload("async_fn_int", []*types.Type{types.IntType}, types.IntType),
+		SingletonAsyncBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+			return args[0]
+		}),
+		SingletonAsyncBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+			return args[0]
+		}),
+	)
+	if err == nil || !strings.Contains(err.Error(), "already has a singleton binding") {
+		t.Errorf("NewFunction() got %v, wanted already has a singleton binding", err)
 	}
 }
 

--- a/interpreter/BUILD.bazel
+++ b/interpreter/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "activation.go",
+        "async.go",
         "attribute_patterns.go",
         "attributes.go",
         "decorators.go",
@@ -46,6 +47,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "activation_test.go",
+        "async_test.go",
         "attribute_patterns_test.go",
         "attributes_test.go",
         "frame_test.go",
@@ -65,6 +67,7 @@ go_test(
         "//common/operators:go_default_library",
         "//common/stdlib:go_default_library",
         "//common/types:go_default_library",
+        "//common/types/ref:go_default_library",
         "//parser:go_default_library",
         "//test:go_default_library",
         "//test/proto2pb:go_default_library",

--- a/interpreter/async.go
+++ b/interpreter/async.go
@@ -102,6 +102,8 @@ func (fn *evalAsyncFunc) Exec(frame *ExecutionFrame) ref.Val {
 	// Early return if any argument to the function is unknown or error.
 	for i, arg := range fn.args {
 		argVals[i] = arg.Exec(frame)
+		// TODO: early return only on errors, aggregate unknowns and validate
+		// whether any argument is unknown before proceeding with the call.
 		if types.IsUnknownOrError(argVals[i]) {
 			return argVals[i]
 		}
@@ -113,18 +115,11 @@ func (fn *evalAsyncFunc) Exec(frame *ExecutionFrame) ref.Val {
 // asyncCallStateTracker manages async call states across re-evaluations of a single program.
 type asyncCallStateTracker struct {
 	mu sync.RWMutex
-	// calls buckets call states by a composite hash of (node id, overload, string/bool args).
+	// calls buckets call states by a composite hash of (node id, overload, string/int/double/uint/bool args).
 	// A single AST node id may host many concurrently-live calls when it is evaluated inside a
 	// comprehension (once per element with different arguments), so each bucket may hold more
 	// than one state. The exact match within a bucket is resolved via asyncCallState.equals,
 	// which applies CEL's full equality semantics to the arguments.
-	//
-	// Caveat for future implementers: dedup relies on argument equality being reflexive. CEL
-	// values whose equality is not reflexive — notably NaN doubles, where NaN != NaN — will never
-	// match a previously registered state. Such a call is therefore relaunched on every
-	// re-evaluation pass and never converges (the evaluation terminates only via context
-	// cancellation/deadline). This is inherent to the CEL equality model and is not special-cased
-	// here; if it ever needs handling, give equals an identity-based fast path before equality.
 	calls        map[uint64][]*asyncCallState
 	callsByID    map[int64]*asyncCallState
 	nextCallID   atomic.Int64
@@ -149,10 +144,10 @@ var (
 
 // hashCall computes the composite bucket key for an async call.
 //
-// Only string and bool argument values contribute to the hash. Numeric and more complex types
-// rely on a richer notion of equivalence (e.g. cross-type numeric equality, unordered maps) that
-// a byte-level hash cannot capture safely, so they are deliberately excluded from the key and are
-// instead disambiguated within the bucket by asyncCallState.equals.
+// Only string, int, double, uint, and bool argument values contribute to the hash. More complex types
+// rely on a richer notion of equivalence (e.g. unordered maps, proto equality, custom types)
+// that a byte-level hash cannot capture safely, so they are intentionally excluded from the key
+// and are instead disambiguated within the bucket by asyncCallState.equals.
 func hashCall(id int64, overload string, args []ref.Val) uint64 {
 	h := fnv.New64a()
 	var idBuf [8]byte
@@ -183,6 +178,15 @@ func hashCall(id int64, overload string, args []ref.Val) uint64 {
 			h.Write(buf[:])
 		case types.Double:
 			h.Write(hashNumberMarker)
+			if math.IsNaN(float64(v)) {
+				h.Write([]byte("NaN"))
+				continue
+			}
+			// Normalize -0.0 to 0.0. Go will treat -0.0 as 0.0 at compile time,
+			// but the function math.Copysign(0.0, -1.0) can be used to test the -0.0 case.
+			if v == types.Double(0.0) && math.Signbit(float64(v)) {
+				v = types.Double(0.0)
+			}
 			var buf [8]byte
 			binary.LittleEndian.PutUint64(buf[:], math.Float64bits(float64(v)))
 			h.Write(buf[:])
@@ -350,6 +354,21 @@ func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState,
 			// Release the concurrency slot when this call finishes or is cancelled.
 			defer func() { <-semaphore }()
 		}
+		if acs.completions != nil {
+			defer func() {
+				// Prioritize context cancellation to prevent racy completion signals.
+				if ctx.Err() != nil {
+					return
+				}
+				// Signal completion to the evaluator. Use a select with ctx.Done() to prevent
+				// the goroutine from leaking if the evaluator has already timed out or aborted.
+				select {
+				case acs.completions <- acs.callID:
+				case <-ctx.Done():
+				}
+			}()
+		}
+
 		ch := acs.impl(ctx, acs.argVals...)
 		// Early terminate with a CEL error when an implementation returns an empty channel.
 		if ch == nil {
@@ -359,7 +378,6 @@ func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState,
 				fmt.Sprintf("function %s returned an empty channel", acs.function))
 			return
 		}
-
 		// Wait for the async computation to finish or for the context to be cancelled.
 		select {
 		case r := <-ch:
@@ -368,14 +386,6 @@ func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState,
 			acs.mu.Unlock()
 			if observer != nil {
 				observer.OnCallFinished(acs.callID, acs.function, acs.overload, r)
-			}
-			if acs.completions != nil {
-				// Signal completion to the evaluator. Use a select with ctx.Done() to prevent
-				// the goroutine from leaking if the evaluator has already timed out or aborted.
-				select {
-				case acs.completions <- acs.callID:
-				case <-ctx.Done():
-				}
 			}
 		case <-ctx.Done():
 			// Evaluation context cancelled before the async operation completed.

--- a/interpreter/async.go
+++ b/interpreter/async.go
@@ -1,0 +1,428 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+import (
+	"context"
+	"encoding/binary"
+	"hash/fnv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/cel-go/common/functions"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// Async extension function support.
+//
+// CEL supports `types.Unknown` as a first-class value, and concurrent (async) function execution
+// in CEL invokes a stub function which checks for the presence of an existing result which matches
+// the function call and call arguments, or which records the 'unexecuted' function and call arguments
+// for concurrent execution in a later phase if the result is `types.Unknown` and indicates the
+// expression ids of the functions necessary to advance the execution.
+//
+// This call pattern is repeated iteratively until there are either no more functions to call or no
+// progress is made toward resolving the unknowns.
+
+// AsyncObserver provides callbacks for monitoring the lifecycle of asynchronous function calls.
+//
+// Implementations must be safe for concurrent use: OnCallStarted is invoked from the evaluator
+// goroutine when a call is launched, while OnCallFinished is invoked from the call's own goroutine
+// when it completes. The two callbacks therefore run on different goroutines, and OnCallFinished
+// callbacks for distinct calls may run concurrently with each other.
+type AsyncObserver interface {
+	// OnCallStarted is called when an asynchronous function is first launched.
+	OnCallStarted(callID int64, function, overload string, args []ref.Val)
+	// OnCallFinished is called when an asynchronous function completes.
+	OnCallFinished(callID int64, function, overload string, res ref.Val)
+}
+
+// AsyncCall describes a pending or completed asynchronous function call.
+type AsyncCall interface {
+	// CallID returns the unique identifier for this async call invocation.
+	CallID() int64
+	// Function returns the name of the function being called.
+	Function() string
+	// Overload returns the specific overload ID being invoked.
+	Overload() string
+}
+
+// evalAsyncFunc is the planned Interpretable for an asynchronous function call.
+type evalAsyncFunc struct {
+	id       int64
+	function string
+	overload string
+	args     []InterpretableV2
+	impl     functions.AsyncOp
+}
+
+// ID implements the Interpretable interface method.
+func (fn *evalAsyncFunc) ID() int64 {
+	return fn.id
+}
+
+// Function returns the name of the function being invoked.
+func (fn *evalAsyncFunc) Function() string {
+	return fn.function
+}
+
+// OverloadID returns the overload id of the function being invoked.
+func (fn *evalAsyncFunc) OverloadID() string {
+	return fn.overload
+}
+
+// Args returns the argument Interpretables for the function call.
+func (fn *evalAsyncFunc) Args() []InterpretableV2 {
+	return fn.args
+}
+
+// Eval implements the Interpretable interface method.
+func (fn *evalAsyncFunc) Eval(vars Activation) ref.Val {
+	return fn.Exec(AsFrame(vars))
+}
+
+// Exec implements the InterpretableV2 interface method.
+func (fn *evalAsyncFunc) Exec(frame *ExecutionFrame) ref.Val {
+	argVals := make([]ref.Val, len(fn.args))
+	// Early return if any argument to the function is unknown or error.
+	for i, arg := range fn.args {
+		argVals[i] = arg.Exec(frame)
+		if types.IsUnknownOrError(argVals[i]) {
+			return argVals[i]
+		}
+	}
+	result := frame.ComputeResult(fn.ID(), fn.Function(), fn.OverloadID(), fn.impl, argVals)
+	return types.LabelErrNode(fn.id, result)
+}
+
+// asyncCallStateTracker manages async call states across re-evaluations of a single program.
+type asyncCallStateTracker struct {
+	mu sync.RWMutex
+	// calls buckets call states by a composite hash of (node id, overload, string/bool args).
+	// A single AST node id may host many concurrently-live calls when it is evaluated inside a
+	// comprehension (once per element with different arguments), so each bucket may hold more
+	// than one state. The exact match within a bucket is resolved via asyncCallState.equals,
+	// which applies CEL's full equality semantics to the arguments.
+	//
+	// Caveat for future implementers: dedup relies on argument equality being reflexive. CEL
+	// values whose equality is not reflexive — notably NaN doubles, where NaN != NaN — will never
+	// match a previously registered state. Such a call is therefore relaunched on every
+	// re-evaluation pass and never converges (the evaluation terminates only via context
+	// cancellation/deadline). This is inherent to the CEL equality model and is not special-cased
+	// here; if it ever needs handling, give equals an identity-based fast path before equality.
+	calls        map[uint64][]*asyncCallState
+	callsByID    map[int64]*asyncCallState
+	nextCallID   atomic.Int64
+	pendingCalls atomic.Int32
+}
+
+func newAsyncCallStateTracker() *asyncCallStateTracker {
+	return &asyncCallStateTracker{
+		calls:     make(map[uint64][]*asyncCallState),
+		callsByID: make(map[int64]*asyncCallState),
+	}
+}
+
+var (
+	hashZeroMarker      = []byte{0}
+	hashStringMarker    = []byte{'s'}
+	hashBoolTrueMarker  = []byte{'b', 1}
+	hashBoolFalseMarker = []byte{'b', 0}
+	hashDefaultMarker   = []byte{'x'}
+)
+
+// hashCall computes the composite bucket key for an async call.
+//
+// Only string and bool argument values contribute to the hash. Numeric and more complex types
+// rely on a richer notion of equivalence (e.g. cross-type numeric equality, unordered maps) that
+// a byte-level hash cannot capture safely, so they are deliberately excluded from the key and are
+// instead disambiguated within the bucket by asyncCallState.equals.
+func hashCall(id int64, overload string, args []ref.Val) uint64 {
+	h := fnv.New64a()
+	var idBuf [8]byte
+	binary.LittleEndian.PutUint64(idBuf[:], uint64(id))
+	h.Write(idBuf[:])
+	h.Write([]byte(overload))
+	h.Write(hashZeroMarker)
+	for _, arg := range args {
+		switch v := arg.(type) {
+		case types.String:
+			h.Write(hashStringMarker)
+			h.Write([]byte(string(v)))
+		case types.Bool:
+			if bool(v) {
+				h.Write(hashBoolTrueMarker)
+			} else {
+				h.Write(hashBoolFalseMarker)
+			}
+		default:
+			// Value intentionally omitted; bucket membership falls back to equals.
+			h.Write(hashDefaultMarker)
+		}
+		// Separator to avoid cross-argument collisions, e.g. ("a", "bc") vs ("ab", "c").
+		h.Write(hashZeroMarker)
+	}
+	return h.Sum64()
+}
+
+// findInBucket returns the call state in the bucket matching the same node id and call identity,
+// or nil if no match is present.
+func findInBucket(bucket []*asyncCallState, id int64, want *asyncCallState) *asyncCallState {
+	for _, acs := range bucket {
+		if acs.id == id && acs.equals(want) {
+			return acs
+		}
+	}
+	return nil
+}
+
+// getOrCreate returns the existing call state for the (node id, args) tuple, or registers and
+// returns a new one. A newly registered call is assigned a unique callID and counted as pending.
+func (t *asyncCallStateTracker) getOrCreate(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp, completions chan<- int64) *asyncCallState {
+	key := hashCall(id, overload, argVals)
+	potentialState := newAsyncCallState(id, function, overload, argVals, impl)
+
+	t.mu.RLock()
+	acs := findInBucket(t.calls[key], id, potentialState)
+	t.mu.RUnlock()
+	if acs != nil {
+		return acs
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	// Check again in case it was created while waiting for the lock.
+	if acs := findInBucket(t.calls[key], id, potentialState); acs != nil {
+		return acs
+	}
+
+	// Assign a new unique call ID for this async call.
+	callID := t.nextCallID.Add(1)
+	potentialState.callID = callID
+	potentialState.completions = completions
+	t.calls[key] = append(t.calls[key], potentialState)
+	t.callsByID[callID] = potentialState
+	// Note: pendingCalls is incremented when the call is actually launched (see launch), not at
+	// registration, so that "pending" reflects in-flight calls and excludes calls deferred by the
+	// launch limiter. Counting deferred calls as pending would deadlock DrainAll.
+	return potentialState
+}
+
+func (t *asyncCallStateTracker) getByID(callID int64) *asyncCallState {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.callsByID[callID]
+}
+
+func (t *asyncCallStateTracker) pendingCount() int {
+	return int(t.pendingCalls.Load())
+}
+
+func (t *asyncCallStateTracker) notifyCompletion(_ int64) {
+	t.pendingCalls.Add(-1)
+}
+
+func newAsyncCallState(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp) *asyncCallState {
+	return &asyncCallState{
+		id:       id,
+		function: function,
+		overload: overload,
+		argVals:  argVals,
+		impl:     impl,
+	}
+}
+
+// asyncCallState tracks the result of a single async function call across multiple re-evaluations.
+type asyncCallState struct {
+	id       int64 // AST expression node ID where the call is defined.
+	callID   int64 // Unique incremental tracking ID assigned to this call.
+	function string
+	overload string
+	argVals  []ref.Val
+	impl     functions.AsyncOp
+
+	mu      sync.RWMutex
+	started bool
+	result  ref.Val
+
+	completions chan<- int64
+}
+
+// CallID returns the unique identifier for this async call invocation.
+func (acs *asyncCallState) CallID() int64 {
+	return acs.callID
+}
+
+// Function returns the name of the function being called.
+func (acs *asyncCallState) Function() string {
+	return acs.function
+}
+
+// Overload returns the specific overload ID being invoked.
+func (acs *asyncCallState) Overload() string {
+	return acs.overload
+}
+
+// launch returns a call's cached result, or starts the call (subject to the launch limiter) and
+// returns an Unknown referencing its callID while the result is pending.
+//
+// Admission control: when a concurrency semaphore is configured, a launch slot is reserved with a
+// non-blocking send. If no slot is free the call is left unstarted and an Unknown is returned; the
+// call is retried on a later re-evaluation pass once an in-flight call completes and frees a slot.
+// The reservation is non-blocking on purpose — the evaluator runs on a single goroutine, and
+// blocking it here while completing calls block on an undrained completion channel would deadlock.
+// The slot is held by the launched goroutine and released when it exits, so the number of live
+// async goroutines is bounded by the semaphore capacity.
+func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState, observer AsyncObserver, semaphore chan struct{}) ref.Val {
+	acs.mu.RLock()
+	res := acs.result
+	started := acs.started
+	acs.mu.RUnlock()
+	if res != nil {
+		return res
+	}
+	if started {
+		return types.NewUnknown(acs.callID, nil)
+	}
+
+	if semaphore != nil {
+		// Non-blocking try-acquire of a concurrency slot. If the semaphore channel is full,
+		// we immediately fallback to default to return an Unknown. This prevents blocking
+		// the single-threaded evaluator, allowing it to continue with other evaluations.
+		// The call will be retried in a future evaluation pass.
+		select {
+		case semaphore <- struct{}{}:
+		default:
+			// No launch slot available; defer to a later pass.
+			return types.NewUnknown(acs.callID, nil)
+		}
+	}
+	acs.mu.Lock()
+	if acs.started || acs.result != nil {
+		// Defensive: the evaluator is single-threaded so this should not happen, but if it does,
+		// return the reserved slot rather than leak it.
+		acs.mu.Unlock()
+		if semaphore != nil {
+			<-semaphore
+		}
+		return types.NewUnknown(acs.callID, nil)
+	}
+	acs.started = true
+	acs.mu.Unlock()
+	t.pendingCalls.Add(1)
+
+	if observer != nil {
+		observer.OnCallStarted(acs.callID, acs.function, acs.overload, acs.argVals)
+	}
+	go func() {
+		if semaphore != nil {
+			// Release the concurrency slot when this call finishes or is cancelled.
+			defer func() { <-semaphore }()
+		}
+		ch := acs.impl(ctx, acs.argVals...)
+		// Wait for the async computation to finish or for the context to be cancelled.
+		select {
+		case r := <-ch:
+			acs.mu.Lock()
+			acs.result = r
+			acs.mu.Unlock()
+			if observer != nil {
+				observer.OnCallFinished(acs.callID, acs.function, acs.overload, r)
+			}
+			if acs.completions != nil {
+				// Signal completion to the evaluator. Use a select with ctx.Done() to prevent
+				// the goroutine from leaking if the evaluator has already timed out or aborted.
+				select {
+				case acs.completions <- acs.callID:
+				case <-ctx.Done():
+				}
+			}
+		case <-ctx.Done():
+			// Evaluation context cancelled before the async operation completed.
+		}
+	}()
+	return types.NewUnknown(acs.callID, nil)
+}
+
+// equals reports whether two call states refer to the same function, overload, and arguments.
+func (acs *asyncCallState) equals(other *asyncCallState) bool {
+	if acs == nil || other == nil {
+		return false
+	}
+	if acs.function != other.function || acs.overload != other.overload {
+		return false
+	}
+	if len(acs.argVals) != len(other.argVals) {
+		return false
+	}
+	for i, v := range acs.argVals {
+		if types.Equal(v, other.argVals[i]) != types.True {
+			return false
+		}
+	}
+	return true
+}
+
+// trackerShrinkThreshold is the entry count above which a released tracker's maps are reallocated
+// rather than cleared in place, so the pool does not retain a large backing array indefinitely.
+const trackerShrinkThreshold = 1024
+
+// asyncCallStateTrackerPool provides a synchronized pool of asyncCallStateTrackers.
+type asyncCallTrackerPool struct {
+	sync.Pool
+}
+
+func (pool *asyncCallTrackerPool) create() *asyncCallStateTracker {
+	return pool.Get().(*asyncCallStateTracker)
+}
+
+func (pool *asyncCallTrackerPool) release(tracker *asyncCallStateTracker) {
+	if tracker == nil {
+		return
+	}
+	tracker.mu.Lock()
+	// Clearing with delete reuses the backing arrays, which is ideal for the common case but pins
+	// a large allocation in the pool after a wide fan-out (e.g. an async call over a big list).
+	// Past a threshold, reallocate so the high-water-mark memory is released to the GC instead of
+	// being retained by the pooled tracker.
+	if len(tracker.calls) > trackerShrinkThreshold || len(tracker.callsByID) > trackerShrinkThreshold {
+		tracker.calls = make(map[uint64][]*asyncCallState)
+		tracker.callsByID = make(map[int64]*asyncCallState)
+	} else {
+		for k := range tracker.calls {
+			delete(tracker.calls, k)
+		}
+		for k := range tracker.callsByID {
+			delete(tracker.callsByID, k)
+		}
+	}
+	tracker.pendingCalls.Store(0)
+	tracker.nextCallID.Store(0)
+	tracker.mu.Unlock()
+	pool.Pool.Put(tracker)
+}
+
+func newAsyncCallTrackerPool() *asyncCallTrackerPool {
+	return &asyncCallTrackerPool{
+		Pool: sync.Pool{
+			New: func() any {
+				return newAsyncCallStateTracker()
+			},
+		},
+	}
+}
+
+var asyncCallStateTrackerPool = newAsyncCallTrackerPool()

--- a/interpreter/async.go
+++ b/interpreter/async.go
@@ -213,7 +213,7 @@ func findInBucket(bucket []*asyncCallState, id int64, want *asyncCallState) *asy
 
 // getOrCreate returns the existing call state for the (node id, args) tuple, or registers and
 // returns a new one. A newly registered call is assigned a unique callID and counted as pending.
-func (t *asyncCallStateTracker) getOrCreate(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp, completions chan<- int64) *asyncCallState {
+func (t *asyncCallStateTracker) getOrCreate(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp, gate *asyncGate) *asyncCallState {
 	key := hashCall(id, overload, argVals)
 	potentialState := newAsyncCallState(id, function, overload, argVals, impl)
 
@@ -234,7 +234,7 @@ func (t *asyncCallStateTracker) getOrCreate(id int64, function, overload string,
 	// Assign a new unique call ID for this async call.
 	callID := t.nextCallID.Add(1)
 	potentialState.callID = callID
-	potentialState.completions = completions
+	potentialState.gate = gate
 	t.calls[key] = append(t.calls[key], potentialState)
 	t.callsByID[callID] = potentialState
 	// Note: pendingCalls is incremented when the call is actually launched (see launch), not at
@@ -247,14 +247,6 @@ func (t *asyncCallStateTracker) getByID(callID int64) *asyncCallState {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.callsByID[callID]
-}
-
-func (t *asyncCallStateTracker) pendingCount() int {
-	return int(t.pendingCalls.Load())
-}
-
-func (t *asyncCallStateTracker) notifyCompletion(_ int64) {
-	t.pendingCalls.Add(-1)
 }
 
 func newAsyncCallState(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp) *asyncCallState {
@@ -280,7 +272,7 @@ type asyncCallState struct {
 	started bool
 	result  ref.Val
 
-	completions chan<- int64
+	gate *asyncGate
 }
 
 // CallID returns the unique identifier for this async call invocation.
@@ -308,7 +300,7 @@ func (acs *asyncCallState) Overload() string {
 // blocking it here while completing calls block on an undrained completion channel would deadlock.
 // The slot is held by the launched goroutine and released when it exits, so the number of live
 // async goroutines is bounded by the semaphore capacity.
-func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState, observer AsyncObserver, semaphore chan struct{}) ref.Val {
+func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState, observer AsyncObserver) ref.Val {
 	acs.mu.RLock()
 	res := acs.result
 	started := acs.started
@@ -320,54 +312,26 @@ func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState,
 		return types.NewUnknown(acs.callID, nil)
 	}
 
-	if semaphore != nil {
-		// Non-blocking try-acquire of a concurrency slot. If the semaphore channel is full,
-		// we immediately fallback to default to return an Unknown. This prevents blocking
-		// the single-threaded evaluator, allowing it to continue with other evaluations.
-		// The call will be retried in a future evaluation pass.
-		select {
-		case semaphore <- struct{}{}:
-		default:
-			// No launch slot available; defer to a later pass.
-			return types.NewUnknown(acs.callID, nil)
-		}
+	gate := acs.gate
+	if !gate.TryAcquire() {
+		return types.NewUnknown(acs.callID, nil)
 	}
 	acs.mu.Lock()
 	if acs.started || acs.result != nil {
 		// Defensive: the evaluator is single-threaded so this should not happen, but if it does,
 		// return the reserved slot rather than leak it.
 		acs.mu.Unlock()
-		if semaphore != nil {
-			<-semaphore
-		}
+		gate.Release()
 		return types.NewUnknown(acs.callID, nil)
 	}
 	acs.started = true
 	acs.mu.Unlock()
-	t.pendingCalls.Add(1)
 
 	if observer != nil {
 		observer.OnCallStarted(acs.callID, acs.function, acs.overload, acs.argVals)
 	}
 	go func() {
-		if semaphore != nil {
-			// Release the concurrency slot when this call finishes or is cancelled.
-			defer func() { <-semaphore }()
-		}
-		if acs.completions != nil {
-			defer func() {
-				// Prioritize context cancellation to prevent racy completion signals.
-				if ctx.Err() != nil {
-					return
-				}
-				// Signal completion to the evaluator. Use a select with ctx.Done() to prevent
-				// the goroutine from leaking if the evaluator has already timed out or aborted.
-				select {
-				case acs.completions <- acs.callID:
-				case <-ctx.Done():
-				}
-			}()
-		}
+		defer gate.Complete(ctx, acs.callID)
 
 		ch := acs.impl(ctx, acs.argVals...)
 		// Early terminate with a CEL error when an implementation returns an empty channel.
@@ -454,8 +418,8 @@ func (pool *asyncCallTrackerPool) release(tracker *asyncCallStateTracker) {
 			delete(tracker.callsByID, k)
 		}
 	}
-	tracker.pendingCalls.Store(0)
 	tracker.nextCallID.Store(0)
+	tracker.pendingCalls.Store(0)
 	tracker.mu.Unlock()
 	pool.Pool.Put(tracker)
 }
@@ -471,3 +435,78 @@ func newAsyncCallTrackerPool() *asyncCallTrackerPool {
 }
 
 var asyncCallStateTrackerPool = newAsyncCallTrackerPool()
+
+// asyncGate coordinates async call admission control and completion signaling.
+type asyncGate struct {
+	semaphore   chan struct{}
+	completions chan<- int64
+	activeCalls atomic.Int32
+}
+
+func newAsyncGate(maxConcurrency int, completions chan<- int64) *asyncGate {
+	var sem chan struct{}
+	if maxConcurrency > 0 {
+		sem = make(chan struct{}, maxConcurrency)
+	}
+	return &asyncGate{
+		semaphore:   sem,
+		completions: completions,
+	}
+}
+
+// TryAcquire attempts to acquire a concurrency slot and increments the active calls count.
+func (g *asyncGate) TryAcquire() bool {
+	if g == nil {
+		return true
+	}
+	if g.semaphore != nil {
+		select {
+		case g.semaphore <- struct{}{}:
+		default:
+			return false
+		}
+	}
+	g.activeCalls.Add(1)
+	return true
+}
+
+// Release releases a concurrency slot and decrements the active calls count (used for defensive recovery).
+func (g *asyncGate) Release() {
+	if g == nil {
+		return
+	}
+	if g.semaphore != nil {
+		select {
+		case <-g.semaphore:
+		default:
+		}
+	}
+	g.activeCalls.Add(-1)
+}
+
+// Complete releases a concurrency slot and notifies completions.
+func (g *asyncGate) Complete(ctx context.Context, callID int64) {
+	if g == nil {
+		return
+	}
+	g.Release()
+
+	if g.completions != nil {
+		// Prioritize context cancellation to prevent racy completion signals.
+		if ctx.Err() != nil {
+			return
+		}
+		select {
+		case g.completions <- callID:
+		case <-ctx.Done():
+		}
+	}
+}
+
+// ActiveCalls returns the number of active asynchronous calls.
+func (g *asyncGate) ActiveCalls() int {
+	if g == nil {
+		return 0
+	}
+	return int(g.activeCalls.Load())
+}

--- a/interpreter/async.go
+++ b/interpreter/async.go
@@ -350,6 +350,9 @@ func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState,
 			}
 		case <-ctx.Done():
 			// Evaluation context cancelled before the async operation completed.
+			if observer != nil {
+				observer.OnCallFinished(acs.callID, acs.function, acs.overload, types.WrapErr(context.Cause(ctx)))
+			}
 		}
 	}()
 	return types.NewUnknown(acs.callID, nil)

--- a/interpreter/async.go
+++ b/interpreter/async.go
@@ -328,7 +328,12 @@ func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState,
 		observer.OnCallStarted(acs.callID, acs.function, acs.overload, acs.argVals)
 	}
 	go func() {
-		defer gate.Complete(ctx, acs.callID)
+		defer func() {
+			if observer != nil {
+				observer.OnCallFinished(acs.callID, acs.function, acs.overload, acs.result)
+			}
+			gate.Complete(ctx, acs.callID)
+		}()
 
 		ch := acs.impl(ctx, acs.argVals...)
 		// Early terminate with a CEL error when an implementation returns an empty channel.
@@ -343,16 +348,13 @@ func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState,
 		select {
 		case r := <-ch:
 			acs.mu.Lock()
+			defer acs.mu.Unlock()
 			acs.result = r
-			acs.mu.Unlock()
-			if observer != nil {
-				observer.OnCallFinished(acs.callID, acs.function, acs.overload, r)
-			}
 		case <-ctx.Done():
 			// Evaluation context cancelled before the async operation completed.
-			if observer != nil {
-				observer.OnCallFinished(acs.callID, acs.function, acs.overload, types.WrapErr(context.Cause(ctx)))
-			}
+			acs.mu.Lock()
+			defer acs.mu.Unlock()
+			acs.result = types.WrapErr(context.Cause(ctx))
 		}
 	}()
 	return types.NewUnknown(acs.callID, nil)

--- a/interpreter/async.go
+++ b/interpreter/async.go
@@ -17,7 +17,9 @@ package interpreter
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"hash/fnv"
+	"math"
 	"sync"
 	"sync/atomic"
 
@@ -141,6 +143,7 @@ var (
 	hashStringMarker    = []byte{'s'}
 	hashBoolTrueMarker  = []byte{'b', 1}
 	hashBoolFalseMarker = []byte{'b', 0}
+	hashNumberMarker    = []byte{'n'}
 	hashDefaultMarker   = []byte{'x'}
 )
 
@@ -168,6 +171,21 @@ func hashCall(id int64, overload string, args []ref.Val) uint64 {
 			} else {
 				h.Write(hashBoolFalseMarker)
 			}
+		case types.Int:
+			h.Write(hashNumberMarker)
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], math.Float64bits(float64(v)))
+			h.Write(buf[:])
+		case types.Uint:
+			h.Write(hashNumberMarker)
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], math.Float64bits(float64(v)))
+			h.Write(buf[:])
+		case types.Double:
+			h.Write(hashNumberMarker)
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], math.Float64bits(float64(v)))
+			h.Write(buf[:])
 		default:
 			// Value intentionally omitted; bucket membership falls back to equals.
 			h.Write(hashDefaultMarker)
@@ -333,6 +351,15 @@ func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState,
 			defer func() { <-semaphore }()
 		}
 		ch := acs.impl(ctx, acs.argVals...)
+		// Early terminate with a CEL error when an implementation returns an empty channel.
+		if ch == nil {
+			acs.mu.Lock()
+			defer acs.mu.Unlock()
+			acs.result = types.NewErrFromString(
+				fmt.Sprintf("function %s returned an empty channel", acs.function))
+			return
+		}
+
 		// Wait for the async computation to finish or for the context to be cancelled.
 		select {
 		case r := <-ch:
@@ -369,9 +396,17 @@ func (acs *asyncCallState) equals(other *asyncCallState) bool {
 		return false
 	}
 	for i, v := range acs.argVals {
-		if types.Equal(v, other.argVals[i]) != types.True {
-			return false
+		otherV := other.argVals[i]
+		if types.Equal(v, otherV) == types.True {
+			continue
 		}
+		if n, ok := v.(types.Double); ok {
+			// Treat NaN as equivalent for the sake of function dispatch equality.
+			if otherN, ok := otherV.(types.Double); ok && math.IsNaN(float64(n)) && math.IsNaN(float64(otherN)) {
+				continue
+			}
+		}
+		return false
 	}
 	return true
 }

--- a/interpreter/async.go
+++ b/interpreter/async.go
@@ -118,12 +118,11 @@ type asyncCallStateTracker struct {
 	// calls buckets call states by a composite hash of (node id, overload, string/int/double/uint/bool args).
 	// A single AST node id may host many concurrently-live calls when it is evaluated inside a
 	// comprehension (once per element with different arguments), so each bucket may hold more
-	// than one state. The exact match within a bucket is resolved via asyncCallState.equals,
+	// than one state. The exact match within a bucket is resolved via asyncCallState.matches,
 	// which applies CEL's full equality semantics to the arguments.
-	calls        map[uint64][]*asyncCallState
-	callsByID    map[int64]*asyncCallState
-	nextCallID   atomic.Int64
-	pendingCalls atomic.Int32
+	calls      map[uint64][]*asyncCallState
+	callsByID  map[int64]*asyncCallState
+	nextCallID atomic.Int64
 }
 
 func newAsyncCallStateTracker() *asyncCallStateTracker {
@@ -147,7 +146,7 @@ var (
 // Only string, int, double, uint, and bool argument values contribute to the hash. More complex types
 // rely on a richer notion of equivalence (e.g. unordered maps, proto equality, custom types)
 // that a byte-level hash cannot capture safely, so they are intentionally excluded from the key
-// and are instead disambiguated within the bucket by asyncCallState.equals.
+// and are instead disambiguated within the bucket by asyncCallState.matches.
 func hashCall(id int64, overload string, args []ref.Val) uint64 {
 	h := fnv.New64a()
 	var idBuf [8]byte
@@ -180,6 +179,7 @@ func hashCall(id int64, overload string, args []ref.Val) uint64 {
 			h.Write(hashNumberMarker)
 			if math.IsNaN(float64(v)) {
 				h.Write([]byte("NaN"))
+				h.Write(hashZeroMarker)
 				continue
 			}
 			// Normalize -0.0 to 0.0. Go will treat -0.0 as 0.0 at compile time,
@@ -191,7 +191,7 @@ func hashCall(id int64, overload string, args []ref.Val) uint64 {
 			binary.LittleEndian.PutUint64(buf[:], math.Float64bits(float64(v)))
 			h.Write(buf[:])
 		default:
-			// Value intentionally omitted; bucket membership falls back to equals.
+			// Value intentionally omitted; bucket membership falls back to matches.
 			h.Write(hashDefaultMarker)
 		}
 		// Separator to avoid cross-argument collisions, e.g. ("a", "bc") vs ("ab", "c").
@@ -202,9 +202,9 @@ func hashCall(id int64, overload string, args []ref.Val) uint64 {
 
 // findInBucket returns the call state in the bucket matching the same node id and call identity,
 // or nil if no match is present.
-func findInBucket(bucket []*asyncCallState, id int64, want *asyncCallState) *asyncCallState {
+func findInBucket(bucket []*asyncCallState, id int64, function, overload string, args []ref.Val) *asyncCallState {
 	for _, acs := range bucket {
-		if acs.id == id && acs.equals(want) {
+		if acs.matches(id, function, overload, args) {
 			return acs
 		}
 	}
@@ -215,10 +215,9 @@ func findInBucket(bucket []*asyncCallState, id int64, want *asyncCallState) *asy
 // returns a new one. A newly registered call is assigned a unique callID and counted as pending.
 func (t *asyncCallStateTracker) getOrCreate(id int64, function, overload string, argVals []ref.Val, impl functions.AsyncOp, gate *asyncGate) *asyncCallState {
 	key := hashCall(id, overload, argVals)
-	potentialState := newAsyncCallState(id, function, overload, argVals, impl)
 
 	t.mu.RLock()
-	acs := findInBucket(t.calls[key], id, potentialState)
+	acs := findInBucket(t.calls[key], id, function, overload, argVals)
 	t.mu.RUnlock()
 	if acs != nil {
 		return acs
@@ -227,20 +226,18 @@ func (t *asyncCallStateTracker) getOrCreate(id int64, function, overload string,
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	// Check again in case it was created while waiting for the lock.
-	if acs := findInBucket(t.calls[key], id, potentialState); acs != nil {
+	if acs := findInBucket(t.calls[key], id, function, overload, argVals); acs != nil {
 		return acs
 	}
 
 	// Assign a new unique call ID for this async call.
+	acs = newAsyncCallState(id, function, overload, argVals, impl)
 	callID := t.nextCallID.Add(1)
-	potentialState.callID = callID
-	potentialState.gate = gate
-	t.calls[key] = append(t.calls[key], potentialState)
-	t.callsByID[callID] = potentialState
-	// Note: pendingCalls is incremented when the call is actually launched (see launch), not at
-	// registration, so that "pending" reflects in-flight calls and excludes calls deferred by the
-	// launch limiter. Counting deferred calls as pending would deadlock DrainAll.
-	return potentialState
+	acs.callID = callID
+	acs.gate = gate
+	t.calls[key] = append(t.calls[key], acs)
+	t.callsByID[callID] = acs
+	return acs
 }
 
 func (t *asyncCallStateTracker) getByID(callID int64) *asyncCallState {
@@ -358,19 +355,19 @@ func (t *asyncCallStateTracker) launch(ctx context.Context, acs *asyncCallState,
 	return types.NewUnknown(acs.callID, nil)
 }
 
-// equals reports whether two call states refer to the same function, overload, and arguments.
-func (acs *asyncCallState) equals(other *asyncCallState) bool {
-	if acs == nil || other == nil {
+// matches reports whether two call states refer to the same function, overload, and arguments.
+func (acs *asyncCallState) matches(id int64, function, overload string, args []ref.Val) bool {
+	if acs == nil {
 		return false
 	}
-	if acs.function != other.function || acs.overload != other.overload {
+	if acs.id != id || acs.function != function || acs.overload != overload {
 		return false
 	}
-	if len(acs.argVals) != len(other.argVals) {
+	if len(acs.argVals) != len(args) {
 		return false
 	}
 	for i, v := range acs.argVals {
-		otherV := other.argVals[i]
+		otherV := args[i]
 		if types.Equal(v, otherV) == types.True {
 			continue
 		}
@@ -419,7 +416,6 @@ func (pool *asyncCallTrackerPool) release(tracker *asyncCallStateTracker) {
 		}
 	}
 	tracker.nextCallID.Store(0)
-	tracker.pendingCalls.Store(0)
 	tracker.mu.Unlock()
 	pool.Pool.Put(tracker)
 }

--- a/interpreter/async_test.go
+++ b/interpreter/async_test.go
@@ -70,8 +70,7 @@ func awaitResult(t *testing.T, frame *ExecutionFrame, completions <-chan int64, 
 			return res
 		}
 		select {
-		case callID := <-completions:
-			frame.NotifyCompletion(callID)
+		case <-completions:
 		case <-deadline:
 			t.Fatal("timed out waiting for async result")
 		}
@@ -89,8 +88,8 @@ func TestComputeResultWithoutContext(t *testing.T) {
 	if !types.IsError(res) {
 		t.Errorf("ComputeResult() got %v, wanted error when tracking uninitialized", res)
 	}
-	if frame.PendingAsyncCalls() != 0 {
-		t.Errorf("PendingAsyncCalls() = %d, wanted 0", frame.PendingAsyncCalls())
+	if frame.ActiveAsyncCalls() != 0 {
+		t.Errorf("ActiveAsyncCalls() = %d, wanted 0", frame.ActiveAsyncCalls())
 	}
 	if call := frame.AsyncCall(1); call != nil {
 		t.Errorf("AsyncCall() = %v, wanted nil", call)
@@ -124,11 +123,12 @@ func TestTrackerDedupAndCallIDs(t *testing.T) {
 	// process-global frame/tracker pools used by ExecutionFrame.
 	tracker := newAsyncCallStateTracker()
 	completions := make(chan int64, 4)
+	gate := newAsyncGate(0, completions)
 	impl := asyncReturning(types.Int(1), nil)
 
 	// Same node id, same args, invoked repeatedly: must dedup to a single registered call.
-	a1 := tracker.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(1)}, impl, completions)
-	a2 := tracker.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(1)}, impl, completions)
+	a1 := tracker.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(1)}, impl, gate)
+	a2 := tracker.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(1)}, impl, gate)
 	if a1 != a2 {
 		t.Error("getOrCreate returned distinct states for identical (id, args)")
 	}
@@ -140,7 +140,7 @@ func TestTrackerDedupAndCallIDs(t *testing.T) {
 	}
 
 	// Same node id, different args: a new call must be registered (re-evaluation with new inputs).
-	a3 := tracker.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(2)}, impl, completions)
+	a3 := tracker.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(2)}, impl, gate)
 	if a3.CallID() == a1.CallID() {
 		t.Error("arg change reused the prior callID, wanted a fresh call")
 	}
@@ -148,8 +148,8 @@ func TestTrackerDedupAndCallIDs(t *testing.T) {
 		t.Errorf("getByID(%d) did not return the second registered call", a3.CallID())
 	}
 	// Registration alone does not mark a call as in-flight; pending counts launched calls only.
-	if got := tracker.pendingCount(); got != 0 {
-		t.Errorf("pendingCount() after registration only = %d, wanted 0", got)
+	if got := gate.ActiveCalls(); got != 0 {
+		t.Errorf("ActiveCalls() after registration only = %d, wanted 0", got)
 	}
 }
 
@@ -285,6 +285,7 @@ func TestTrackerComprehensionReuse(t *testing.T) {
 	// relaunch every iteration and never converge.
 	tracker := newAsyncCallStateTracker()
 	completions := make(chan int64, 8)
+	gate := newAsyncGate(0, completions)
 	impl := asyncReturning(types.Int(0), nil)
 	const id = int64(1)
 
@@ -295,7 +296,7 @@ func TestTrackerComprehensionReuse(t *testing.T) {
 	}
 	states := make([]*asyncCallState, len(args))
 	for i, a := range args {
-		states[i] = tracker.getOrCreate(id, "fn", "fn_int", a, impl, completions)
+		states[i] = tracker.getOrCreate(id, "fn", "fn_int", a, impl, gate)
 	}
 
 	// Each distinct argument set is a distinct, uniquely-identified call.
@@ -310,14 +311,14 @@ func TestTrackerComprehensionReuse(t *testing.T) {
 	// Re-evaluation: every prior (id, args) tuple must resolve to its existing state and must
 	// not register a new call.
 	for i, a := range args {
-		if got := tracker.getOrCreate(id, "fn", "fn_int", a, impl, completions); got != states[i] {
+		if got := tracker.getOrCreate(id, "fn", "fn_int", a, impl, gate); got != states[i] {
 			t.Errorf("re-lookup of args %v returned a new state, wanted the existing one", a)
 		}
 	}
 
 	// Identical string arguments at the same node dedup to a single call.
-	s1 := tracker.getOrCreate(2, "fn", "fn_str", []ref.Val{types.String("k")}, impl, completions)
-	s2 := tracker.getOrCreate(2, "fn", "fn_str", []ref.Val{types.String("k")}, impl, completions)
+	s1 := tracker.getOrCreate(2, "fn", "fn_str", []ref.Val{types.String("k")}, impl, gate)
+	s2 := tracker.getOrCreate(2, "fn", "fn_str", []ref.Val{types.String("k")}, impl, gate)
 	if s1 != s2 {
 		t.Error("identical string args did not dedup to a single call")
 	}
@@ -326,10 +327,11 @@ func TestTrackerComprehensionReuse(t *testing.T) {
 func TestTrackerRegistrationLookup(t *testing.T) {
 	tracker := newAsyncCallStateTracker()
 	completions := make(chan int64, 2)
+	gate := newAsyncGate(0, completions)
 	impl := asyncReturning(types.Int(1), nil)
 
-	a := tracker.getOrCreate(1, "fn", "a", []ref.Val{types.Int(1)}, impl, completions)
-	b := tracker.getOrCreate(2, "fn", "b", []ref.Val{types.Int(2)}, impl, completions)
+	a := tracker.getOrCreate(1, "fn", "a", []ref.Val{types.Int(1)}, impl, gate)
+	b := tracker.getOrCreate(2, "fn", "b", []ref.Val{types.Int(2)}, impl, gate)
 
 	// Registered calls must be retrievable by callID.
 	for _, want := range []*asyncCallState{a, b} {
@@ -415,7 +417,7 @@ func TestLaunchAdmissionAndBounding(t *testing.T) {
 
 	// A single evaluation pass: attempt to launch all calls (distinct node ids).
 	pass := func() {
-		for i := 0; i < total; i++ {
+		for i := range total {
 			frame.ComputeResult(int64(i+1), "fn", "fn_int", impl, []ref.Val{types.Int(int64(i))})
 		}
 	}
@@ -423,8 +425,8 @@ func TestLaunchAdmissionAndBounding(t *testing.T) {
 	// First pass admits only `limit` launches; the rest are deferred. pending is updated
 	// synchronously as calls are admitted, so it must equal the limit immediately.
 	pass()
-	if got := frame.PendingAsyncCalls(); got != limit {
-		t.Fatalf("PendingAsyncCalls() after first pass = %d, wanted %d", got, limit)
+	if got := frame.ActiveAsyncCalls(); got != limit {
+		t.Fatalf("ActiveAsyncCalls() after first pass = %d, wanted %d", got, limit)
 	}
 
 	// Drive completions and re-evaluate until every call has resolved, simulating ConcurrentEval.
@@ -435,7 +437,6 @@ func TestLaunchAdmissionAndBounding(t *testing.T) {
 		pass() // re-evaluate: launch any newly-admissible calls
 		select {
 		case id := <-completions:
-			frame.NotifyCompletion(id)
 			done[id] = true
 		case <-deadline:
 			t.Fatalf("only %d/%d calls completed; maxLive=%d", len(done), total, maxLive.Load())
@@ -445,8 +446,8 @@ func TestLaunchAdmissionAndBounding(t *testing.T) {
 	if got := maxLive.Load(); got > limit {
 		t.Errorf("max concurrent launches = %d, wanted <= %d", got, limit)
 	}
-	if got := frame.PendingAsyncCalls(); got != 0 {
-		t.Errorf("PendingAsyncCalls() after all completions = %d, wanted 0", got)
+	if got := frame.ActiveAsyncCalls(); got != 0 {
+		t.Errorf("ActiveAsyncCalls() after all completions = %d, wanted 0", got)
 	}
 }
 
@@ -461,12 +462,17 @@ func TestLaunchUnlimitedWhenNoSemaphore(t *testing.T) {
 		t.Fatalf("SetCompletions() failed: %v", err)
 	}
 
+	release := make(chan struct{})
+	defer close(release)
+	var live, maxLive atomic.Int32
+	impl := asyncControllable(release, &live, &maxLive)
+
 	const total = 5
 	for i := 0; i < total; i++ {
-		frame.ComputeResult(int64(i+1), "fn", "fn_int", asyncReturning(types.Int(int64(i)), nil), []ref.Val{types.Int(int64(i))})
+		frame.ComputeResult(int64(i+1), "fn", "fn_int", impl, []ref.Val{types.Int(int64(i))})
 	}
-	if got := frame.PendingAsyncCalls(); got != total {
-		t.Errorf("PendingAsyncCalls() with no limit = %d, wanted %d", got, total)
+	if got := frame.ActiveAsyncCalls(); got != total {
+		t.Errorf("ActiveAsyncCalls() with no limit = %d, wanted %d", got, total)
 	}
 }
 
@@ -514,20 +520,16 @@ func TestAsyncCallStateCancellation(t *testing.T) {
 func TestAsyncTrackerPoolReleaseClearsState(t *testing.T) {
 	tracker := newAsyncCallStateTracker()
 	completions := make(chan int64, 4)
+	gate := newAsyncGate(0, completions)
 	for i := int64(1); i <= 3; i++ {
-		tracker.getOrCreate(i, "fn", "ov", []ref.Val{types.Int(i)}, asyncReturning(types.Int(i), nil), completions)
+		tracker.getOrCreate(i, "fn", "ov", []ref.Val{types.Int(i)}, asyncReturning(types.Int(i), nil), gate)
 	}
-	// Simulate launched calls so the release path is exercised against non-zero in-flight state.
-	tracker.pendingCalls.Store(3)
 	if tracker.getByID(2) == nil {
 		t.Fatal("getByID(2) = nil before release, wanted a call record")
 	}
 
 	asyncCallStateTrackerPool.release(tracker)
 
-	if got := tracker.pendingCount(); got != 0 {
-		t.Errorf("pendingCount() after release = %d, wanted 0", got)
-	}
 	if got := len(tracker.calls); got != 0 {
 		t.Errorf("calls map size after release = %d, wanted 0", got)
 	}
@@ -538,7 +540,7 @@ func TestAsyncTrackerPoolReleaseClearsState(t *testing.T) {
 		t.Errorf("nextCallID after release = %d, wanted 0", got)
 	}
 	// A released tracker is safe to reuse: callIDs restart and bookkeeping is fresh.
-	acs := tracker.getOrCreate(1, "fn", "ov", []ref.Val{types.Int(1)}, asyncReturning(types.Int(1), nil), completions)
+	acs := tracker.getOrCreate(1, "fn", "ov", []ref.Val{types.Int(1)}, asyncReturning(types.Int(1), nil), gate)
 	if acs.CallID() != 1 {
 		t.Errorf("reused tracker assigned callID %d, wanted 1", acs.CallID())
 	}
@@ -612,25 +614,25 @@ func TestExecutionFrameChildSharesAsyncContext(t *testing.T) {
 
 	// Counts are taken relative to a baseline, since ExecutionFrame draws its tracker from a
 	// process-global pool whose starting pending count is not guaranteed to be zero.
-	base := frame.PendingAsyncCalls()
+	base := frame.ActiveAsyncCalls()
 
 	child := frame.Push(EmptyActivation())
-	if got := child.PendingAsyncCalls(); got != base {
-		t.Errorf("child PendingAsyncCalls() = %d, wanted %d (shared parent ctx)", got, base)
+	if got := child.ActiveAsyncCalls(); got != base {
+		t.Errorf("child ActiveAsyncCalls() = %d, wanted %d (shared parent ctx)", got, base)
 	}
 
 	// A call launched from the child frame must be visible through the shared parent tracker.
 	child.ComputeResult(1, "fn", "fn_int", asyncReturning(types.Int(5), nil), []ref.Val{types.Int(1)})
-	if got := child.PendingAsyncCalls(); got != base+1 {
-		t.Errorf("child PendingAsyncCalls() after launch = %d, wanted %d", got, base+1)
+	if got := child.ActiveAsyncCalls(); got != base+1 {
+		t.Errorf("child ActiveAsyncCalls() after launch = %d, wanted %d", got, base+1)
 	}
 
 	parent := child.Pop()
 	if parent != frame {
 		t.Fatalf("Pop() did not return the parent frame")
 	}
-	if got := frame.PendingAsyncCalls(); got != base+1 {
-		t.Errorf("parent PendingAsyncCalls() after Pop = %d, wanted %d", got, base+1)
+	if got := frame.ActiveAsyncCalls(); got != base+1 {
+		t.Errorf("parent ActiveAsyncCalls() after Pop = %d, wanted %d", got, base+1)
 	}
 	// The launched call is retrievable via the parent frame's AsyncCall accessor.
 	select {
@@ -638,7 +640,6 @@ func TestExecutionFrameChildSharesAsyncContext(t *testing.T) {
 		if call := frame.AsyncCall(callID); call == nil {
 			t.Errorf("AsyncCall(%d) = nil, wanted a call record from the shared tracker", callID)
 		}
-		frame.NotifyCompletion(callID)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for child call completion")
 	}
@@ -710,10 +711,9 @@ func TestEvalAsyncFuncLifecycle(t *testing.T) {
 		t.Errorf("Exec() first call got %v, wanted Unknown", res)
 	}
 
-	// Now notify completion and re-evaluate
+	// Now await completion and re-evaluate
 	select {
-	case callID := <-completions:
-		frame.NotifyCompletion(callID)
+	case <-completions:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for completion")
 	}
@@ -773,11 +773,12 @@ func TestTrackerPoolShrink(t *testing.T) {
 	pool := newAsyncCallTrackerPool()
 	tracker := pool.create()
 	completions := make(chan int64, 1)
+	gate := newAsyncGate(0, completions)
 	impl := asyncReturning(types.Int(1), nil)
 
 	// Register more than trackerShrinkThreshold calls to trigger map reallocation
 	for i := int64(1); i <= trackerShrinkThreshold+10; i++ {
-		tracker.getOrCreate(i, "fn", "fn_int", []ref.Val{types.Int(i)}, impl, completions)
+		tracker.getOrCreate(i, "fn", "fn_int", []ref.Val{types.Int(i)}, impl, gate)
 	}
 
 	// Release the tracker; since size exceeds threshold, maps should be reallocated
@@ -790,7 +791,7 @@ func TestTrackerPoolShrink(t *testing.T) {
 	}
 
 	// Now register a small number of calls, release, and check that delete path works
-	tracker2.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(1)}, impl, completions)
+	tracker2.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(1)}, impl, gate)
 	pool.release(tracker2)
 
 	tracker3 := pool.create()
@@ -898,12 +899,11 @@ func TestAsyncWithTraceAndExhaustiveEval(t *testing.T) {
 loop:
 	for {
 		res = runPass()
-		if !types.IsUnknown(res) && frame.PendingAsyncCalls() == 0 {
+		if !types.IsUnknown(res) && frame.ActiveAsyncCalls() == 0 {
 			break loop
 		}
 		select {
-		case callID := <-completions:
-			frame.NotifyCompletion(callID)
+		case <-completions:
 		case <-deadline:
 			t.Fatal("timed out waiting for async result")
 		}

--- a/interpreter/async_test.go
+++ b/interpreter/async_test.go
@@ -244,6 +244,26 @@ func TestHashCall(t *testing.T) {
 			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.String("ab"), types.String("c")}},
 			wantHash: 14974838604657976619,
 		},
+		{
+			name:     "node id 1 with double arg NaN",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Double(math.NaN())}},
+			wantHash: 4356663283625852078,
+		},
+		{
+			name:     "node id 1 with string arg NaN",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.String("NaN")}},
+			wantHash: 17422508148545277865,
+		},
+		{
+			name:     "node id 1 with double arg 0.0",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Double(0.0)}},
+			wantHash: 2331193227347896467,
+		},
+		{
+			name:     "node id 1 with double arg -0.0",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Double(math.Copysign(0.0, -1.0))}},
+			wantHash: 2331193227347896467,
+		},
 	}
 
 	for _, tc := range tests {
@@ -930,5 +950,3 @@ func TestAsyncSetupWithoutContextErrors(t *testing.T) {
 		t.Error("SetAsyncMaxConcurrency() succeeded without context, wanted error")
 	}
 }
-
-

--- a/interpreter/async_test.go
+++ b/interpreter/async_test.go
@@ -844,7 +844,7 @@ func TestAsyncWithTraceAndExhaustiveEval(t *testing.T) {
 loop:
 	for {
 		res = runPass()
-		if !types.IsUnknown(res) {
+		if !types.IsUnknown(res) && frame.PendingAsyncCalls() == 0 {
 			break loop
 		}
 		select {

--- a/interpreter/async_test.go
+++ b/interpreter/async_test.go
@@ -16,7 +16,9 @@ package interpreter
 
 import (
 	"context"
+	"errors"
 	"math"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -367,6 +369,74 @@ func TestAsyncObserverLifecycle(t *testing.T) {
 	}
 	if got := obs.finished.Load(); got != 1 {
 		t.Errorf("OnCallFinished called %d times, wanted 1", got)
+	}
+}
+
+func TestAsyncObserverOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	frame, closeFrame := newTestFrame(t, ctx)
+	defer closeFrame()
+
+	type finishedEvent struct {
+		callID   int64
+		function string
+		overload string
+		res      ref.Val
+	}
+	finishedChan := make(chan finishedEvent, 1)
+
+	obs := &recordingObserverWithCallback{
+		onFinished: func(callID int64, function, overload string, res ref.Val) {
+			finishedChan <- finishedEvent{callID, function, overload, res}
+		},
+	}
+	if err := frame.SetAsyncObserver(obs); err != nil {
+		t.Fatalf("SetAsyncObserver() failed: %v", err)
+	}
+
+	release := make(chan struct{})
+	defer close(release)
+	var live, maxLive atomic.Int32
+	impl := asyncControllable(release, &live, &maxLive)
+
+	res := frame.ComputeResult(1, "fn", "fn_int", impl, []ref.Val{types.Int(1)})
+	if !types.IsUnknown(res) {
+		t.Fatalf("ComputeResult() got %v, wanted Unknown", res)
+	}
+
+	cancelErr := errors.New("aborted by user request")
+	cancel(cancelErr)
+
+	select {
+	case event := <-finishedChan:
+		if event.callID != 1 {
+			t.Errorf("observer got callID = %d, wanted 1", event.callID)
+		}
+		if event.function != "fn" || event.overload != "fn_int" {
+			t.Errorf("observer got func/overload = %q/%q, wanted fn/fn_int", event.function, event.overload)
+		}
+		if !types.IsError(event.res) {
+			t.Errorf("observer result got %v, wanted error", event.res)
+		} else {
+			errVal := event.res.(*types.Err)
+			if !strings.Contains(errVal.Error(), "aborted by user request") {
+				t.Errorf("expected observer error to contain cause, got: %v", errVal)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for observer completion notification on context cancel")
+	}
+}
+
+type recordingObserverWithCallback struct {
+	onFinished func(callID int64, function, overload string, res ref.Val)
+}
+
+func (o *recordingObserverWithCallback) OnCallStarted(callID int64, function, overload string, args []ref.Val) {}
+
+func (o *recordingObserverWithCallback) OnCallFinished(callID int64, function, overload string, res ref.Val) {
+	if o.onFinished != nil {
+		o.onFinished(callID, function, overload, res)
 	}
 }
 

--- a/interpreter/async_test.go
+++ b/interpreter/async_test.go
@@ -247,7 +247,7 @@ func TestHashCall(t *testing.T) {
 		{
 			name:     "node id 1 with double arg NaN",
 			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Double(math.NaN())}},
-			wantHash: 4356663283625852078,
+			wantHash: 4464412628189895594,
 		},
 		{
 			name:     "node id 1 with string arg NaN",
@@ -546,7 +546,7 @@ func TestAsyncTrackerPoolReleaseClearsState(t *testing.T) {
 	}
 }
 
-func TestAsyncCallStateEquals(t *testing.T) {
+func TestAsyncCallStateMatches(t *testing.T) {
 	mk := func(fn, ov string, args ...ref.Val) *asyncCallState {
 		return newAsyncCallState(1, fn, ov, args, nil)
 	}
@@ -561,19 +561,18 @@ func TestAsyncCallStateEquals(t *testing.T) {
 		{"diff overload", mk("fn", "other", types.Int(1), types.String("a")), false},
 		{"diff arg value", mk("fn", "ov", types.Int(2), types.String("a")), false},
 		{"diff arity", mk("fn", "ov", types.Int(1)), false},
-		{"nil other", nil, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := base.equals(tc.other); got != tc.want {
-				t.Errorf("equals() = %v, wanted %v", got, tc.want)
+			if got := base.matches(1, tc.other.function, tc.other.overload, tc.other.argVals); got != tc.want {
+				t.Errorf("matches() = %v, wanted %v", got, tc.want)
 			}
 		})
 	}
 	t.Run("nil receiver", func(t *testing.T) {
 		var nilState *asyncCallState
-		if nilState.equals(base) {
-			t.Error("nil.equals() returned true")
+		if nilState.matches(1, base.function, base.overload, base.argVals) {
+			t.Error("nil.matches() returned true")
 		}
 	})
 	t.Run("NaN equivalence", func(t *testing.T) {
@@ -593,8 +592,8 @@ func TestAsyncCallStateEquals(t *testing.T) {
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
-				if got := tc.state.equals(tc.other); got != tc.want {
-					t.Errorf("equals() = %v, wanted %v", got, tc.want)
+				if got := tc.state.matches(1, tc.other.function, tc.other.overload, tc.other.argVals); got != tc.want {
+					t.Errorf("matches() = %v, wanted %v", got, tc.want)
 				}
 			})
 		}

--- a/interpreter/async_test.go
+++ b/interpreter/async_test.go
@@ -16,6 +16,7 @@ package interpreter
 
 import (
 	"context"
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -204,24 +205,34 @@ func TestHashCall(t *testing.T) {
 			wantHash: 17791913581187873402,
 		},
 		{
-			name:     "numeric args excluded - int 1",
+			name:     "node id 1 with int arg 1",
 			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Int(1)}},
-			wantHash: 11388483313428953077,
+			wantHash: 6250879603390619476,
 		},
 		{
-			name:     "numeric args excluded - int 2",
+			name:     "node id 1 with uint arg 1",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Uint(1)}},
+			wantHash: 6250879603390619476,
+		},
+		{
+			name:     "node id 1 with double arg 1.0",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Double(1.0)}},
+			wantHash: 6250879603390619476,
+		},
+		{
+			name:     "node id 1 with int arg 2",
 			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Int(2)}},
-			wantHash: 11388483313428953077,
+			wantHash: 2269972419901218387,
 		},
 		{
-			name:     "numeric args excluded - double 1.5",
+			name:     "node id 1 with double arg 1.5",
 			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Double(1.5)}},
-			wantHash: 11388483313428953077,
+			wantHash: 1181031487041842476,
 		},
 		{
-			name:     "numeric args excluded - double 9.9",
+			name:     "node id 1 with double arg 9.9",
 			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Double(9.9)}},
-			wantHash: 11388483313428953077,
+			wantHash: 6763353195175059609,
 		},
 		{
 			name:     "separation a, bc",
@@ -541,6 +552,29 @@ func TestAsyncCallStateEquals(t *testing.T) {
 		var nilState *asyncCallState
 		if nilState.equals(base) {
 			t.Error("nil.equals() returned true")
+		}
+	})
+	t.Run("NaN equivalence", func(t *testing.T) {
+		s1 := mk("fn", "ov", types.Double(math.NaN()))
+		s2 := mk("fn", "ov", types.Double(math.NaN()))
+		s3 := mk("fn", "ov", types.Double(1.23))
+
+		tests := []struct {
+			name  string
+			state *asyncCallState
+			other *asyncCallState
+			want  bool
+		}{
+			{"NaN vs NaN", s1, s2, true},
+			{"NaN vs non-NaN", s1, s3, false},
+			{"non-NaN vs NaN", s3, s1, false},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				if got := tc.state.equals(tc.other); got != tc.want {
+					t.Errorf("equals() = %v, wanted %v", got, tc.want)
+				}
+			})
 		}
 	})
 }

--- a/interpreter/async_test.go
+++ b/interpreter/async_test.go
@@ -1,0 +1,900 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interpreter
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/checker"
+	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/containers"
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/functions"
+	"github.com/google/cel-go/common/overloads"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/parser"
+)
+
+// asyncReturning returns an AsyncOp that immediately produces the given value, while counting the
+// number of times the implementation is invoked.
+func asyncReturning(val ref.Val, calls *atomic.Int32) functions.AsyncOp {
+	return func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
+		if calls != nil {
+			calls.Add(1)
+		}
+		ch := make(chan ref.Val, 1)
+		ch <- val
+		close(ch)
+		return ch
+	}
+}
+
+// newTestFrame creates an ExecutionFrame with an evaluation context attached.
+func newTestFrame(t *testing.T, ctx context.Context) (*ExecutionFrame, func()) {
+	t.Helper()
+	frame, err := NewExecutionFrame(EmptyActivation())
+	if err != nil {
+		t.Fatalf("NewExecutionFrame() failed: %v", err)
+	}
+	if err := frame.SetContext(ctx, 0); err != nil {
+		t.Fatalf("SetContext() failed: %v", err)
+	}
+	return frame, frame.Close
+}
+
+// awaitResult re-evaluates ComputeResult until it returns a non-Unknown value or the deadline fires.
+func awaitResult(t *testing.T, frame *ExecutionFrame, completions <-chan int64, id int64, fn, overload string, impl functions.AsyncOp, args ...ref.Val) ref.Val {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		res := frame.ComputeResult(id, fn, overload, impl, args)
+		if !types.IsUnknown(res) {
+			return res
+		}
+		select {
+		case callID := <-completions:
+			frame.NotifyCompletion(callID)
+		case <-deadline:
+			t.Fatal("timed out waiting for async result")
+		}
+	}
+}
+
+func TestComputeResultWithoutContext(t *testing.T) {
+	frame, err := NewExecutionFrame(EmptyActivation())
+	if err != nil {
+		t.Fatalf("NewExecutionFrame() failed: %v", err)
+	}
+	defer frame.Close()
+	// No SetContext call, so async tracking is uninitialized.
+	res := frame.ComputeResult(1, "fn", "fn_overload", asyncReturning(types.Int(1), nil), nil)
+	if !types.IsError(res) {
+		t.Errorf("ComputeResult() got %v, wanted error when tracking uninitialized", res)
+	}
+	if frame.PendingAsyncCalls() != 0 {
+		t.Errorf("PendingAsyncCalls() = %d, wanted 0", frame.PendingAsyncCalls())
+	}
+	if call := frame.AsyncCall(1); call != nil {
+		t.Errorf("AsyncCall() = %v, wanted nil", call)
+	}
+}
+
+func TestComputeResultResolves(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	frame, closeFrame := newTestFrame(t, ctx)
+	defer closeFrame()
+
+	completions := make(chan int64, 1)
+	if err := frame.SetCompletions(completions); err != nil {
+		t.Fatalf("SetCompletions() failed: %v", err)
+	}
+
+	var calls atomic.Int32
+	impl := asyncReturning(types.Int(42), &calls)
+	res := awaitResult(t, frame, completions, 1, "fn", "fn_int", impl, types.Int(1))
+	if res.Equal(types.Int(42)) != types.True {
+		t.Errorf("async result = %v, wanted 42", res)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("impl invoked %d times, wanted exactly 1", got)
+	}
+}
+
+func TestTrackerDedupAndCallIDs(t *testing.T) {
+	// Exercise the tracker directly to keep bookkeeping assertions isolated from the
+	// process-global frame/tracker pools used by ExecutionFrame.
+	tracker := newAsyncCallStateTracker()
+	completions := make(chan int64, 4)
+	impl := asyncReturning(types.Int(1), nil)
+
+	// Same node id, same args, invoked repeatedly: must dedup to a single registered call.
+	a1 := tracker.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(1)}, impl, completions)
+	a2 := tracker.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(1)}, impl, completions)
+	if a1 != a2 {
+		t.Error("getOrCreate returned distinct states for identical (id, args)")
+	}
+	if a1.CallID() != a2.CallID() {
+		t.Errorf("dedup callIDs differ: %d vs %d", a1.CallID(), a2.CallID())
+	}
+	if got := tracker.getByID(a1.CallID()); got != a1 {
+		t.Errorf("getByID(%d) did not return the registered call", a1.CallID())
+	}
+
+	// Same node id, different args: a new call must be registered (re-evaluation with new inputs).
+	a3 := tracker.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(2)}, impl, completions)
+	if a3.CallID() == a1.CallID() {
+		t.Error("arg change reused the prior callID, wanted a fresh call")
+	}
+	if got := tracker.getByID(a3.CallID()); got != a3 {
+		t.Errorf("getByID(%d) did not return the second registered call", a3.CallID())
+	}
+	// Registration alone does not mark a call as in-flight; pending counts launched calls only.
+	if got := tracker.pendingCount(); got != 0 {
+		t.Errorf("pendingCount() after registration only = %d, wanted 0", got)
+	}
+}
+
+func TestHashCall(t *testing.T) {
+	type hashInput struct {
+		id       int64
+		overload string
+		args     []ref.Val
+	}
+	tests := []struct {
+		name     string
+		input    hashInput
+		wantHash uint64
+	}{
+		{
+			name:     "node id 1 with string arg a",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.String("a")}},
+			wantHash: 13175600815575489707,
+		},
+		{
+			name:     "node id 1 with string arg b",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.String("b")}},
+			wantHash: 13172731090226426672,
+		},
+		{
+			name:     "node id 1 with bool arg true",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Bool(true)}},
+			wantHash: 5368363472817480916,
+		},
+		{
+			name:     "node id 1 with bool arg false",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Bool(false)}},
+			wantHash: 5369320047933835261,
+		},
+		{
+			name:     "node id 1 with nil args",
+			input:    hashInput{1, overloads.ContainsString, nil},
+			wantHash: 16571860343215109013,
+		},
+		{
+			name:     "node id 2 with nil args",
+			input:    hashInput{2, overloads.ContainsString, nil},
+			wantHash: 7332562693386296450,
+		},
+		{
+			name:     "node id 1 with overload matches_string",
+			input:    hashInput{1, overloads.MatchesString, nil},
+			wantHash: 6112375249444952169,
+		},
+		{
+			name:     "node id 1 with overload starts_with_string",
+			input:    hashInput{1, overloads.StartsWithString, nil},
+			wantHash: 17791913581187873402,
+		},
+		{
+			name:     "numeric args excluded - int 1",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Int(1)}},
+			wantHash: 11388483313428953077,
+		},
+		{
+			name:     "numeric args excluded - int 2",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Int(2)}},
+			wantHash: 11388483313428953077,
+		},
+		{
+			name:     "numeric args excluded - double 1.5",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Double(1.5)}},
+			wantHash: 11388483313428953077,
+		},
+		{
+			name:     "numeric args excluded - double 9.9",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.Double(9.9)}},
+			wantHash: 11388483313428953077,
+		},
+		{
+			name:     "separation a, bc",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.String("a"), types.String("bc")}},
+			wantHash: 16286284200968323077,
+		},
+		{
+			name:     "separation ab, c",
+			input:    hashInput{1, overloads.ContainsString, []ref.Val{types.String("ab"), types.String("c")}},
+			wantHash: 14974838604657976619,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := hashCall(tc.input.id, tc.input.overload, tc.input.args)
+			if got != tc.wantHash {
+				t.Errorf("hashCall() = %d, wanted %d", got, tc.wantHash)
+			}
+		})
+	}
+}
+
+func TestTrackerComprehensionReuse(t *testing.T) {
+	// Regression: a single AST node id evaluated repeatedly with distinct argument values (as
+	// happens for an async call inside a comprehension) must register one call per distinct
+	// argument set, and re-lookups must return the existing state rather than relaunching. A
+	// node-id-keyed map collapses these into a single slot, causing every re-evaluation pass to
+	// relaunch every iteration and never converge.
+	tracker := newAsyncCallStateTracker()
+	completions := make(chan int64, 8)
+	impl := asyncReturning(types.Int(0), nil)
+	const id = int64(1)
+
+	args := [][]ref.Val{
+		{types.Int(1)},
+		{types.Int(2)},
+		{types.Int(3)},
+	}
+	states := make([]*asyncCallState, len(args))
+	for i, a := range args {
+		states[i] = tracker.getOrCreate(id, "fn", "fn_int", a, impl, completions)
+	}
+
+	// Each distinct argument set is a distinct, uniquely-identified call.
+	seen := map[int64]bool{}
+	for _, s := range states {
+		if seen[s.CallID()] {
+			t.Errorf("duplicate callID %d across distinct args", s.CallID())
+		}
+		seen[s.CallID()] = true
+	}
+
+	// Re-evaluation: every prior (id, args) tuple must resolve to its existing state and must
+	// not register a new call.
+	for i, a := range args {
+		if got := tracker.getOrCreate(id, "fn", "fn_int", a, impl, completions); got != states[i] {
+			t.Errorf("re-lookup of args %v returned a new state, wanted the existing one", a)
+		}
+	}
+
+	// Identical string arguments at the same node dedup to a single call.
+	s1 := tracker.getOrCreate(2, "fn", "fn_str", []ref.Val{types.String("k")}, impl, completions)
+	s2 := tracker.getOrCreate(2, "fn", "fn_str", []ref.Val{types.String("k")}, impl, completions)
+	if s1 != s2 {
+		t.Error("identical string args did not dedup to a single call")
+	}
+}
+
+func TestTrackerRegistrationLookup(t *testing.T) {
+	tracker := newAsyncCallStateTracker()
+	completions := make(chan int64, 2)
+	impl := asyncReturning(types.Int(1), nil)
+
+	a := tracker.getOrCreate(1, "fn", "a", []ref.Val{types.Int(1)}, impl, completions)
+	b := tracker.getOrCreate(2, "fn", "b", []ref.Val{types.Int(2)}, impl, completions)
+
+	// Registered calls must be retrievable by callID.
+	for _, want := range []*asyncCallState{a, b} {
+		if got := tracker.getByID(want.CallID()); got != want {
+			t.Errorf("getByID(%d) returned a different call record", want.CallID())
+		}
+	}
+	// Unknown callIDs resolve to nil rather than panicking.
+	if got := tracker.getByID(99999); got != nil {
+		t.Errorf("getByID(unknown) = %v, wanted nil", got)
+	}
+}
+
+func TestAsyncObserverLifecycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	frame, closeFrame := newTestFrame(t, ctx)
+	defer closeFrame()
+
+	obs := &recordingObserver{}
+	if err := frame.SetAsyncObserver(obs); err != nil {
+		t.Fatalf("SetAsyncObserver() failed: %v", err)
+	}
+	completions := make(chan int64, 1)
+	if err := frame.SetCompletions(completions); err != nil {
+		t.Fatalf("SetCompletions() failed: %v", err)
+	}
+
+	awaitResult(t, frame, completions, 1, "fn", "fn_int", asyncReturning(types.Int(7), nil), types.Int(1))
+
+	if got := obs.started.Load(); got != 1 {
+		t.Errorf("OnCallStarted called %d times, wanted 1", got)
+	}
+	if got := obs.finished.Load(); got != 1 {
+		t.Errorf("OnCallFinished called %d times, wanted 1", got)
+	}
+}
+
+// asyncControllable returns a channel-based AsyncOp whose calls block until release is closed,
+// tracking the number of concurrently live calls and the high-water mark.
+func asyncControllable(release <-chan struct{}, live, maxLive *atomic.Int32) functions.AsyncOp {
+	return func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
+		ch := make(chan ref.Val, 1)
+		go func() {
+			cur := live.Add(1)
+			for {
+				old := maxLive.Load()
+				if cur <= old || maxLive.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			live.Add(-1)
+			ch <- args[0]
+			close(ch)
+		}()
+		return ch
+	}
+}
+
+func TestLaunchAdmissionAndBounding(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	frame, closeFrame := newTestFrame(t, ctx)
+	defer closeFrame()
+
+	const limit = 2
+	const total = 5
+	if err := frame.SetAsyncMaxConcurrency(limit); err != nil {
+		t.Fatalf("SetAsyncMaxConcurrency() failed: %v", err)
+	}
+	completions := make(chan int64, total*2)
+	if err := frame.SetCompletions(completions); err != nil {
+		t.Fatalf("SetCompletions() failed: %v", err)
+	}
+
+	release := make(chan struct{})
+	var live, maxLive atomic.Int32
+	impl := asyncControllable(release, &live, &maxLive)
+
+	// A single evaluation pass: attempt to launch all calls (distinct node ids).
+	pass := func() {
+		for i := 0; i < total; i++ {
+			frame.ComputeResult(int64(i+1), "fn", "fn_int", impl, []ref.Val{types.Int(int64(i))})
+		}
+	}
+
+	// First pass admits only `limit` launches; the rest are deferred. pending is updated
+	// synchronously as calls are admitted, so it must equal the limit immediately.
+	pass()
+	if got := frame.PendingAsyncCalls(); got != limit {
+		t.Fatalf("PendingAsyncCalls() after first pass = %d, wanted %d", got, limit)
+	}
+
+	// Drive completions and re-evaluate until every call has resolved, simulating ConcurrentEval.
+	close(release)
+	done := map[int64]bool{}
+	deadline := time.After(5 * time.Second)
+	for len(done) < total {
+		pass() // re-evaluate: launch any newly-admissible calls
+		select {
+		case id := <-completions:
+			frame.NotifyCompletion(id)
+			done[id] = true
+		case <-deadline:
+			t.Fatalf("only %d/%d calls completed; maxLive=%d", len(done), total, maxLive.Load())
+		}
+	}
+
+	if got := maxLive.Load(); got > limit {
+		t.Errorf("max concurrent launches = %d, wanted <= %d", got, limit)
+	}
+	if got := frame.PendingAsyncCalls(); got != 0 {
+		t.Errorf("PendingAsyncCalls() after all completions = %d, wanted 0", got)
+	}
+}
+
+func TestLaunchUnlimitedWhenNoSemaphore(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	frame, closeFrame := newTestFrame(t, ctx)
+	defer closeFrame()
+	// No SetAsyncMaxConcurrency -> nil semaphore -> all calls admitted in one pass.
+	completions := make(chan int64, 8)
+	if err := frame.SetCompletions(completions); err != nil {
+		t.Fatalf("SetCompletions() failed: %v", err)
+	}
+
+	const total = 5
+	for i := 0; i < total; i++ {
+		frame.ComputeResult(int64(i+1), "fn", "fn_int", asyncReturning(types.Int(int64(i)), nil), []ref.Val{types.Int(int64(i))})
+	}
+	if got := frame.PendingAsyncCalls(); got != total {
+		t.Errorf("PendingAsyncCalls() with no limit = %d, wanted %d", got, total)
+	}
+}
+
+func TestAsyncCallStateCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	frame, closeFrame := newTestFrame(t, ctx)
+	defer closeFrame()
+
+	completions := make(chan int64, 1)
+	if err := frame.SetCompletions(completions); err != nil {
+		t.Fatalf("SetCompletions() failed: %v", err)
+	}
+
+	var exited sync.WaitGroup
+	exited.Add(1)
+	blocking := func(ctx context.Context, args ...ref.Val) <-chan ref.Val {
+		ch := make(chan ref.Val) // never written; goroutine must exit via ctx.Done
+		go func() {
+			defer exited.Done()
+			<-ctx.Done()
+		}()
+		return ch
+	}
+	res := frame.ComputeResult(1, "fn", "fn_int", blocking, []ref.Val{types.Int(1)})
+	if !types.IsUnknown(res) {
+		t.Fatalf("ComputeResult() = %v, wanted Unknown while pending", res)
+	}
+	cancel()
+
+	done := make(chan struct{})
+	go func() { exited.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("async impl goroutine did not exit on cancellation")
+	}
+	// No completion should have been delivered for the cancelled call.
+	select {
+	case callID := <-completions:
+		t.Errorf("unexpected completion for cancelled call: %d", callID)
+	default:
+	}
+}
+
+func TestAsyncTrackerPoolReleaseClearsState(t *testing.T) {
+	tracker := newAsyncCallStateTracker()
+	completions := make(chan int64, 4)
+	for i := int64(1); i <= 3; i++ {
+		tracker.getOrCreate(i, "fn", "ov", []ref.Val{types.Int(i)}, asyncReturning(types.Int(i), nil), completions)
+	}
+	// Simulate launched calls so the release path is exercised against non-zero in-flight state.
+	tracker.pendingCalls.Store(3)
+	if tracker.getByID(2) == nil {
+		t.Fatal("getByID(2) = nil before release, wanted a call record")
+	}
+
+	asyncCallStateTrackerPool.release(tracker)
+
+	if got := tracker.pendingCount(); got != 0 {
+		t.Errorf("pendingCount() after release = %d, wanted 0", got)
+	}
+	if got := len(tracker.calls); got != 0 {
+		t.Errorf("calls map size after release = %d, wanted 0", got)
+	}
+	if got := len(tracker.callsByID); got != 0 {
+		t.Errorf("callsByID map size after release = %d, wanted 0", got)
+	}
+	if got := tracker.nextCallID.Load(); got != 0 {
+		t.Errorf("nextCallID after release = %d, wanted 0", got)
+	}
+	// A released tracker is safe to reuse: callIDs restart and bookkeeping is fresh.
+	acs := tracker.getOrCreate(1, "fn", "ov", []ref.Val{types.Int(1)}, asyncReturning(types.Int(1), nil), completions)
+	if acs.CallID() != 1 {
+		t.Errorf("reused tracker assigned callID %d, wanted 1", acs.CallID())
+	}
+}
+
+func TestAsyncCallStateEquals(t *testing.T) {
+	mk := func(fn, ov string, args ...ref.Val) *asyncCallState {
+		return newAsyncCallState(1, fn, ov, args, nil)
+	}
+	base := mk("fn", "ov", types.Int(1), types.String("a"))
+	tests := []struct {
+		name  string
+		other *asyncCallState
+		want  bool
+	}{
+		{"identical", mk("fn", "ov", types.Int(1), types.String("a")), true},
+		{"diff function", mk("other", "ov", types.Int(1), types.String("a")), false},
+		{"diff overload", mk("fn", "other", types.Int(1), types.String("a")), false},
+		{"diff arg value", mk("fn", "ov", types.Int(2), types.String("a")), false},
+		{"diff arity", mk("fn", "ov", types.Int(1)), false},
+		{"nil other", nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := base.equals(tc.other); got != tc.want {
+				t.Errorf("equals() = %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+	t.Run("nil receiver", func(t *testing.T) {
+		var nilState *asyncCallState
+		if nilState.equals(base) {
+			t.Error("nil.equals() returned true")
+		}
+	})
+}
+
+func TestExecutionFrameChildSharesAsyncContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	frame, closeFrame := newTestFrame(t, ctx)
+	defer closeFrame()
+
+	completions := make(chan int64, 1)
+	if err := frame.SetCompletions(completions); err != nil {
+		t.Fatalf("SetCompletions() failed: %v", err)
+	}
+
+	// Counts are taken relative to a baseline, since ExecutionFrame draws its tracker from a
+	// process-global pool whose starting pending count is not guaranteed to be zero.
+	base := frame.PendingAsyncCalls()
+
+	child := frame.Push(EmptyActivation())
+	if got := child.PendingAsyncCalls(); got != base {
+		t.Errorf("child PendingAsyncCalls() = %d, wanted %d (shared parent ctx)", got, base)
+	}
+
+	// A call launched from the child frame must be visible through the shared parent tracker.
+	child.ComputeResult(1, "fn", "fn_int", asyncReturning(types.Int(5), nil), []ref.Val{types.Int(1)})
+	if got := child.PendingAsyncCalls(); got != base+1 {
+		t.Errorf("child PendingAsyncCalls() after launch = %d, wanted %d", got, base+1)
+	}
+
+	parent := child.Pop()
+	if parent != frame {
+		t.Fatalf("Pop() did not return the parent frame")
+	}
+	if got := frame.PendingAsyncCalls(); got != base+1 {
+		t.Errorf("parent PendingAsyncCalls() after Pop = %d, wanted %d", got, base+1)
+	}
+	// The launched call is retrievable via the parent frame's AsyncCall accessor.
+	select {
+	case callID := <-completions:
+		if call := frame.AsyncCall(callID); call == nil {
+			t.Errorf("AsyncCall(%d) = nil, wanted a call record from the shared tracker", callID)
+		}
+		frame.NotifyCompletion(callID)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for child call completion")
+	}
+}
+
+type recordingObserver struct {
+	started  atomic.Int32
+	finished atomic.Int32
+}
+
+func (o *recordingObserver) OnCallStarted(callID int64, function, overload string, args []ref.Val) {
+	o.started.Add(1)
+}
+
+func (o *recordingObserver) OnCallFinished(callID int64, function, overload string, res ref.Val) {
+	o.finished.Add(1)
+}
+
+func TestEvalAsyncFuncGetters(t *testing.T) {
+	fn := &evalAsyncFunc{
+		id:       42,
+		function: "async_fn",
+		overload: "async_fn_overload",
+		args: []InterpretableV2{
+			&evalConst{val: types.Int(1)},
+		},
+		impl: asyncReturning(types.Int(100), nil),
+	}
+
+	if fn.ID() != 42 {
+		t.Errorf("ID() = %d, wanted 42", fn.ID())
+	}
+	if fn.Function() != "async_fn" {
+		t.Errorf("Function() = %s, wanted async_fn", fn.Function())
+	}
+	if fn.OverloadID() != "async_fn_overload" {
+		t.Errorf("OverloadID() = %s, wanted async_fn_overload", fn.OverloadID())
+	}
+	if len(fn.Args()) != 1 {
+		t.Errorf("Args() length = %d, wanted 1", len(fn.Args()))
+	}
+}
+
+func TestEvalAsyncFuncLifecycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	frame, closeFrame := newTestFrame(t, ctx)
+	defer closeFrame()
+
+	completions := make(chan int64, 1)
+	if err := frame.SetCompletions(completions); err != nil {
+		t.Fatalf("SetCompletions() failed: %v", err)
+	}
+
+	impl := asyncReturning(types.Int(100), nil)
+	fn := &evalAsyncFunc{
+		id:       42,
+		function: "async_fn",
+		overload: "async_fn_overload",
+		args: []InterpretableV2{
+			&evalConst{val: types.Int(1)},
+		},
+		impl: impl,
+	}
+
+	// Test Exec first pass
+	res := fn.Exec(frame)
+	if !types.IsUnknown(res) {
+		t.Errorf("Exec() first call got %v, wanted Unknown", res)
+	}
+
+	// Now notify completion and re-evaluate
+	select {
+	case callID := <-completions:
+		frame.NotifyCompletion(callID)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion")
+	}
+
+	res2 := fn.Exec(frame)
+	if res2.Equal(types.Int(100)) != types.True {
+		t.Errorf("Exec() second call got %v, wanted 100", res2)
+	}
+
+	// Test Eval method
+	res3 := fn.Eval(frame)
+	if res3.Equal(types.Int(100)) != types.True {
+		t.Errorf("Eval() got %v, wanted 100", res3)
+	}
+}
+
+func TestEvalAsyncFuncEarlyReturn(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	frame, closeFrame := newTestFrame(t, ctx)
+	defer closeFrame()
+
+	impl := asyncReturning(types.Int(100), nil)
+
+	// Test Exec returning early when an argument is error
+	fnErrArg := &evalAsyncFunc{
+		id:       43,
+		function: "async_fn",
+		overload: "async_fn_overload",
+		args: []InterpretableV2{
+			&evalConst{val: types.NewErr("argument error")},
+		},
+		impl: impl,
+	}
+	resErr := fnErrArg.Exec(frame)
+	if !types.IsError(resErr) {
+		t.Errorf("Exec with error arg got %v, wanted error", resErr)
+	}
+
+	// Test Exec returning early when an argument is unknown
+	fnUnknownArg := &evalAsyncFunc{
+		id:       44,
+		function: "async_fn",
+		overload: "async_fn_overload",
+		args: []InterpretableV2{
+			&evalConst{val: types.NewUnknown(999, nil)},
+		},
+		impl: impl,
+	}
+	resUnknown := fnUnknownArg.Exec(frame)
+	if !types.IsUnknown(resUnknown) {
+		t.Errorf("Exec with unknown arg got %v, wanted Unknown", resUnknown)
+	}
+}
+
+func TestTrackerPoolShrink(t *testing.T) {
+	pool := newAsyncCallTrackerPool()
+	tracker := pool.create()
+	completions := make(chan int64, 1)
+	impl := asyncReturning(types.Int(1), nil)
+
+	// Register more than trackerShrinkThreshold calls to trigger map reallocation
+	for i := int64(1); i <= trackerShrinkThreshold+10; i++ {
+		tracker.getOrCreate(i, "fn", "fn_int", []ref.Val{types.Int(i)}, impl, completions)
+	}
+
+	// Release the tracker; since size exceeds threshold, maps should be reallocated
+	pool.release(tracker)
+
+	// Retrieve again from pool to make sure it's clean and empty
+	tracker2 := pool.create()
+	if len(tracker2.calls) != 0 || len(tracker2.callsByID) != 0 {
+		t.Errorf("released tracker was not cleared: calls size = %d, callsByID size = %d", len(tracker2.calls), len(tracker2.callsByID))
+	}
+
+	// Now register a small number of calls, release, and check that delete path works
+	tracker2.getOrCreate(1, "fn", "fn_int", []ref.Val{types.Int(1)}, impl, completions)
+	pool.release(tracker2)
+
+	tracker3 := pool.create()
+	if len(tracker3.calls) != 0 || len(tracker3.callsByID) != 0 {
+		t.Errorf("released tracker (delete path) was not cleared: calls size = %d, callsByID size = %d", len(tracker3.calls), len(tracker3.callsByID))
+	}
+	pool.release(tracker3)
+}
+
+func TestAsyncWithTraceAndExhaustiveEval(t *testing.T) {
+	asyncFnDecl, err := decls.NewFunction("async_eq_true",
+		decls.Overload("async_eq_true_int",
+			[]*types.Type{types.IntType},
+			types.BoolType,
+			decls.AsyncBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+				val := args[0].(types.Int)
+				select {
+				case <-time.After(50 * time.Millisecond):
+					return types.Bool(val == 1)
+				case <-ctx.Done():
+					return types.NewErr("cancelled")
+				}
+			}),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewFunction failed: %v", err)
+	}
+
+	exprStr := "async_eq_true(1) && async_eq_true(2)"
+	s := common.NewTextSource(exprStr)
+	p, err := parser.NewParser(
+		parser.Macros(parser.AllMacros...),
+	)
+	if err != nil {
+		t.Fatalf("NewParser failed: %v", err)
+	}
+	parsed, errs := p.Parse(s)
+	if len(errs.GetErrors()) != 0 {
+		t.Fatalf("Parse errors: %s", errs.ToDisplayString())
+	}
+
+	reg := newTestRegistry(t)
+	env := newTestEnv(t, containers.DefaultContainer, reg)
+	err = env.AddFunctions(asyncFnDecl)
+	if err != nil {
+		t.Fatalf("AddFunctions failed: %v", err)
+	}
+	checked, errs := checker.Check(parsed, s, env)
+	if len(errs.GetErrors()) != 0 {
+		t.Fatalf("Check errors: %s", errs.ToDisplayString())
+	}
+
+	disp := NewDispatcher()
+	addFunctionBindings(t, disp)
+	bindings, err := asyncFnDecl.Bindings()
+	if err != nil {
+		t.Fatalf("Bindings() failed: %v", err)
+	}
+	err = disp.Add(bindings...)
+	if err != nil {
+		t.Fatalf("dispatcher.Add() failed: %v", err)
+	}
+
+	attrs := NewAttributeFactory(containers.DefaultContainer, reg, reg)
+	interp := NewInterpreter(disp, containers.DefaultContainer, reg, reg, attrs)
+
+	state := NewEvalState()
+	prg, err := interp.NewInterpretable(checked,
+		ExhaustiveEval(),
+		EvalStateObserver(EvalStateFactory(func() EvalState { return state })),
+	)
+	if err != nil {
+		t.Fatalf("NewInterpretable failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	frame, err := NewExecutionFrame(EmptyActivation())
+	if err != nil {
+		t.Fatalf("NewExecutionFrame failed: %v", err)
+	}
+	defer frame.Close()
+	if err := frame.SetContext(ctx, 0); err != nil {
+		t.Fatalf("SetContext failed: %v", err)
+	}
+
+	completions := make(chan int64, 4)
+	if err := frame.SetCompletions(completions); err != nil {
+		t.Fatalf("SetCompletions() failed: %v", err)
+	}
+
+	oi, isObservable := prg.(*ObservableInterpretable)
+	if !isObservable {
+		t.Fatalf("expected program to be observable")
+	}
+
+	runPass := func() ref.Val {
+		return oi.ObserveExec(frame, func(observed any) {
+		})
+	}
+
+	var res ref.Val
+	deadline := time.After(2 * time.Second)
+loop:
+	for {
+		res = runPass()
+		if !types.IsUnknown(res) {
+			break loop
+		}
+		select {
+		case callID := <-completions:
+			frame.NotifyCompletion(callID)
+		case <-deadline:
+			t.Fatal("timed out waiting for async result")
+		}
+	}
+
+	if res.Equal(types.False) != types.True {
+		t.Errorf("expected false, got %v", res)
+	}
+
+	state.Reset()
+	resLast := runPass()
+	if resLast.Equal(types.False) != types.True {
+		t.Errorf("expected final pass result to be false, got %v", resLast)
+	}
+
+	for _, id := range state.IDs() {
+		val, found := state.Value(id)
+		if !found {
+			continue
+		}
+		if types.IsUnknown(val) {
+			t.Errorf("found unknown value in final eval state for node %d: %v", id, val)
+		}
+	}
+}
+
+func TestAsyncSetupWithoutContextErrors(t *testing.T) {
+	frame, err := NewExecutionFrame(EmptyActivation())
+	if err != nil {
+		t.Fatalf("NewExecutionFrame() failed: %v", err)
+	}
+	defer frame.Close()
+
+	// No frame.SetContext called, so context is nil.
+	completions := make(chan int64, 1)
+	if err := frame.SetCompletions(completions); err == nil {
+		t.Error("SetCompletions() succeeded without context, wanted error")
+	}
+	obs := &recordingObserver{}
+	if err := frame.SetAsyncObserver(obs); err == nil {
+		t.Error("SetAsyncObserver() succeeded without context, wanted error")
+	}
+	if err := frame.SetAsyncMaxConcurrency(2); err == nil {
+		t.Error("SetAsyncMaxConcurrency() succeeded without context, wanted error")
+	}
+}
+
+

--- a/interpreter/frame.go
+++ b/interpreter/frame.go
@@ -58,14 +58,11 @@ type evalContext struct {
 	// asyncCalls tracks the state of async call invocations across re-evaluations.
 	asyncCalls *asyncCallStateTracker
 
-	// completions is the channel async calls signal their callID to upon completion.
-	completions chan<- int64
+	// gate coordinates async call admission control and completion signaling.
+	gate *asyncGate
 
 	// observer for monitoring async calls.
 	observer AsyncObserver
-
-	// semaphore for limiting async call concurrency. A nil value indicates no limit.
-	semaphore chan struct{}
 }
 
 // ExecutionFrame provides the context for a single evaluation of an expression.
@@ -108,6 +105,7 @@ func (f *ExecutionFrame) SetContext(ctx context.Context, interruptCheckFrequency
 	f.ctx = evalContextPool.Get().(*evalContext)
 	f.ctx.ctx, f.ctx.cancel = context.WithCancel(ctx)
 	f.ctx.asyncCalls = asyncCallStateTrackerPool.create()
+	f.ctx.gate = &asyncGate{}
 	f.ctx.interrupt = ctx.Done()
 	f.ctx.interruptCheckFrequency = interruptCheckFrequency
 	f.ctx.interruptCheckCount.Store(0)
@@ -123,11 +121,10 @@ func (f *ExecutionFrame) Close() {
 			f.ctx.cancel = nil
 		}
 		f.ctx.ctx = nil
-		f.ctx.completions = nil
+		f.ctx.gate = nil
 		asyncCallStateTrackerPool.release(f.ctx.asyncCalls)
 		f.ctx.asyncCalls = nil
 		f.ctx.observer = nil
-		f.ctx.semaphore = nil
 		f.ctx.interrupt = nil
 		f.ctx.state = nil
 		f.ctx.costs = nil
@@ -230,17 +227,17 @@ func (f *ExecutionFrame) ComputeResult(id int64, function, overload string, impl
 		return types.NewErrWithNodeID(id, "asynchronous function calls require concurrent evaluation and cannot be resolved by a synchronous Eval")
 	}
 	t := f.ctx.asyncCalls
-	acs := t.getOrCreate(id, function, overload, argVals, impl, f.ctx.completions)
-	return t.launch(f.ctx.ctx, acs, f.ctx.observer, f.ctx.semaphore)
+	acs := t.getOrCreate(id, function, overload, argVals, impl, f.ctx.gate)
+	return t.launch(f.ctx.ctx, acs, f.ctx.observer)
 }
 
-// PendingAsyncCalls returns the number of async function calls that have been launched
+// ActiveAsyncCalls returns the number of async function calls that have been launched
 // but whose completions have not yet been drained.
-func (f *ExecutionFrame) PendingAsyncCalls() int {
-	if f.ctx == nil || f.ctx.asyncCalls == nil {
+func (f *ExecutionFrame) ActiveAsyncCalls() int {
+	if f.ctx == nil || f.ctx.gate == nil {
 		return 0
 	}
-	return f.ctx.asyncCalls.pendingCount()
+	return f.ctx.gate.ActiveCalls()
 }
 
 // AsyncCall returns the state of an async call by its callID, or nil if not found.
@@ -255,19 +252,12 @@ func (f *ExecutionFrame) AsyncCall(callID int64) AsyncCall {
 	return acs
 }
 
-// NotifyCompletion notifies the execution frame that an async call has completed and been drained.
-func (f *ExecutionFrame) NotifyCompletion(callID int64) {
-	if f.ctx != nil && f.ctx.asyncCalls != nil {
-		f.ctx.asyncCalls.notifyCompletion(callID)
-	}
-}
-
 // SetCompletions configures a channel to receive callIDs when asynchronous evaluations finish.
 func (f *ExecutionFrame) SetCompletions(ch chan<- int64) error {
 	if f.ctx == nil {
 		return errors.New("asynchronous evaluation options require the execution frame to have a context configured")
 	}
-	f.ctx.completions = ch
+	f.ctx.gate.completions = ch
 	return nil
 }
 
@@ -288,9 +278,9 @@ func (f *ExecutionFrame) SetAsyncMaxConcurrency(n int) error {
 		return errors.New("asynchronous evaluation options require the execution frame to have a context configured")
 	}
 	if n > 0 {
-		f.ctx.semaphore = make(chan struct{}, n)
+		f.ctx.gate.semaphore = make(chan struct{}, n)
 	} else {
-		f.ctx.semaphore = nil
+		f.ctx.gate.semaphore = nil
 	}
 	return nil
 }

--- a/interpreter/frame.go
+++ b/interpreter/frame.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/google/cel-go/common/functions"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 )
 
@@ -52,6 +54,18 @@ type evalContext struct {
 
 	// cancel cancels the context when the evaluation is finished.
 	cancel context.CancelFunc
+
+	// asyncCalls tracks the state of async call invocations across re-evaluations.
+	asyncCalls *asyncCallStateTracker
+
+	// completions is the channel async calls signal their callID to upon completion.
+	completions chan<- int64
+
+	// observer for monitoring async calls.
+	observer AsyncObserver
+
+	// semaphore for limiting async call concurrency. A nil value indicates no limit.
+	semaphore chan struct{}
 }
 
 // ExecutionFrame provides the context for a single evaluation of an expression.
@@ -93,6 +107,7 @@ func (f *ExecutionFrame) SetContext(ctx context.Context, interruptCheckFrequency
 	}
 	f.ctx = evalContextPool.Get().(*evalContext)
 	f.ctx.ctx, f.ctx.cancel = context.WithCancel(ctx)
+	f.ctx.asyncCalls = asyncCallStateTrackerPool.create()
 	f.ctx.interrupt = ctx.Done()
 	f.ctx.interruptCheckFrequency = interruptCheckFrequency
 	f.ctx.interruptCheckCount.Store(0)
@@ -108,6 +123,11 @@ func (f *ExecutionFrame) Close() {
 			f.ctx.cancel = nil
 		}
 		f.ctx.ctx = nil
+		f.ctx.completions = nil
+		asyncCallStateTrackerPool.release(f.ctx.asyncCalls)
+		f.ctx.asyncCalls = nil
+		f.ctx.observer = nil
+		f.ctx.semaphore = nil
 		f.ctx.interrupt = nil
 		f.ctx.state = nil
 		f.ctx.costs = nil
@@ -196,6 +216,81 @@ func (f *ExecutionFrame) CheckInterrupt() bool {
 		}
 	}
 	return false
+}
+
+// ComputeResult tracks and computes the result of the given asynchronous function.
+//
+// The first invocation for a given (node id, args) tuple launches the call and returns an
+// Unknown which references the call's unique callID. Subsequent invocations return the cached
+// result once the call has completed.
+func (f *ExecutionFrame) ComputeResult(id int64, function, overload string, impl functions.AsyncOp, argVals []ref.Val) ref.Val {
+	if f.ctx == nil || f.ctx.asyncCalls == nil {
+		return types.NewErrWithNodeID(id, "asynchronous function calls require concurrent evaluation and cannot be resolved by a synchronous Eval")
+	}
+	t := f.ctx.asyncCalls
+	acs := t.getOrCreate(id, function, overload, argVals, impl, f.ctx.completions)
+	return t.launch(f.ctx.ctx, acs, f.ctx.observer, f.ctx.semaphore)
+}
+
+// PendingAsyncCalls returns the number of async function calls that have been launched
+// but whose completions have not yet been drained.
+func (f *ExecutionFrame) PendingAsyncCalls() int {
+	if f.ctx == nil || f.ctx.asyncCalls == nil {
+		return 0
+	}
+	return f.ctx.asyncCalls.pendingCount()
+}
+
+// AsyncCall returns the state of an async call by its callID, or nil if not found.
+func (f *ExecutionFrame) AsyncCall(callID int64) AsyncCall {
+	if f.ctx == nil || f.ctx.asyncCalls == nil {
+		return nil
+	}
+	acs := f.ctx.asyncCalls.getByID(callID)
+	if acs == nil {
+		return nil
+	}
+	return acs
+}
+
+// NotifyCompletion notifies the execution frame that an async call has completed and been drained.
+func (f *ExecutionFrame) NotifyCompletion(callID int64) {
+	if f.ctx != nil && f.ctx.asyncCalls != nil {
+		f.ctx.asyncCalls.notifyCompletion(callID)
+	}
+}
+
+// SetCompletions configures a channel to receive callIDs when asynchronous evaluations finish.
+func (f *ExecutionFrame) SetCompletions(ch chan<- int64) error {
+	if f.ctx == nil {
+		return errors.New("asynchronous evaluation options require the execution frame to have a context configured")
+	}
+	f.ctx.completions = ch
+	return nil
+}
+
+// SetAsyncObserver sets the observer for monitoring asynchronous function calls.
+func (f *ExecutionFrame) SetAsyncObserver(observer AsyncObserver) error {
+	if f.ctx == nil {
+		return errors.New("asynchronous evaluation options require the execution frame to have a context configured")
+	}
+	f.ctx.observer = observer
+	return nil
+}
+
+// SetAsyncMaxConcurrency sets the maximum concurrency for asynchronous function calls.
+//
+// A non-positive value indicates that concurrency is unbounded.
+func (f *ExecutionFrame) SetAsyncMaxConcurrency(n int) error {
+	if f.ctx == nil {
+		return errors.New("asynchronous evaluation options require the execution frame to have a context configured")
+	}
+	if n > 0 {
+		f.ctx.semaphore = make(chan struct{}, n)
+	} else {
+		f.ctx.semaphore = nil
+	}
+	return nil
 }
 
 // frameStack provides a synchronized pool of ExecutionFrames.

--- a/interpreter/frame.go
+++ b/interpreter/frame.go
@@ -138,17 +138,19 @@ func (f *ExecutionFrame) Close() {
 	}
 	f.ctx = nil
 	f.parent = nil
-	switch a := f.Activation.(type) {
-	case *hierarchicalActivation:
-		if child, ok := a.child.(*inputActivation); ok {
-			activationInput.release(child)
+	if f.Activation != nil {
+		switch a := f.Activation.(type) {
+		case *hierarchicalActivation:
+			if child, ok := a.child.(*inputActivation); ok {
+				activationInput.release(child)
+			}
+			activationStack.release(a)
+		case *inputActivation:
+			activationInput.release(a)
 		}
-		activationStack.release(a)
-	case *inputActivation:
-		activationInput.release(a)
+		f.Activation = nil
+		frameStack.Put(f)
 	}
-	f.Activation = nil
-	frameStack.Put(f)
 }
 
 // Push pushes the given activation onto the activation stack and returns the new frame.

--- a/interpreter/frame_test.go
+++ b/interpreter/frame_test.go
@@ -380,6 +380,23 @@ func TestFrameClose(t *testing.T) {
 	}
 }
 
+func TestFrameDoubleClose(t *testing.T) {
+	frame := mustNewExecutionFrame(t, EmptyActivation())
+	ctx := context.Background()
+	frame.SetContext(ctx, 1)
+
+	// Close the frame the first time.
+	frame.Close()
+
+	// Closing it again should be a no-op and not panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("double Close() panicked: %v", r)
+		}
+	}()
+	frame.Close()
+}
+
 func TestFrameLifecycleAndPooling(t *testing.T) {
 	vars := map[string]any{"a": 1, "b": 2}
 	frame := mustNewExecutionFrame(t, vars)

--- a/interpreter/planner.go
+++ b/interpreter/planner.go
@@ -281,6 +281,10 @@ func (p *planBuilder) planCall(expr ast.Expr) (InterpretableV2, error) {
 	if fnDef == nil {
 		fnDef, _ = p.disp.FindOverload(fnName)
 	}
+	// Async overloads are planned into an evalAsyncFunc regardless of arity.
+	if fnDef != nil && fnDef.Async != nil {
+		return p.planCallAsync(expr, fnName, oName, fnDef, args)
+	}
 	switch argCount {
 	case 0:
 		return p.planCallZero(expr, fnName, oName, fnDef)
@@ -301,6 +305,24 @@ func (p *planBuilder) planCall(expr ast.Expr) (InterpretableV2, error) {
 	default:
 		return p.planCallVarArgs(expr, fnName, oName, fnDef, args)
 	}
+}
+
+// planCallAsync generates an asynchronous callable Interpretable.
+func (p *planBuilder) planCallAsync(expr ast.Expr,
+	function string,
+	overload string,
+	impl *functions.Overload,
+	args []InterpretableV2) (InterpretableV2, error) {
+	if impl == nil || impl.Async == nil {
+		return nil, fmt.Errorf("no such overload: %s()", function)
+	}
+	return &evalAsyncFunc{
+		id:       expr.ID(),
+		function: function,
+		overload: overload,
+		args:     args,
+		impl:     impl.Async,
+	}, nil
 }
 
 // planCallZero generates a zero-arity callable Interpretable.


### PR DESCRIPTION
Internal support for async function evaluation.

* Declaration support with guard functions just like sync functions
* The framework manages async function launches according to configurable concurrency limits
* Async functions are provided the `context.Context` object and expected to block
  until a result is available and return it. The framework manages go routines

The implementation supports minimal call deduplication logic which users
will be able to extend with functionality introduced into later PRs.