### PR TITLE
copy operands in Bytes.Add to avoid aliasing the receiver

### DIFF
--- a/common/types/bytes.go
+++ b/common/types/bytes.go
@@ -44,7 +44,10 @@ func (b Bytes) Add(other ref.Val) ref.Val {
 	if !ok {
 		return ValOrErr(other, "no such overload")
 	}
-	return append(b, otherBytes...)
+	sum := make([]byte, 0, len(b)+len(otherBytes))
+	sum = append(sum, b...)
+	sum = append(sum, otherBytes...)
+	return Bytes(sum)
 }
 
 // Compare implements traits.Comparer interface method by lexicographic ordering.

--- a/common/types/bytes_test.go
+++ b/common/types/bytes_test.go
@@ -36,6 +36,27 @@ func TestBytesAdd(t *testing.T) {
 	}
 }
 
+func TestBytesAddNoAlias(t *testing.T) {
+	// A bytes value whose backing array has spare capacity, as happens when a
+	// host binds a []byte that is a sub-slice of a larger buffer.
+	backing := make([]byte, 3, 16)
+	copy(backing, "abc")
+	b := Bytes(backing)
+
+	first := b.Add(Bytes("111")).(Bytes)
+	second := b.Add(Bytes("222")).(Bytes)
+
+	if !bytes.Equal(first, []byte("abc111")) {
+		t.Errorf("first concatenation aliased: got %q, wanted %q", first, "abc111")
+	}
+	if !bytes.Equal(second, []byte("abc222")) {
+		t.Errorf("second concatenation wrong: got %q, wanted %q", second, "abc222")
+	}
+	if !bytes.Equal(b, []byte("abc")) {
+		t.Errorf("receiver mutated: got %q, wanted %q", b, "abc")
+	}
+}
+
 func TestBytesCompare(t *testing.T) {
 	if !Bytes("1234").Compare(Bytes("2345")).Equal(IntNegOne).(Bool) {
 		t.Error("Comparison did not yield -1")


### PR DESCRIPTION
**Aliased backing array in Bytes.Add**
`Bytes.Add` grows the receiver with `append`, so when a bound bytes value's backing array has spare capacity the second operand is written into that capacity and the result aliases the receiver rather than being a fresh copy. Evaluating `[b + b"\x01", b + b"\x02"]` against such a value returns `[b+0x02, b+0x02]` because the second concatenation overwrites the first. The concatenation now allocates its own slice sized to both operands, the same immutable-view guarantee list concatenation already provides.