### PR TITLE
Introduce async DrainStrategy, DrainAction, Observer, and Call types

### DIFF
--- a/cel/async/BUILD.bazel
+++ b/cel/async/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(
+    licenses = ["notice"],  # Apache 2.0
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "async.go",
+    ],
+    importpath = "github.com/google/cel-go/cel/async",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//interpreter:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "async_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+    ],
+)

--- a/cel/async/async.go
+++ b/cel/async/async.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package async provides helpers for configuring and executing asynchronous CEL functions,
+// including drain strategies, retry, timeout, concurrency limiting, and caching wrappers.
+package async
+
+import (
+	"time"
+
+	"github.com/google/cel-go/interpreter"
+)
+
+// Call describes a pending or completed asynchronous function call.
+// This interface exposes a safe, read-only view of the internal interpreter state.
+type Call = interpreter.AsyncCall
+
+// Observer provides callbacks for monitoring the lifecycle of asynchronous function calls.
+//
+// Implementations must be safe for concurrent use: the start and finish callbacks run on different
+// goroutines, and finish callbacks for distinct calls may run concurrently. See
+// interpreter.AsyncObserver for details.
+type Observer = interpreter.AsyncObserver
+
+// DrainAction dictates what ConcurrentEval should do after inspecting completions.
+type DrainAction struct {
+	// Reevaluate indicates that the AST should be re-evaluated immediately.
+	// If true, WaitDuration is ignored.
+	Reevaluate bool
+	// WaitDuration indicates how long the evaluator should wait for additional
+	// completions before deciding to re-evaluate. A duration of 0 means wait
+	// indefinitely (block on the next completion).
+	WaitDuration time.Duration
+}
+
+// DrainStrategy controls when ConcurrentEval re-evaluates after async completions.
+//
+// The evaluator consults the strategy each time a completion is received.
+type DrainStrategy interface {
+	// NextAction evaluates the current state of asynchronous evaluation and
+	// determines the next step.
+	//
+	// - completed: The set of completions accumulated in the current batch.
+	// - pending: The number of async calls currently launched but unresolved.
+	NextAction(completed []Call, pending int) DrainAction
+}
+
+// DrainNone returns a strategy that re-evaluates after every single completion.
+// This is the default strategy.
+func DrainNone() DrainStrategy {
+	return drainNone{}
+}
+
+type drainNone struct{}
+
+func (drainNone) NextAction(completed []Call, pending int) DrainAction {
+	return DrainAction{Reevaluate: pending == 0 || len(completed) > 0}
+}
+
+// DrainReady returns a strategy that waits for a short duration after the first
+// completion to batch any other functions that complete at roughly the same time.
+func DrainReady(debounce time.Duration) DrainStrategy {
+	return drainReady{debounce: debounce}
+}
+
+type drainReady struct {
+	debounce time.Duration
+}
+
+func (d drainReady) NextAction(completed []Call, pending int) DrainAction {
+	if pending == 0 {
+		return DrainAction{Reevaluate: true} // Nothing left to wait for
+	}
+	if len(completed) == 0 {
+		return DrainAction{Reevaluate: false, WaitDuration: 0} // Wait indefinitely for first
+	}
+	return DrainAction{Reevaluate: false, WaitDuration: d.debounce} // Wait for debounce period
+}
+
+// DrainAll returns a strategy that waits for all currently pending calls to
+// complete before re-evaluating.
+//
+// Note: This strategy is optimal for independent async calls, but will over-wait
+// if some calls depend on the results of others.
+func DrainAll() DrainStrategy {
+	return drainAll{}
+}
+
+type drainAll struct{}
+
+func (drainAll) NextAction(completed []Call, pending int) DrainAction {
+	return DrainAction{Reevaluate: pending == 0}
+}

--- a/cel/async/async_test.go
+++ b/cel/async/async_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package async_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/cel/async"
+)
+
+type mockAsyncCall struct {
+	id       int64
+	function string
+	overload string
+}
+
+func (m mockAsyncCall) CallID() int64    { return m.id }
+func (m mockAsyncCall) Function() string { return m.function }
+func (m mockAsyncCall) Overload() string { return m.overload }
+
+func TestAsyncCallMethods(t *testing.T) {
+	m := mockAsyncCall{id: 1, function: "f", overload: "o"}
+	if m.CallID() != 1 {
+		t.Errorf("got %d, want 1", m.CallID())
+	}
+	if m.Function() != "f" {
+		t.Errorf("got %s, want f", m.Function())
+	}
+	if m.Overload() != "o" {
+		t.Errorf("got %s, want o", m.Overload())
+	}
+}
+
+func TestDrainNone(t *testing.T) {
+	s := async.DrainNone()
+	// No completions, calls still pending -> no re-evaluation
+	if s.NextAction(nil, 1).Reevaluate {
+		t.Error("DrainNone re-evaluated with nil batch")
+	}
+	// One completion -> re-evaluate
+	if !s.NextAction([]async.Call{mockAsyncCall{}}, 1).Reevaluate {
+		t.Error("DrainNone did not re-evaluate with 1 completion")
+	}
+	// No pending -> re-evaluate regardless of batch
+	if !s.NextAction(nil, 0).Reevaluate {
+		t.Error("DrainNone did not re-evaluate when nothing pending")
+	}
+}
+
+func TestDrainAll(t *testing.T) {
+	s := async.DrainAll()
+	// Pending calls remain -> no re-evaluation
+	if s.NextAction([]async.Call{mockAsyncCall{}}, 1).Reevaluate {
+		t.Error("DrainAll re-evaluated while calls are pending")
+	}
+	// No pending calls -> re-evaluate
+	if !s.NextAction([]async.Call{mockAsyncCall{}}, 0).Reevaluate {
+		t.Error("DrainAll did not re-evaluate when no calls pending")
+	}
+}
+
+func TestDrainReady(t *testing.T) {
+	debounce := 10 * time.Millisecond
+	s := async.DrainReady(debounce)
+
+	// No pending calls -> re-evaluate immediately
+	action := s.NextAction([]async.Call{mockAsyncCall{}}, 0)
+	if !action.Reevaluate {
+		t.Error("DrainReady did not re-evaluate when no calls pending")
+	}
+
+	// No completions -> wait indefinitely
+	action = s.NextAction(nil, 1)
+	if action.Reevaluate || action.WaitDuration != 0 {
+		t.Errorf("DrainReady NextAction(nil, 1) = %v, want {false, 0}", action)
+	}
+
+	// Some completions, still pending -> wait for the debounce window
+	action = s.NextAction([]async.Call{mockAsyncCall{}}, 1)
+	if action.Reevaluate || action.WaitDuration != debounce {
+		t.Errorf("DrainReady NextAction(batch, 1) = %v, want {false, %v}", action, debounce)
+	}
+}


### PR DESCRIPTION
Create `cel/async` package with interfaces used by concurrent eval

* `async.Call` is a read-only view of a pending or completed async operation
* `async.Observer` can be used to receive start / stop notification for an `async.Call`
* `async.DrainStrategy` controls how and when to consume async call results in an evaluation
* `async.DrainAction` indicates how the concurrent evaluation should treat the batch of results

`ConcurrentEval` will initiate a CEL expression evaluation that triggers one or more async
calls. As calls complete, the expression evaluation will be performed again using the results
from the call to advance the expression evaluation to a conclusive state.