### PR TITLE
compare ints against doubles without rounding

### DIFF
--- a/common/types/compare.go
+++ b/common/types/compare.go
@@ -20,28 +20,54 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 )
 
+// compareDoubleInt orders a double against an int by their mathematical values.
+//
+// The int is split from the double rather than converted to one: ints above 2^53 have no exact
+// double representation, so converting rounds them to a neighbouring value. Callers screen NaN
+// before dispatching here.
 func compareDoubleInt(d Double, i Int) Int {
-	if d < math.MinInt64 {
+	f := float64(d)
+	if f < math.MinInt64 {
 		return IntNegOne
 	}
-	if d > math.MaxInt64 {
+	// MaxInt64 rounds up to 2^63 as a double, which is the first value above the int64 range.
+	if f >= math.MaxInt64 {
 		return IntOne
 	}
-	return compareDouble(d, Double(i))
+	// The integral part is now within the int64 range, so it converts exactly.
+	whole := math.Trunc(f)
+	if Int(whole) < i {
+		return IntNegOne
+	}
+	if Int(whole) > i {
+		return IntOne
+	}
+	// Equal whole parts, so the remaining fraction decides the order.
+	return compareDouble(Double(f-whole), 0)
 }
 
 func compareIntDouble(i Int, d Double) Int {
 	return -compareDoubleInt(d, i)
 }
 
+// compareDoubleUint orders a double against a uint by their mathematical values, splitting the
+// double instead of converting the uint for the reason given on compareDoubleInt.
 func compareDoubleUint(d Double, u Uint) Int {
-	if d < 0 {
+	f := float64(d)
+	if f < 0 {
 		return IntNegOne
 	}
-	if d > math.MaxUint64 {
+	if f >= doubleTwoTo64 {
 		return IntOne
 	}
-	return compareDouble(d, Double(u))
+	whole := math.Trunc(f)
+	if Uint(whole) < u {
+		return IntNegOne
+	}
+	if Uint(whole) > u {
+		return IntOne
+	}
+	return compareDouble(Double(f-whole), 0)
 }
 
 func compareUintDouble(u Uint, d Double) Int {

--- a/common/types/double_test.go
+++ b/common/types/double_test.go
@@ -117,6 +117,23 @@ func TestDoubleCompare(t *testing.T) {
 			out: IntOne,
 		},
 		{
+			// 2^53+1 has no double representation, so it must not compare equal to 2^53.
+			a:   Double(1 << 53),
+			b:   Int(1<<53) + 1,
+			out: IntNegOne,
+		},
+		{
+			a:   Double(1 << 53),
+			b:   Uint(1<<53) + 1,
+			out: IntNegOne,
+		},
+		{
+			// MaxInt64 rounds up to 2^63 as a double, but remains below it as an int.
+			a:   Double(1 << 63),
+			b:   Int(math.MaxInt64),
+			out: IntOne,
+		},
+		{
 			a:   Double(1),
 			b:   String("1"),
 			out: NoSuchOverloadErr(),
@@ -405,6 +422,26 @@ func TestDoubleEqual(t *testing.T) {
 		{
 			a:   Double(math.NaN()),
 			b:   Int(10),
+			out: False,
+		},
+		{
+			a:   Double(1 << 53),
+			b:   Int(1<<53) + 1,
+			out: False,
+		},
+		{
+			a:   Double(1 << 53),
+			b:   Uint(1<<53) + 1,
+			out: False,
+		},
+		{
+			a:   Double(1 << 63),
+			b:   Int(math.MaxInt64),
+			out: False,
+		},
+		{
+			a:   Double(math.MaxUint64),
+			b:   Uint(math.MaxUint64),
 			out: False,
 		},
 	}

--- a/common/types/int_test.go
+++ b/common/types/int_test.go
@@ -130,6 +130,17 @@ func TestIntCompare(t *testing.T) {
 			out: IntOne,
 		},
 		{
+			// 2^53+1 has no double representation, so it must not compare equal to 2^53.
+			a:   Int(1<<53) + 1,
+			b:   Double(1 << 53),
+			out: IntOne,
+		},
+		{
+			a:   Int(math.MaxInt64),
+			b:   Double(1 << 63),
+			out: IntNegOne,
+		},
+		{
 			a:   Int(1),
 			b:   String("1"),
 			out: NoSuchOverloadErr(),
@@ -427,6 +438,16 @@ func TestIntEqual(t *testing.T) {
 		{
 			a:   Int(10),
 			b:   Double(math.NaN()),
+			out: False,
+		},
+		{
+			a:   Int(1<<53) + 1,
+			b:   Double(1 << 53),
+			out: False,
+		},
+		{
+			a:   Int(math.MaxInt64),
+			b:   Double(1 << 63),
 			out: False,
 		},
 		{

--- a/common/types/uint_test.go
+++ b/common/types/uint_test.go
@@ -118,6 +118,17 @@ func TestUintCompare(t *testing.T) {
 			out: IntOne,
 		},
 		{
+			// 2^53+1 has no double representation, so it must not compare equal to 2^53.
+			a:   Uint(1<<53) + 1,
+			b:   Double(1 << 53),
+			out: IntOne,
+		},
+		{
+			a:   Uint(math.MaxUint64),
+			b:   Double(math.MaxUint64),
+			out: IntNegOne,
+		},
+		{
 			a:   Uint(1),
 			b:   String("1"),
 			out: NoSuchOverloadErr(),
@@ -377,6 +388,16 @@ func TestUintEqual(t *testing.T) {
 		{
 			a:   Uint(10),
 			b:   Double(math.NaN()),
+			out: False,
+		},
+		{
+			a:   Uint(1<<53) + 1,
+			b:   Double(1 << 53),
+			out: False,
+		},
+		{
+			a:   Uint(math.MaxUint64),
+			b:   Double(math.MaxUint64),
 			out: False,
 		},
 	}


### PR DESCRIPTION
1. compareDoubleInt and compareDoubleUint converted the integer operand to a double before comparing, so any int or uint above 2^53 was rounded onto a neighbouring value first.
2. Equal is defined as Compare() == 0 for all three numeric types, so int(9007199254740993) == 9007199254740992.0 evaluated to true and MaxInt64 < 9223372036854775808.0 evaluated to false.
3. That also disagreed with map and list indexing, which already resolve cross-type numeric keys through the lossless helpers in overflow.go: with those same two values `x in [d]` returned true while `{d: 1}[x]` reported no such key.

Split the double instead of converting the integer: range-check it, compare the integral part directly against the integer operand, and let the remaining fraction break the tie. NaN never reaches either helper, every caller screens it first.