### PR TITLE
Fix constant folding and local variable resolution

### DIFF
--- a/cel/folding.go
+++ b/cel/folding.go
@@ -17,7 +17,6 @@ package cel
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/operators"
@@ -178,17 +177,8 @@ func evaluateExpr(ctx *OptimizerContext, a *ast.AST, navigableExpr ast.Navigable
 		return nil, err
 	}
 	out, _, err := prg.Eval(partialActivation)
-	if err != nil {
-		if strings.Contains(err.Error(), "no such attribute") {
-			return nil, errCannotFold
-		}
-		return nil, err
-	}
-	if types.IsUnknown(out) {
+	if err != nil || types.IsUnknown(out) {
 		return nil, errCannotFold
-	}
-	if types.IsError(out) {
-		return nil, fmt.Errorf("%v", out)
 	}
 	return out, nil
 }

--- a/cel/folding.go
+++ b/cel/folding.go
@@ -15,7 +15,9 @@
 package cel
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/operators"
@@ -102,9 +104,9 @@ func (opt *constantFoldingOptimizer) Optimize(ctx *OptimizerContext, a *ast.AST)
 			}
 			// Otherwise, assume all context is needed to evaluate the expression.
 			err := opt.tryFold(ctx, a, fold)
-			// Ignore errors for identifiers, since there is no guarantee that the environment
+			// Ignore errors for identifiers or subexpressions that cannot be folded, since there is no guarantee that the environment
 			// has a value for them.
-			if err != nil && fold.Kind() != ast.IdentKind {
+			if err != nil && fold.Kind() != ast.IdentKind && !errors.Is(err, errCannotFold) {
 				ctx.ReportErrorAtID(fold.ID(), "constant-folding evaluation failed: %v", err.Error())
 				return a
 			}
@@ -142,30 +144,53 @@ func (opt *constantFoldingOptimizer) Optimize(ctx *OptimizerContext, a *ast.AST)
 	return a
 }
 
