### PR TITLE
interpreter: reject duplicate keys in map literals

### DIFF
--- a/conformance/BUILD.bazel
+++ b/conformance/BUILD.bazel
@@ -39,8 +39,7 @@ _ALL_TESTS = [
 
 _TESTS_TO_SKIP = [
     # Failing conformance tests.
-    "fields/qualified_identifier_resolution/map_key_float,map_key_null,map_value_repeat_key",
-    "fields/qualified_identifier_resolution/map_value_repeat_key_heterogeneous",
+    "fields/qualified_identifier_resolution/map_key_float,map_key_null",
     "timestamps/duration_converters/get_milliseconds",
     "optionals/optionals/map_optional_select_has",
 

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -827,6 +827,17 @@ func (m *evalMap) Exec(frame *ExecutionFrame) ref.Val {
 			}
 			valVal = optVal.GetValue()
 		}
+		// Reject duplicate keys. The CEL specification defines a map literal with
+		// repeated keys as an evaluation error. Map keys are compared using CEL
+		// equality, so equal values of different runtime types (e.g. the int 1 and
+		// the uint 1u) collide even though they are distinct Go map keys. This
+		// mirrors the check already performed by mutableMap.Insert for the
+		// comprehension map-building path.
+		for existingKey := range entries {
+			if keyVal.Equal(existingKey) == types.True {
+				return types.LabelErrNode(m.id, types.NewErr("insert failed: key %v already exists", keyVal))
+			}
+		}
 		entries[keyVal] = valVal
 	}
 	return types.NewRefValMap(m.adapter, entries)

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -509,6 +509,30 @@ func testData(t testing.TB) []testCase {
 			expr: `{1: 'hello', 2: 'world'}[dyn(2u)] == 'world'`,
 		},
 		{
+			name: "map_literal_repeated_key",
+			expr: `{true: 1, false: 2, true: 3}[true]`,
+			err:  "insert failed: key true already exists",
+		},
+		{
+			name: "map_literal_repeated_key_string",
+			expr: `{'k': 'x', 'k': 'y'}['k']`,
+			err:  "insert failed: key k already exists",
+		},
+		{
+			name: "map_literal_repeated_key_heterogeneous",
+			expr: `{0: 1, 0u: 2}[0.0]`,
+			err:  "insert failed: key 0 already exists",
+		},
+		{
+			name: "map_literal_repeated_key_computed",
+			expr: `{('rol' + 'e'): 'admin', 'role': 'guest'}['role']`,
+			err:  "insert failed: key role already exists",
+		},
+		{
+			name: "map_literal_distinct_heterogeneous_keys",
+			expr: `{1: 'a', 2u: 'b'}[dyn(2u)] == 'b'`,
+		},
+		{
 			name: "index_cross_type_bad_qualifier",
 			expr: `{1: 'hello', 2: 'world'}[x] == 'world'`,
 			vars: []*decls.VariableDecl{


### PR DESCRIPTION
Fixes #1348

### Problem

A map literal that contains duplicate keys was evaluated without error; the last value silently won instead of failing as the spec requires:

```
{1: "a", 1: "b"}         // -> {1: "b"}, no error
{"k": "x", "k": "y"}     // -> {"k": "y"}, no error
{true: 1, false: 2, true: 3}[true]   // -> 3, no error
```

The CEL language spec ("Aggregate Values") states: *"It is an error to have duplicate keys or field names."* Both cel-cpp and cel-java reject such expressions, so cel-go was inconsistent with the spec and the other implementations.

The inconsistency also exists **within** cel-go: the comprehension map-building path already reports the collision via `mutableMap.Insert` ("insert failed: key ... already exists"), but the map-literal evaluation path (`evalMap.Exec`) wrote into a plain Go `map[ref.Val]ref.Val` and never checked for duplicates.

Keys are not necessarily constant — they can be computed at runtime (e.g. `{("rol" + "e"): "admin", "role": "guest"}`), so the duplicate is not always visible to the type checker and must be detected during evaluation.

### Fix

`evalMap.Exec` now rejects duplicate keys, mirroring the check already performed by `mutableMap.Insert`. Keys are compared using CEL equality, so equal values of different runtime types (e.g. the int `1` and the uint `1u`) collide even though they are distinct Go map keys. The error is labeled with the map's AST node id, consistent with the other errors produced by `evalMap.Exec`.

The optional-entry path is unaffected: an entry whose optional value is absent removes the key and is not treated as a duplicate.

### Verification

- Added regression tests in `interpreter/interpreter_test.go` covering same-type, string, heterogeneous (`{0: 1, 0u: 2}`), and runtime-computed duplicate keys, plus a negative case ensuring distinct heterogeneous keys still work. These run under the default, `optimize` (constant-folding), `exhaustive`, and `track` planner modes, and assert the error carries an AST node id.
- Confirmed the tests fail before the change (returning the last-wins value) and pass after it.
- This makes cel-go pass the previously-skipped conformance tests `fields/qualified_identifier_resolution/map_value_repeat_key` and `map_value_repeat_key_heterogeneous`, which are removed from the skip list in `conformance/BUILD.bazel`. Both expressions were verified to type-check (they have no `disable_check`) and to error at evaluation through the full `cel` compile+eval pipeline.
- `go test ./...` (excluding the bazel-only conformance package) passes with no regressions; `gofmt` and `go vet` are clean.
