### PR TITLE
Async timeout and retry wrappers

### DIFF
--- a/cel/async/BUILD.bazel
+++ b/cel/async/BUILD.bazel
@@ -12,7 +12,10 @@ go_library(
     importpath = "github.com/google/cel-go/cel/async",
     visibility = ["//visibility:public"],
     deps = [
+        "//common/decls:go_default_library",
         "//common/functions:go_default_library",
+        "//common/types:go_default_library",
+        "//common/types/ref:go_default_library",
         "//interpreter:go_default_library",
     ],
 )
@@ -24,5 +27,9 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//common/decls:go_default_library",
+        "//common/functions:go_default_library",
+        "//common/types:go_default_library",
+        "//common/types/ref:go_default_library",
     ],
 )

--- a/cel/async/async.go
+++ b/cel/async/async.go
@@ -17,9 +17,14 @@
 package async
 
 import (
+	"context"
+	"errors"
 	"time"
 
+	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/functions"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
 )
 
@@ -105,4 +110,126 @@ type drainAll struct{}
 
 func (drainAll) NextAction(completed []Call, active int) DrainAction {
 	return DrainAction{Reevaluate: active == 0}
+}
+
+// Timeout wraps a BlockingAsyncOp with a per-call timeout.
+//
+// The timeout is enforced even when the wrapped function ignores its context: the function runs on
+// its own goroutine and Timeout selects on the deadline, returning a timeout error when it
+// fires. A function that ignores cancellation cannot be forcibly stopped (Go cannot kill a
+// goroutine), so its goroutine continues running in the background until it returns on its own;
+// only its result is abandoned. This is the recommended way to bound functions that may hang or
+// are not under the caller's control. The extra goroutine is incurred only by Timeout-wrapped
+// calls, not by async evaluation in general.
+func Timeout(fn functions.BlockingAsyncOp, timeout time.Duration) functions.BlockingAsyncOp {
+	return func(ctx context.Context, args ...ref.Val) ref.Val {
+		tCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		resCh := make(chan ref.Val, 1)
+		go func() { resCh <- fn(tCtx, args...) }()
+		select {
+		case res := <-resCh:
+			return res
+		case <-tCtx.Done():
+			return types.NewErr("operation timed out after %v: %v", timeout, tCtx.Err())
+		}
+	}
+}
+
+// TimeoutBinding wraps a BlockingAsyncOp with a per-call timeout and returns an OverloadOpt.
+func TimeoutBinding(fn functions.BlockingAsyncOp, timeout time.Duration) decls.OverloadOpt {
+	return decls.AsyncBinding(Timeout(fn, timeout))
+}
+
+// RetryOption configures the behavior of RetryBinding.
+type RetryOption func(*retryConfig)
+
+type retryConfig struct {
+	maxAttempts int
+	backoff     time.Duration
+}
+
+// RetryAttempts sets the maximum number of attempts (including the first one).
+func RetryAttempts(attempts int) RetryOption {
+	return func(c *retryConfig) {
+		c.maxAttempts = attempts
+	}
+}
+
+// RetryBackoff sets the fixed backoff duration between attempts.
+func RetryBackoff(backoff time.Duration) RetryOption {
+	return func(c *retryConfig) {
+		c.backoff = backoff
+	}
+}
+
+// RetryableError is an interface that errors can implement to signal whether they are retryable.
+type RetryableError interface {
+	error
+	IsRetryable() bool
+}
+
+// Retry wraps a BlockingAsyncOp with a retry policy.
+// It will retry the operation if it returns a types.Err that wraps a RetryableError returning true for IsRetryable.
+func Retry(fn functions.BlockingAsyncOp, opts ...RetryOption) functions.BlockingAsyncOp {
+	config := &retryConfig{
+		maxAttempts: 3,
+		backoff:     100 * time.Millisecond,
+	}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	return func(ctx context.Context, args ...ref.Val) ref.Val {
+		var lastErr ref.Val
+		var backoff *time.Timer
+		defer func() {
+			if backoff != nil {
+				backoff.Stop()
+			}
+		}()
+		for i := 0; i < config.maxAttempts; i++ {
+			if i > 0 {
+				// Reuse a single timer across attempts and stop it on cancellation so the
+				// pending timer is not left to fire after the call returns.
+				if backoff == nil {
+					backoff = time.NewTimer(config.backoff)
+				} else {
+					backoff.Reset(config.backoff)
+				}
+				select {
+				case <-backoff.C:
+				case <-ctx.Done():
+					backoff.Stop()
+					return types.NewErr("operation cancelled during retry: %v", ctx.Err())
+				}
+			}
+
+			res := fn(ctx, args...)
+			if !types.IsError(res) {
+				return res
+			}
+
+			err := res.(*types.Err)
+			lastErr = res
+
+			if !isRetryable(err) {
+				return res
+			}
+		}
+		return lastErr
+	}
+}
+
+// RetryBinding wraps a BlockingAsyncOp with a retry policy and returns an OverloadOpt.
+func RetryBinding(fn functions.BlockingAsyncOp, opts ...RetryOption) decls.OverloadOpt {
+	return decls.AsyncBinding(Retry(fn, opts...))
+}
+
+func isRetryable(err *types.Err) bool {
+	var re RetryableError
+	if errors.As(err, &re) {
+		return re.IsRetryable()
+	}
+	return false
 }