+var errCannotFold = errors.New("subexpression cannot be folded")
+
 // tryFold attempts to evaluate a sub-expression to a literal.
 //
 // If the evaluation succeeds, the input expr value will be modified to become a literal, otherwise
 // the method will return an error.
 func (opt *constantFoldingOptimizer) tryFold(ctx *OptimizerContext, a *ast.AST, expr ast.Expr) error {
-	// Assume all context is needed to evaluate the expression.
-	subAST := &Ast{
-		impl: ast.NewCheckedAST(ast.NewAST(expr, a.SourceInfo()), a.TypeMap(), a.ReferenceMap()),
-	}
-	prg, err := ctx.Program(subAST)
-	if err != nil {
-		return err
-	}
 	activation := opt.knownValues
 	if activation == nil {
 		activation = NoVars()
 	}
-	out, _, err := prg.Eval(activation)
+	navExpr := expr.(ast.NavigableExpr)
+	out, err := evaluateExpr(ctx, a, navExpr, activation)
 	if err != nil {
 		return err
 	}
 	// Update the fold expression to be a literal.
 	ctx.UpdateExpr(expr, ctx.NewLiteral(out))
 	return nil
+}
+
+func evaluateExpr(ctx *OptimizerContext, a *ast.AST, navigableExpr ast.NavigableExpr, activation Activation) (ref.Val, error) {
+	partialActivation, err := ctx.PartialVars(activation)
+	if err != nil {
+		return nil, err
+	}
+	subAST := &Ast{
+		impl: ast.NewCheckedAST(ast.NewAST(navigableExpr, a.SourceInfo()), a.TypeMap(), a.ReferenceMap()),
+	}
+	prg, err := ctx.Program(subAST)
+	if err != nil {
+		return nil, err
+	}
+	out, _, err := prg.Eval(partialActivation)
+	if err != nil {
+		if strings.Contains(err.Error(), "no such attribute") {
+			return nil, errCannotFold
+		}
+		return nil, err
+	}
+	if types.IsUnknown(out) {
+		return nil, errCannotFold
+	}
+	if types.IsError(out) {
+		return nil, fmt.Errorf("%v", out)
+	}
+	return out, nil
 }
 
 func isLateBoundFunctionCall(ctx *OptimizerContext, expr ast.Expr) bool {
@@ -207,11 +232,17 @@ func maybePruneBranches(ctx *OptimizerContext, expr ast.NavigableExpr) bool {
 			return true
 		}
 		needle := args[0]
-		if needle.Kind() == ast.LiteralKind && haystack.Kind() == ast.ListKind {
-			needleValue := needle.AsLiteral()
+		if (needle.Kind() == ast.LiteralKind || needle.Kind() == ast.IdentKind) && haystack.Kind() == ast.ListKind {
+			needleIsLit := needle.Kind() == ast.LiteralKind
+			needleLitVal := needle.AsLiteral()
+			needleIdentVal := needle.AsIdent()
 			list := haystack.AsList()
-			for _, e := range list.Elements() {
-				if e.Kind() == ast.LiteralKind && e.AsLiteral().Equal(needleValue) == types.True {
+			for _, elem := range list.Elements() {
+				if needleIsLit && elem.Kind() == ast.LiteralKind && elem.AsLiteral().Equal(needleLitVal) == types.True {
+					ctx.UpdateExpr(expr, ctx.NewLiteral(types.True))
+					return true
+				}
+				if !needleIsLit && elem.Kind() == ast.IdentKind && elem.AsIdent() == needleIdentVal {
 					ctx.UpdateExpr(expr, ctx.NewLiteral(types.True))
 					return true
 				}
@@ -285,9 +316,9 @@ func pruneOptionalListElements(ctx *OptimizerContext, e ast.Expr) {
 	updatedElems := []ast.Expr{}
 	updatedIndices := []int32{}
 	newOptIndex := -1
-	for _, e := range elems {
+	for i, e := range elems {
 		newOptIndex++
-		if !l.IsOptional(int32(newOptIndex)) {
+		if !l.IsOptional(int32(i)) {
 			updatedElems = append(updatedElems, e)
 			continue
 		}
@@ -554,17 +585,33 @@ func constantCallMatcher(e ast.NavigableExpr) bool {
 			return true
 		}
 	}
+	if fnName == operators.Equals || fnName == operators.NotEquals {
+		if hasComprehensionVar(e) {
+			return false
+		}
+		if isExprConstantOfKind(children[0], types.BoolType) || isExprConstantOfKind(children[1], types.BoolType) {
+			return true
+		}
+	}
 	if fnName == operators.In {
+		if hasComprehensionVar(e) {
+			return false
+		}
 		haystack := children[1]
 		if haystack.Kind() == ast.ListKind && haystack.AsList().Size() == 0 {
 			return true
 		}
 		needle := children[0]
-		if needle.Kind() == ast.LiteralKind && haystack.Kind() == ast.ListKind {
-			needleValue := needle.AsLiteral()
+		if (needle.Kind() == ast.LiteralKind || needle.Kind() == ast.IdentKind) && haystack.Kind() == ast.ListKind {
+			needleIsLit := needle.Kind() == ast.LiteralKind
+			needleLitVal := needle.AsLiteral()
+			needleIdentVal := needle.AsIdent()
 			list := haystack.AsList()
-			for _, e := range list.Elements() {
-				if e.Kind() == ast.LiteralKind && e.AsLiteral().Equal(needleValue) == types.True {
+			for _, elem := range list.Elements() {
+				if needleIsLit && elem.Kind() == ast.LiteralKind && elem.AsLiteral().Equal(needleLitVal) == types.True {
+					return true
+				}
+				if !needleIsLit && elem.Kind() == ast.IdentKind && elem.AsIdent() == needleIdentVal {
 					return true
 				}
 			}
@@ -577,6 +624,31 @@ func constantCallMatcher(e ast.NavigableExpr) bool {
 		}
 	}
 	return true
+}
+
+func isExprConstantOfKind(e ast.Expr, t *types.Type) bool {
+	return e.Kind() == ast.LiteralKind && e.AsLiteral().Type() == t
+}
+
+func hasComprehensionVar(e ast.NavigableExpr) bool {
+	idents := ast.MatchDescendants(e, ast.KindMatcher(ast.IdentKind))
+	for _, identNode := range idents {
+		identName := identNode.AsIdent()
+		curr := identNode
+		parent, found := curr.Parent()
+		for found {
+			if parent.Kind() == ast.ComprehensionKind {
+				compre := parent.AsComprehension()
+				if (compre.AccuVar() == identName || compre.IterVar() == identName || compre.IterVar2() == identName) &&
+					curr.ID() != compre.IterRange().ID() && curr.ID() != compre.AccuInit().ID() {
+					return true
+				}
+			}
+			curr = parent
+			parent, found = parent.Parent()
+		}
+	}
+	return false
 }
 
 func isNestedComprehension(e ast.NavigableExpr) bool {

--- a/cel/folding.go
+++ b/cel/folding.go
@@ -522,7 +522,7 @@ func (opt *constantFoldingOptimizer) constantExprMatcher(ctx *OptimizerContext, 
 		sel := e.AsSelect() // guaranteed to be a navigable value
 		return constantMatcher(sel.Operand().(ast.NavigableExpr))
 	case ast.IdentKind:
-		return opt.knownValues != nil && a.ReferenceMap()[e.ID()] != nil
+		return opt.knownValues != nil && a.ReferenceMap()[e.ID()] != nil && !hasComprehensionVar(e)
 	case ast.ComprehensionKind:
 		if isNestedComprehension(e) {
 			return false
@@ -534,6 +534,9 @@ func (opt *constantFoldingOptimizer) constantExprMatcher(ctx *OptimizerContext, 
 				nested := e.AsComprehension()
 				vars[nested.AccuVar()] = true
 				vars[nested.IterVar()] = true
+				if nested.IterVar2() != "" {
+					vars[nested.IterVar2()] = true
+				}
 			}
 			if e.Kind() == ast.IdentKind && !vars[e.AsIdent()] {
 				constantExprs = false

--- a/cel/folding_test.go
+++ b/cel/folding_test.go
@@ -15,6 +15,7 @@
 package cel
 
 import (
+	"errors"
 	"reflect"
 	"sort"
 	"strings"
@@ -24,8 +25,10 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter"
 
 	proto3pb "github.com/google/cel-go/test/proto3pb"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -118,6 +121,14 @@ func TestConstantFoldingOptimizer(t *testing.T) {
 			folded: `[1, 2, 3].map(i, [1, 2, 3].map(j, i * j).filter(k, k % 2 == x))`,
 		},
 		{
+			expr:   `[(x - 1 > 3) ? 1 : 2].all(x, x < .x)`,
+			folded: `[(x - 1 > 3) ? 1 : 2].all(x, x < .x)`,
+		},
+		{
+			expr:   `[(x - 1 > 3) ? (x - 1) : 5].exists(x, x - 1 > 3)`,
+			folded: `[(x - 1 > 3) ? (x - 1) : 5].exists(x, x - 1 > 3)`,
+		},
+		{
 			expr:   `[{}, {"a": 1}, {"b": 2}].filter(m, has(m.a))`,
 			folded: `[{"a": 1}]`,
 		},
@@ -150,6 +161,10 @@ func TestConstantFoldingOptimizer(t *testing.T) {
 			folded: `[?x]`,
 		},
 		{
+			expr:   `[?optional.of(1), ?x]`,
+			folded: `[1, ?x]`,
+		},
+		{
 			expr:   `[1, x, ?optional.ofNonZeroValue(0), ?x.?y]`,
 			folded: `[1, x, ?x.?y]`,
 		},
@@ -176,6 +191,26 @@ func TestConstantFoldingOptimizer(t *testing.T) {
 		{
 			expr:   `false ? x + 'world' : 'hello' + 'world'`,
 			folded: `"helloworld"`,
+		},
+		{
+			expr:   `x == true`,
+			folded: `x == true`,
+		},
+		{
+			expr:   `true == x`,
+			folded: `true == x`,
+		},
+		{
+			expr:   `x != false`,
+			folded: `x != false`,
+		},
+		{
+			expr:   `false != x`,
+			folded: `false != x`,
+		},
+		{
+			expr:   `x ? 1 + 2 : 3 + 4`,
+			folded: `x ? 3 : 7`,
 		},
 		{
 			expr:   `true && x`,
@@ -326,12 +361,142 @@ func TestConstantFoldingOptimizer(t *testing.T) {
 				"o": &proto3pb.TestAllTypes{RepeatedInt32: []int32{1, 2, 3}},
 			},
 		},
+		{
+			expr:   `false || x || false || y`,
+			folded: `x || y`,
+		},
+		{
+			expr:   `true ? (false ? x + 1 : x + 2) : x`,
+			folded: `x + 2`,
+		},
+		{
+			expr:   `false ? x : (true ? x + 1 : x + 2)`,
+			folded: `x + 1`,
+		},
+		{
+			expr:   `1 in []`,
+			folded: `false`,
+		},
+		{
+			expr:   `x in [1, 2, x]`,
+			folded: `true`,
+		},
+		{
+			expr:   `[1, 2].filter(x, x in [1, 2])`,
+			folded: `[1, 2]`,
+		},
+		{
+			expr:   `5 in [1, x, y, 5]`,
+			folded: `true`,
+		},
+		{
+			expr:   `!(5 in [1, x, y, 5])`,
+			folded: `false`,
+		},
+		{
+			expr:   `[1, ?optional.of(3)]`,
+			folded: `[1, 3]`,
+		},
+		{
+			expr:   `[1, optional.of(3)]`,
+			folded: `[1, optional.of(3)]`,
+		},
+		{
+			expr:   `[?optional.of(1 + 2 + 3)]`,
+			folded: `[6]`,
+		},
+		{
+			expr:   `[?optional.of(3)]`,
+			folded: `[3]`,
+		},
+		{
+			expr:   `[?optional.of(x)]`,
+			folded: `[?optional.of(x)]`,
+		},
+		{
+			expr:   `[?optional.ofNonZeroValue(3)]`,
+			folded: `[3]`,
+		},
+		{
+			expr:   `[optional.of(1 + 2 + 3)]`,
+			folded: `[optional.of(6)]`,
+		},
+		{
+			expr:   `[optional.of(x)]`,
+			folded: `[optional.of(x)]`,
+		},
+		{
+			expr:   `[optional.ofNonZeroValue(1 + 2 + 3)]`,
+			folded: `[optional.of(6)]`,
+		},
+		{
+			expr:   `[optional.ofNonZeroValue(3)]`,
+			folded: `[optional.of(3)]`,
+		},
+		{
+			expr:   `{?1: optional.none()}`,
+			folded: `{}`,
+		},
+		{
+			expr:   `google.expr.proto3.test.TestAllTypes{single_int64: 1 + 2 + 3 + x}`,
+			folded: `google.expr.proto3.test.TestAllTypes{single_int64: 6 + x}`,
+		},
+		{
+			expr:   `google.expr.proto3.test.TestAllTypes{single_nested_message: google.expr.proto3.test.TestAllTypes.NestedMessage{bb: 42}}.single_nested_message.bb`,
+			folded: `42`,
+		},
+		{
+			expr:   `{"a": 1}["a"]`,
+			folded: `1`,
+		},
+		{
+			expr:   `{"a": {"b": 2}}["a"]["b"]`,
+			folded: `2`,
+		},
+		{
+			expr:   `{"hello": "world"}.?hello`,
+			folded: `optional.of("world")`,
+		},
+		{
+			expr:   `[1] + [2] + [3]`,
+			folded: `[1, 2, 3]`,
+		},
+		{
+			expr:   `[?optional.none(), 2]`,
+			folded: `[2]`,
+		},
+		{
+			expr:   `[1] + [?optional.of(2)] + [3]`,
+			folded: `[1, 2, 3]`,
+		},
+		{
+			expr:   `[1] + [x]`,
+			folded: `[1] + [x]`,
+		},
+
+		{
+			expr:   `duration("1h") - duration("60m")`,
+			folded: `duration("0s")`,
+		},
+		{
+			expr:   `timestamp("1970-01-01T00:15:00Z") - timestamp("1970-01-01T00:00:10Z")`,
+			folded: `duration("890s")`,
+		},
+		{
+			expr:   `timestamp("2000-01-01T00:02:03.2123Z") + duration("25h2m32s42ms53us29ns")`,
+			folded: `timestamp("2000-01-02T01:04:35.254353029Z")`,
+		},
+		{
+			expr:   `[1 + 1, 1 + 2].exists(i, i < 10)`,
+			folded: `true`,
+		},
 	}
 	e, err := NewEnv(
 		OptionalTypes(),
 		EnableMacroCallTracking(),
 		Types(&proto3pb.TestAllTypes{}),
 		Variable("x", DynType),
+		Variable("y", DynType),
 		// work around different package convention in piper vs github.
 		// google.expr.proto3.test.ImportedGlobalEnum.IMPORT_BAZ
 		Constant("c", IntType, types.Int(2)),
@@ -919,3 +1084,145 @@ func (x int64Slice) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
 
 // Sort is a convenience method: x.Sort() calls Sort(x).
 func (x int64Slice) Sort() { sort.Sort(x) }
+
+func TestConstantFoldingOption_FoldKnownValuesNilInput(t *testing.T) {
+	opt, err := FoldKnownValues(nil)(&constantFoldingOptimizer{})
+	if err != nil || opt.knownValues == nil {
+		t.Errorf("FoldKnownValues(nil) failed: %v", err)
+	}
+}
+
+func TestNewConstantFoldingOptimizer_OptionErrorPropagation(t *testing.T) {
+	errOpt := func(opt *constantFoldingOptimizer) (*constantFoldingOptimizer, error) {
+		return nil, errors.New("option error")
+	}
+	if _, err := NewConstantFoldingOptimizer(errOpt); err == nil {
+		t.Error("NewConstantFoldingOptimizer(errOpt) wanted error, got nil")
+	}
+}
+
+func TestConstantFoldingOptimizer_EvaluateExpr(t *testing.T) {
+	partAct, err := interpreter.NewPartialActivation(
+		interpreter.EmptyActivation(),
+		interpreter.NewAttributePattern("x"))
+	if err != nil {
+		t.Fatalf("NewPartialActivation() failed: %v", err)
+	}
+	unknownValAct, err := NewActivation(map[string]any{
+		"x": types.NewUnknown(1, types.NewAttributeTrail("x")),
+	})
+	if err != nil {
+		t.Fatalf("NewActivation() failed: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		expr     string
+		vars     []EnvOption
+		act      Activation
+		wantFold string
+		wantErr  string
+	}{
+		{
+			name:     "missing attribute",
+			expr:     "x + 1",
+			vars:     []EnvOption{Variable("x", IntType)},
+			act:      partAct,
+			wantFold: "x + 1",
+		},
+		{
+			name:     "unknown value",
+			expr:     "x + 1",
+			vars:     []EnvOption{Variable("x", IntType)},
+			act:      unknownValAct,
+			wantFold: "x + 1",
+		},
+		{
+			name:    "evaluation error",
+			expr:    "1 / 0",
+			wantErr: "division by zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, err := NewEnv(tt.vars...)
+			if err != nil {
+				t.Fatalf("NewEnv() failed: %v", err)
+			}
+			var foldOpts []ConstantFoldingOption
+			if tt.act != nil {
+				foldOpts = append(foldOpts, FoldKnownValues(tt.act))
+			}
+			folder, err := NewConstantFoldingOptimizer(foldOpts...)
+			if err != nil {
+				t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
+			}
+			opt, err := NewStaticOptimizer(folder)
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
+			ast, iss := env.Compile(tt.expr)
+			if iss.Err() != nil {
+				t.Fatalf("Compile() failed: %v", iss.Err())
+			}
+			optimized, iss := opt.Optimize(env, ast)
+			if tt.wantErr != "" {
+				if iss.Err() == nil {
+					t.Fatalf("Optimize(%q) wanted error containing %q, got nil", tt.expr, tt.wantErr)
+				}
+				if !strings.Contains(iss.Err().Error(), tt.wantErr) {
+					t.Errorf("Optimize(%q) got %v, wanted error containing %q", tt.expr, iss.Err(), tt.wantErr)
+				}
+				return
+			}
+			if iss.Err() != nil {
+				t.Fatalf("Optimize() failed: %v", iss.Err())
+			}
+			folded, err := AstToString(optimized)
+			if err != nil {
+				t.Fatalf("AstToString() failed: %v", err)
+			}
+			if folded != tt.wantFold {
+				t.Errorf("got %q, wanted %q", folded, tt.wantFold)
+			}
+		})
+	}
+}
+
+type testVariadicLogicOptimizer struct{}
+
+func (t *testVariadicLogicOptimizer) Optimize(ctx *OptimizerContext, a *ast.AST) *ast.AST {
+	call := ctx.NewCall(operators.LogicalAnd, ctx.NewIdent("x"), ctx.NewLiteral(types.True), ctx.NewIdent("y"))
+	return ctx.NewAST(call)
+}
+
+func TestConstantFoldingOptimizer_VariadicShortcircuitLogic(t *testing.T) {
+	env, err := NewEnv(Variable("x", BoolType), Variable("y", BoolType))
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	folder, err := NewConstantFoldingOptimizer()
+	if err != nil {
+		t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
+	}
+	opt, err := NewStaticOptimizer(&testVariadicLogicOptimizer{}, folder)
+	if err != nil {
+		t.Fatalf("NewStaticOptimizer() failed: %v", err)
+	}
+	parsed, iss := env.Parse("x && y")
+	if iss.Err() != nil {
+		t.Fatalf("Parse() failed: %v", iss.Err())
+	}
+	optimized, iss := opt.Optimize(env, parsed)
+	if iss.Err() != nil {
+		t.Fatalf("Optimize() failed: %v", iss.Err())
+	}
+	folded, err := AstToString(optimized)
+	if err != nil {
+		t.Fatalf("AstToString() failed: %v", err)
+	}
+	if folded != "x && y" {
+		t.Errorf("got %q, wanted %q", folded, "x && y")
+	}
+}

--- a/cel/folding_test.go
+++ b/cel/folding_test.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/encoding/prototext"
@@ -554,7 +553,6 @@ func TestConstantFoldingCallsWithSideEffects(t *testing.T) {
 	tests := []struct {
 		expr   string
 		folded string
-		error  string
 	}{
 		{
 			expr:   `noSideEffect(3)`,
@@ -573,8 +571,8 @@ func TestConstantFoldingCallsWithSideEffects(t *testing.T) {
 			folded: `true`,
 		},
 		{
-			expr:  `noImpl(3)`,
-			error: `constant-folding evaluation failed: no such overload: noImpl`,
+			expr:   `noImpl(3)`,
+			folded: "noImpl(3)",
 		},
 	}
 	e, err := NewEnv(
@@ -614,14 +612,6 @@ func TestConstantFoldingCallsWithSideEffects(t *testing.T) {
 				t.Fatalf("NewStaticOptimizer() failed: %v", err)
 			}
 			optimized, iss := opt.Optimize(e, checked)
-			if tc.error != "" {
-				if iss.Err() == nil {
-					t.Errorf("got nil, wanted error containing %q", tc.error)
-				} else if !strings.Contains(iss.Err().Error(), tc.error) {
-					t.Errorf("got %q, wanted error containing %q", iss.Err().Error(), tc.error)
-				}
-				return
-			}
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())
 			}
@@ -1121,7 +1111,6 @@ func TestConstantFoldingOptimizer_EvaluateExpr(t *testing.T) {
 		vars     []EnvOption
 		act      Activation
 		wantFold string
-		wantErr  string
 	}{
 		{
 			name:     "missing attribute",
@@ -1138,9 +1127,14 @@ func TestConstantFoldingOptimizer_EvaluateExpr(t *testing.T) {
 			wantFold: "x + 1",
 		},
 		{
-			name:    "evaluation error",
-			expr:    "1 / 0",
-			wantErr: "division by zero",
+			name:     "evaluation error division by zero",
+			expr:     "1 / 0",
+			wantFold: "1 / 0",
+		},
+		{
+			name:     "evaluation error index out of bounds",
+			expr:     "[1, 2][5]",
+			wantFold: "[1, 2][5]",
 		},
 	}
 
@@ -1167,15 +1161,6 @@ func TestConstantFoldingOptimizer_EvaluateExpr(t *testing.T) {
 				t.Fatalf("Compile() failed: %v", iss.Err())
 			}
 			optimized, iss := opt.Optimize(env, ast)
-			if tt.wantErr != "" {
-				if iss.Err() == nil {
-					t.Fatalf("Optimize(%q) wanted error containing %q, got nil", tt.expr, tt.wantErr)
-				}
-				if !strings.Contains(iss.Err().Error(), tt.wantErr) {
-					t.Errorf("Optimize(%q) got %v, wanted error containing %q", tt.expr, iss.Err(), tt.wantErr)
-				}
-				return
-			}
 			if iss.Err() != nil {
 				t.Fatalf("Optimize() failed: %v", iss.Err())
 			}

--- a/cel/optimizer_test.go
+++ b/cel/optimizer_test.go
@@ -337,3 +337,107 @@ func optimizerEnv(t *testing.T) *cel.Env {
 	}
 	return e
 }
+
+func TestConstantFoldingOptimizerTwoVar(t *testing.T) {
+	tests := []struct {
+		expr        string
+		folded      string
+		knownValues map[string]any
+	}{
+		{
+			expr:   `[1 + 1, 1 + 2].all(i, v, i < 10 && v < 10)`,
+			folded: `true`,
+		},
+		{
+			expr:   `[1 + 1, 1 + 2].all(i, v, i < 10 && v < x)`,
+			folded: `[2, 3].all(i, v, i < 10 && v < x)`,
+		},
+		{
+			expr:   `[1, 2, 3].transformList(i, v, i + v)`,
+			folded: `[1, 3, 5]`,
+		},
+		{
+			expr:   `{'a': 1, 'b': 2}.all(k, v, v > 0)`,
+			folded: `true`,
+		},
+		{
+			expr:   `v > 0 && [1 + 1, 1 + 2].all(i, v, i < 10 && v < 10)`,
+			folded: `v > 0`,
+		},
+		{
+			expr:   `[1 + 1, 1 + 2].all(i, v, i < 10 && v < 10) && v > 0`,
+			folded: `v > 0`,
+		},
+		{
+			expr:   `[1, 2, 3].transformList(i, v, i + v + k)`,
+			folded: `[1, 2, 3].transformList(i, v, i + v + k)`,
+		},
+		{
+			expr:   `l.transformList(i, v, i + v)`,
+			folded: `l.transformList(i, v, i + v)`,
+		},
+		{
+			expr:   `v > 0 && [1 + 1, 1 + 2].all(i, v, i < 10 && v < 10)`,
+			folded: `true`,
+			knownValues: map[string]any{
+				"v": 5,
+			},
+		},
+		{
+			expr:   `[1 + 1, 1 + 2].all(i, v, i < 10 && v < .v)`,
+			folded: `true`,
+			knownValues: map[string]any{
+				"v": 10,
+			},
+		},
+	}
+	e, err := cel.NewEnv(
+		cel.OptionalTypes(),
+		cel.EnableMacroCallTracking(),
+		ext.TwoVarComprehensions(),
+		cel.Variable("x", cel.IntType),
+		cel.Variable("v", cel.IntType),
+		cel.Variable("i", cel.IntType),
+		cel.Variable("k", cel.IntType),
+		cel.Variable("l", cel.ListType(cel.IntType)),
+	)
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.expr, func(t *testing.T) {
+			checked, iss := e.Compile(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("Compile() failed: %v", iss.Err())
+			}
+			var foldingOpts []cel.ConstantFoldingOption
+			if tc.knownValues != nil {
+				knownValues, err := cel.NewActivation(tc.knownValues)
+				if err != nil {
+					t.Fatalf("NewActivation() failed: %v", err)
+				}
+				foldingOpts = append(foldingOpts, cel.FoldKnownValues(knownValues))
+			}
+			folder, err := cel.NewConstantFoldingOptimizer(foldingOpts...)
+			if err != nil {
+				t.Fatalf("NewConstantFoldingOptimizer() failed: %v", err)
+			}
+			opt, err := cel.NewStaticOptimizer(folder)
+			if err != nil {
+				t.Fatalf("NewStaticOptimizer() failed: %v", err)
+			}
+			optimized, iss := opt.Optimize(e, checked)
+			if iss.Err() != nil {
+				t.Fatalf("Optimize() generated an invalid AST: %v", iss.Err())
+			}
+			folded, err := cel.AstToString(optimized)
+			if err != nil {
+				t.Fatalf("AstToString() failed: %v", err)
+			}
+			if folded != tc.folded {
+				t.Errorf("got %q, wanted %q", folded, tc.folded)
+			}
+		})
+	}
+}

--- a/interpreter/activation.go
+++ b/interpreter/activation.go
@@ -134,6 +134,19 @@ func (a *hierarchicalActivation) Unwrap() Activation {
 	return a.parent
 }
 
+// IsLocalVariable reports whether the variable name is locally bound in the hierarchical activation.
+func (a *hierarchicalActivation) IsLocalVariable(name string) bool {
+	if holder, ok := a.child.(localVariableHolder); ok {
+		if holder.IsLocalVariable(name) {
+			return true
+		}
+	}
+	if holder, ok := a.parent.(localVariableHolder); ok {
+		return holder.IsLocalVariable(name)
+	}
+	return false
+}
+
 // AsPartialActivation checks the child first via direct type assertion (to
 // avoid recursion through the folder → frame → hierarchicalActivation cycle),
 // then walks the parent hierarchy via the free function.

--- a/interpreter/activation_test.go
+++ b/interpreter/activation_test.go
@@ -130,3 +130,75 @@ func TestAsPartialActivation(t *testing.T) {
 		t.Error("AsPartialActivation() failed, did not find parent partial activation")
 	}
 }
+
+func TestIsLocalVariableNested(t *testing.T) {
+	parentAct := EmptyActivation()
+	frame := mustNewExecutionFrame(t, parentAct)
+	defer frame.Close()
+
+	// Outer comprehension scope (e.g. fold1)
+	fold1 := &evalFold{
+		accuVar:  "accu1",
+		iterVar:  "iter1",
+		iterVar2: "iter1_2",
+	}
+	fld1 := newFolder(fold1, frame)
+	defer releaseFolder(fld1)
+
+	// Push outer scope
+	frame1 := frame.Push(fld1)
+	defer frame1.Pop()
+
+	// Inner comprehension scope (e.g. fold2)
+	fold2 := &evalFold{
+		accuVar: "accu2",
+		iterVar: "iter2",
+	}
+	fld2 := newFolder(fold2, frame1)
+	defer releaseFolder(fld2)
+
+	// Push inner scope
+	frame2 := frame1.Push(fld2)
+	defer frame2.Pop()
+
+	// Verify localVariableHolder implementations and recursive checks
+	tests := []struct {
+		name      string
+		varName   string
+		wantLocal bool
+	}{
+		{"inner accu", "accu2", true},
+		{"inner iter", "iter2", true},
+		{"outer accu", "accu1", true},
+		{"outer iter", "iter1", true},
+		{"outer iter2", "iter1_2", true},
+		{"global var", "x", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := frame2.IsLocalVariable(tc.varName); got != tc.wantLocal {
+				t.Errorf("IsLocalVariable(%q) = %t, wanted %t", tc.varName, got, tc.wantLocal)
+			}
+		})
+	}
+}
+
+func TestActivation_NewActivationNilInput(t *testing.T) {
+	if _, err := NewActivation(nil); err == nil {
+		t.Error("NewActivation(nil) wanted error, got nil")
+	}
+}
+
+func TestPartialActivation_NewPartialActivationNilInput(t *testing.T) {
+	if _, err := NewPartialActivation(nil); err == nil {
+		t.Error("NewPartialActivation(nil) wanted error, got nil")
+	}
+}
+
+func TestAsPartialActivation_NonPartialActivation(t *testing.T) {
+	standardAct, _ := NewActivation(map[string]any{"a": 1})
+	if _, found := AsPartialActivation(standardAct); found {
+		t.Error("AsPartialActivation(standardAct) wanted false, got true")
+	}
+}

--- a/interpreter/attribute_patterns.go
+++ b/interpreter/attribute_patterns.go
@@ -255,6 +255,9 @@ func (fac *partialAttributeFactory) matchesUnknownPatterns(
 	patterns := vars.UnknownAttributePatterns()
 	candidateIndices := map[int]struct{}{}
 	for _, variable := range variableNames {
+		if holder, ok := vars.(localVariableHolder); ok && holder.IsLocalVariable(variable) {
+			continue
+		}
 		for i, pat := range patterns {
 			if pat.VariableMatches(variable) {
 				if len(qualifiers) == 0 {

--- a/interpreter/attribute_patterns_test.go
+++ b/interpreter/attribute_patterns_test.go
@@ -336,3 +336,199 @@ func genAttr(fac AttributeFactory, a attr) Attribute {
 	}
 	return attr
 }
+
+func TestAttributePattern_LocallyBound(t *testing.T) {
+	reg := newTestRegistry(t)
+	fac := NewPartialAttributeFactory(containers.DefaultContainer, reg, reg)
+
+	// Create a partial activation that designates "x" and "y" as unknown.
+	partAct, err := NewPartialActivation(EmptyActivation(), NewAttributePattern("x"), NewAttributePattern("y"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	frame := mustNewExecutionFrame(t, partAct)
+	defer frame.Close()
+
+	// Create folder (representing a local scope for variable "x" only)
+	fold := &evalFold{
+		iterVar: "x",
+		adapter: types.DefaultTypeAdapter,
+	}
+	fld := newFolder(fold, frame)
+	defer releaseFolder(fld)
+
+	// Push onto the frame stack to simulate local variable scope
+	frame1 := frame.Push(fld)
+	defer frame1.Pop()
+
+	// 1. Resolve attribute matching "x".
+	// Because "x" is locally bound in fld, it should not resolve to types.Unknown.
+	attrX := fac.AbsoluteAttribute(1, "x")
+	valX, err := attrX.Resolve(frame1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, isUnk := valX.(*types.Unknown); isUnk {
+		t.Errorf("Resolve(x) got unknown, wanted value (since x is locally bound)")
+	}
+
+	// 2. Resolve attribute matching "y".
+	// Because "y" is NOT locally bound in any local scope layer, it should resolve to types.Unknown.
+	attrY := fac.AbsoluteAttribute(2, "y")
+	valY, err := attrY.Resolve(frame1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, isUnk := valY.(*types.Unknown); !isUnk {
+		t.Errorf("Resolve(y) got %v, wanted types.Unknown (since y is not locally bound)", valY)
+	}
+}
+
+func TestQualifierValueEquals(t *testing.T) {
+	tests := []struct {
+		name      string
+		qualifier interface {
+			QualifierValueEquals(any) bool
+		}
+		cases []struct {
+			input any
+			want  bool
+		}
+	}{
+		{
+			name:      "fieldQualifier",
+			qualifier: &fieldQualifier{Name: "foo"},
+			cases: []struct {
+				input any
+				want  bool
+			}{
+				{input: "foo", want: true},
+				{input: "bar", want: false},
+				{input: 123, want: false},
+				{input: true, want: false},
+				{input: nil, want: false},
+			},
+		},
+		{
+			name:      "stringQualifier",
+			qualifier: &stringQualifier{value: "hello"},
+			cases: []struct {
+				input any
+				want  bool
+			}{
+				{input: "hello", want: true},
+				{input: "world", want: false},
+				{input: 123, want: false},
+				{input: nil, want: false},
+			},
+		},
+		{
+			name:      "boolQualifier",
+			qualifier: &boolQualifier{value: true},
+			cases: []struct {
+				input any
+				want  bool
+			}{
+				{input: true, want: true},
+				{input: false, want: false},
+				{input: "true", want: false},
+				{input: 1, want: false},
+				{input: nil, want: false},
+			},
+		},
+		{
+			name:      "intQualifier",
+			qualifier: &intQualifier{celValue: types.Int(42)},
+			cases: []struct {
+				input any
+				want  bool
+			}{
+				{input: int64(42), want: true},
+				{input: int32(42), want: true},
+				{input: uint64(42), want: true},
+				{input: float64(42.0), want: true},
+				{input: types.Int(42), want: true},
+				{input: types.Double(42.0), want: true},
+				{input: int64(100), want: false},
+				{input: "42", want: false},
+				{input: nil, want: false},
+			},
+		},
+		{
+			name:      "uintQualifier",
+			qualifier: &uintQualifier{celValue: types.Uint(100)},
+			cases: []struct {
+				input any
+				want  bool
+			}{
+				{input: uint64(100), want: true},
+				{input: int64(100), want: true},
+				{input: float64(100.0), want: true},
+				{input: types.Uint(100), want: true},
+				{input: uint64(50), want: false},
+				{input: "100", want: false},
+				{input: nil, want: false},
+			},
+		},
+		{
+			name:      "doubleQualifier",
+			qualifier: &doubleQualifier{celValue: types.Double(3.14)},
+			cases: []struct {
+				input any
+				want  bool
+			}{
+				{input: float64(3.14), want: true},
+				{input: types.Double(3.14), want: true},
+				{input: float64(2.71), want: false},
+				{input: int64(3), want: false},
+				{input: "3.14", want: false},
+				{input: nil, want: false},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, c := range tc.cases {
+				if got := tc.qualifier.QualifierValueEquals(c.input); got != c.want {
+					t.Errorf("%s.QualifierValueEquals(%v (%T)) = %t, wanted %t", tc.name, c.input, c.input, got, c.want)
+				}
+			}
+		})
+	}
+}
+
+func TestPartialAttributeFactory_MaybeAttributeGloballyNamespaced(t *testing.T) {
+	reg := newTestRegistry(t)
+	fac := NewPartialAttributeFactory(containers.DefaultContainer, reg, reg)
+	dotAttr := fac.MaybeAttribute(10, ".global_var")
+	if dotAttr == nil {
+		t.Error("MaybeAttribute(.global_var) got nil")
+	}
+}
+
+func TestPartialAttributeFactory_ResolveUnknownQualifier(t *testing.T) {
+	reg := newTestRegistry(t)
+	fac := NewPartialAttributeFactory(containers.DefaultContainer, reg, reg)
+	partVars, _ := NewPartialActivation(
+		map[string]any{"a": map[string]any{"b": 1}},
+		NewAttributePattern("a").QualString("b"))
+	a := fac.AbsoluteAttribute(1, "a")
+	b, _ := fac.NewQualifier(nil, 2, "b", false)
+	a.AddQualifier(b)
+	val, err := a.Resolve(partVars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unkVal, ok := val.(*types.Unknown)
+	if !ok {
+		t.Fatalf("Resolve(a.b) got %v (%T), wanted *types.Unknown", val, val)
+	}
+	unkAttr := types.NewAttributeTrail("a")
+	types.QualifyAttribute[string](unkAttr, "b")
+	wantUnk := types.NewUnknown(2, unkAttr)
+	if !wantUnk.Contains(unkVal) {
+		t.Errorf("Resolve(a.b) got unknown %v, wanted %v", unkVal, wantUnk)
+	}
+}

--- a/interpreter/attributes_test.go
+++ b/interpreter/attributes_test.go
@@ -1479,3 +1479,33 @@ func TestQualifyIfPresent(t *testing.T) {
 		})
 	}
 }
+
+func TestAttribute_StringRepresentation(t *testing.T) {
+	reg := newTestRegistry(t)
+	cont := containers.DefaultContainer
+	fac := NewAttributeFactory(cont, reg, reg)
+
+	abs := fac.AbsoluteAttribute(1, "a.b")
+	maybe := fac.MaybeAttribute(2, "c")
+	rel := fac.RelativeAttribute(3, NewConstValue(1, types.String("d")))
+	cond := fac.ConditionalAttribute(4, NewConstValue(1, types.True), abs, maybe)
+	trail := types.NewAttributeTrail("x")
+
+	tests := []struct {
+		name     string
+		stringer fmt.Stringer
+	}{
+		{name: "absoluteAttribute", stringer: abs.(fmt.Stringer)},
+		{name: "maybeAttribute", stringer: maybe.(fmt.Stringer)},
+		{name: "relativeAttribute", stringer: rel.(fmt.Stringer)},
+		{name: "conditionalAttribute", stringer: cond.(fmt.Stringer)},
+		{name: "AttributeTrail", stringer: trail},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if str := tc.stringer.String(); str == "" {
+				t.Errorf("%s.String() returned empty string", tc.name)
+			}
+		})
+	}
+}

--- a/interpreter/frame.go
+++ b/interpreter/frame.go
@@ -196,6 +196,20 @@ func (f *ExecutionFrame) Unwrap() Activation {
 	return f.Activation
 }
 
+// IsLocalVariable reports whether the variable name is locally bound in the frame.
+func (f *ExecutionFrame) IsLocalVariable(name string) bool {
+	if holder, ok := f.Activation.(localVariableHolder); ok {
+		if holder.IsLocalVariable(name) {
+			return true
+		}
+	}
+	// Search parent scopes
+	if f.parent != nil {
+		return f.parent.IsLocalVariable(name)
+	}
+	return false
+}
+
 // CheckInterrupt returns whether the evaluation has been interrupted.
 func (f *ExecutionFrame) CheckInterrupt() bool {
 	if f.ctx == nil {

--- a/interpreter/interpretable.go
+++ b/interpreter/interpretable.go
@@ -1602,6 +1602,26 @@ func (f *folder) Unwrap() Activation {
 	return f.frame.parent
 }
 
+// IsLocalVariable reports whether the variable name is locally bound by the folder scope.
+func (f *folder) IsLocalVariable(name string) bool {
+	if name == f.accuVar {
+		return true
+	}
+	if !f.computeResult && (name == f.iterVar || name == f.iterVar2) {
+		return true
+	}
+	parent := f.Parent()
+	if parent == nil {
+		return false
+	}
+	if varHolder, ok := parent.(localVariableHolder); ok {
+		if varHolder.IsLocalVariable(name) {
+			return true
+		}
+	}
+	return false
+}
+
 // UnknownAttributePatterns implements the PartialActivation interface returning the unknown patterns
 // if they were provided to the input activation, or an empty set if the proxied activation is not partial.
 func (f *folder) UnknownAttributePatterns() []*AttributePattern {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -113,6 +113,12 @@ type activationWrapper interface {
 	Unwrap() Activation
 }
 
+// localVariableHolder identifies an Activation scope that holds local variables and supports testing
+// whether a variable name is local to this scope.
+type localVariableHolder interface {
+	IsLocalVariable(name string) bool
+}
+
 // evalStateFactory holds a reference to a factory function that produces an EvalState instance.
 type evalStateFactory struct {
 	factory func() EvalState


### PR DESCRIPTION
Align constant folding and attribute resolution behavior with cel-java, fixing local variable pattern matching during partial evaluation.

* Updated `matchesUnknownPatterns` to check whether a variable is locally bound (e.g. comprehension iterator/accumulator variables `i`, `accuVar`) so local variables are not incorrectly flagged as unknown global attributes during partial evaluation.
* Updated folding to skip attempting computations over local variables within a comprehension.
* Added support for partial evaluation over unknown values to fold properly with Unknown rather than error.
* Added `in` optimizations to cover element or identity equality even when the variable is unknown.

Closes #1296 