--- a/cel/async/async_test.go
+++ b/cel/async/async_test.go
@@ -15,11 +15,151 @@
 package async_test
 
 import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/cel-go/cel/async"
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/functions"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
 )
+
+type retryableTestErr struct{}
+
+func (retryableTestErr) Error() string     { return "retry me" }
+func (retryableTestErr) IsRetryable() bool { return true }
+
+type nonRetryableTestErr struct{}
+
+func (nonRetryableTestErr) Error() string     { return "do not retry me" }
+func (nonRetryableTestErr) IsRetryable() bool { return false }
+
+// buildZeroArgAsync builds a zero-arity async overload from an option and returns its AsyncOp.
+func buildZeroArgAsync(t *testing.T, opt decls.OverloadOpt) functions.AsyncOp {
+	t.Helper()
+	fnDecl, err := decls.NewFunction("fn", decls.Overload("fn_zero", []*types.Type{}, types.IntType, opt))
+	if err != nil {
+		t.Fatalf("NewFunction() failed: %v", err)
+	}
+	bindings, err := fnDecl.Bindings()
+	if err != nil {
+		t.Fatalf("Bindings() failed: %v", err)
+	}
+	for _, b := range bindings {
+		if b.Async != nil {
+			return b.Async
+		}
+	}
+	t.Fatal("no async binding produced")
+	return nil
+}
+
+func TestRetryMultipleAttemptsTimerReset(t *testing.T) {
+	var attempts atomic.Int32
+	op := buildZeroArgAsync(t, async.RetryBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+		a := attempts.Add(1)
+		if a < 3 {
+			return types.WrapErr(retryableTestErr{})
+		}
+		return types.Int(100)
+	}, async.RetryAttempts(4), async.RetryBackoff(5*time.Millisecond)))
+
+	res := <-op(context.Background())
+	if res.Equal(types.Int(100)) != types.True {
+		t.Fatalf("result = %v, want 100", res)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("attempts = %d, want 3", got)
+	}
+}
+
+func TestRetryMaxAttemptsExhausted(t *testing.T) {
+	var attempts atomic.Int32
+	op := buildZeroArgAsync(t, async.RetryBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+		a := attempts.Add(1)
+		return types.WrapErr(fmt.Errorf("retry attempt %d failed: %w", a, retryableTestErr{}))
+	}, async.RetryAttempts(3), async.RetryBackoff(5*time.Millisecond)))
+
+	res := <-op(context.Background())
+	if !types.IsError(res) {
+		t.Fatalf("result = %v, want error", res)
+	}
+	msg := res.(*types.Err).Error()
+	if !strings.Contains(msg, "retry attempt 3 failed") {
+		t.Errorf("result error = %q, want last error 'retry attempt 3 failed'", msg)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("attempts = %d, want 3", got)
+	}
+}
+
+func TestRetryBindingCancellation(t *testing.T) {
+	var attempts atomic.Int32
+	op := buildZeroArgAsync(t, async.RetryBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+		attempts.Add(1)
+		return types.WrapErr(retryableTestErr{})
+	}, async.RetryAttempts(5), async.RetryBackoff(500*time.Millisecond)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	var res ref.Val
+	select {
+	case res = <-op(ctx):
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry op did not return after cancellation")
+	}
+	elapsed := time.Since(start)
+
+	if !types.IsError(res) || !strings.Contains(res.(*types.Err).Error(), "cancelled") {
+		t.Errorf("result = %v, want a cancellation error", res)
+	}
+	// Cancellation must interrupt the backoff wait rather than running it to completion.
+	if elapsed >= 500*time.Millisecond {
+		t.Errorf("retry waited the full backoff (%v); cancellation did not interrupt it", elapsed)
+	}
+}
+
+func TestRetryNonRetryableError(t *testing.T) {
+	var attempts atomic.Int32
+	op := buildZeroArgAsync(t, async.RetryBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+		attempts.Add(1)
+		return types.WrapErr(nonRetryableTestErr{})
+	}, async.RetryAttempts(5), async.RetryBackoff(10*time.Millisecond)))
+
+	res := <-op(context.Background())
+	if !types.IsError(res) || !strings.Contains(res.(*types.Err).Error(), "do not retry me") {
+		t.Fatalf("result = %v, want 'do not retry me'", res)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("attempts = %d, want 1 (non-retryable error should not be retried)", got)
+	}
+}
+
+func TestRetryStandardError(t *testing.T) {
+	var attempts atomic.Int32
+	op := buildZeroArgAsync(t, async.RetryBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+		attempts.Add(1)
+		return types.NewErr("generic error")
+	}, async.RetryAttempts(5), async.RetryBackoff(10*time.Millisecond)))
+
+	res := <-op(context.Background())
+	if !types.IsError(res) || !strings.Contains(res.(*types.Err).Error(), "generic error") {
+		t.Fatalf("result = %v, want 'generic error'", res)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("attempts = %d, want 1 (standard error should not be retried)", got)
+	}
+}
 
 type mockAsyncCall struct {
 	id       int64
@@ -92,5 +232,30 @@ func TestDrainReady(t *testing.T) {
 	action = s.NextAction([]async.Call{mockAsyncCall{}}, 1)
 	if action.Reevaluate || action.WaitDuration != debounce {
 		t.Errorf("DrainReady NextAction(batch, 1) = %v, want {false, %v}", action, debounce)
+	}
+}
+
+func TestTimeoutBindingEnforcesAgainstContextIgnoringOp(t *testing.T) {
+	// The wrapped op sleeps well past the timeout without consulting its context. TimeoutBinding
+	// must still return at the deadline rather than waiting for the op to finish.
+	op := buildZeroArgAsync(t, async.TimeoutBinding(func(ctx context.Context, args ...ref.Val) ref.Val {
+		time.Sleep(2 * time.Second) // ignores ctx entirely
+		return types.Int(1)
+	}, 50*time.Millisecond))
+
+	start := time.Now()
+	var res ref.Val
+	select {
+	case res = <-op(context.Background()):
+	case <-time.After(2 * time.Second):
+		t.Fatal("TimeoutBinding did not return; the op was not abandoned")
+	}
+	elapsed := time.Since(start)
+
+	if !types.IsError(res) || !strings.Contains(res.(*types.Err).Error(), "timed out") {
+		t.Errorf("result = %v, want a timeout error", res)
+	}
+	if elapsed >= 500*time.Millisecond {
+		t.Errorf("TimeoutBinding waited %v; the timeout must abandon a ctx-ignoring op", elapsed)
 	}
 }


### PR DESCRIPTION
Introduce support for `Timeout` and `Retry` wrappers for async functions.

- `Timeout` ensures requests are cancelled even if the async call does not honor context cancellation
- `Retry` supports fixed number retries at fixed intervals using the `RetryableError` interface as a basis
   for determining whether to retry the request.

For HTTP requests, the expectation is that the async function wrapper will inspect the response code
and surface a `types.Err` for non-OK responses. 