### PR TITLE
Expression node limits for parser and checker

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -3700,6 +3700,91 @@ func TestParserExpressionSizeLimit(t *testing.T) {
 	}
 }
 
+func TestParserExpressionNodeLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		expr         string
+		limit        int
+		expectErr    bool
+		errSubstring string
+	}{
+		{
+			name:      "single optMap within limit",
+			expr:      "x.optMap(a, a + 1)",
+			limit:     500,
+			expectErr: false,
+		},
+		{
+			name:         "chained optMap exceeding configured limit",
+			expr:         "x.optMap(a, a + 1).optMap(b, b + 1).optMap(c, c + 1).optMap(d, d + 1).optMap(e, e + 1).optMap(f, f + 1)",
+			limit:        100,
+			expectErr:    true,
+			errSubstring: "expression count exceeds limit of 100 while expanding macro 'optMap'",
+		},
+		{
+			name:         "chained optMap of various complexity exceeding default limit",
+			expr:         "x.optMap(a, [a, a]).optMap(b, {b: b}).optMap(c, c + 1).optMap(d, d + 2).optMap(e, e + 3).optMap(f, f + 4).optMap(g, g + 5).optMap(h, h + 6).optMap(i, i + 7).optMap(j, j + 8).optMap(k, k + 9).optMap(l, l + 10).optMap(m, m + 11).optMap(n, n + 12)",
+			limit:        0, // default limit 100,000
+			expectErr:    true,
+			errSubstring: "expression count exceeds limit of 100000 while expanding macro 'optMap'",
+		},
+		{
+			name:      "chained optMap with unbounded limit (-1)",
+			expr:      "x.optMap(a, a + 1).optMap(b, b + 1).optMap(c, c + 1).optMap(d, d + 1).optMap(e, e + 1).optMap(f, f + 1)",
+			limit:     -1,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []EnvOption{
+				OptionalTypes(),
+				Variable("x", OptionalType(IntType)),
+			}
+			if tt.limit != 0 {
+				opts = append(opts, ExpressionNodeLimit(tt.limit), ParserExpressionNodeLimit(tt.limit))
+			}
+			env := testEnv(t, opts...)
+			_, iss := env.Parse(tt.expr)
+			if tt.expectErr {
+				if iss.Err() == nil {
+					t.Fatalf("Parse(%q) succeeded, expected error containing %q", tt.expr, tt.errSubstring)
+				}
+				if !strings.Contains(iss.Err().Error(), tt.errSubstring) {
+					t.Errorf("Parse(%q) got error %v, expected substring %q", tt.expr, iss.Err(), tt.errSubstring)
+				}
+			} else {
+				if iss.Err() != nil {
+					t.Errorf("Parse(%q) unexpectedly failed: %v", tt.expr, iss.Err())
+				}
+			}
+		})
+	}
+}
+
+func TestExpressionNodeLimitCheck(t *testing.T) {
+	env, err := NewEnv(ExpressionNodeLimit(5), Variable("x", IntType))
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	parseEnv, err := NewEnv(ExpressionNodeLimit(-1), Variable("x", IntType))
+	if err != nil {
+		t.Fatalf("NewEnv() failed: %v", err)
+	}
+	ast, iss := parseEnv.Parse("x + 1 + 2 + 3 + 4 + 5")
+	if iss.Err() != nil {
+		t.Fatalf("Parse() failed: %v", iss.Err())
+	}
+	_, iss = env.Check(ast)
+	if iss.Err() == nil {
+		t.Fatal("Check() succeeded, expected node count limit error")
+	}
+	if !strings.Contains(iss.Err().Error(), "expression node count exceeds limit") {
+		t.Errorf("Check() got error %v, expected node count limit error", iss.Err())
+	}
+}
+
 func BenchmarkOptionalValues(b *testing.B) {
 	env := testEnv(b,
 		OptionalTypes(),

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -3700,7 +3700,7 @@ func TestParserExpressionSizeLimit(t *testing.T) {
 	}
 }
 
-func TestParserExpressionNodeLimit(t *testing.T) {
+func TestExpressionNodeLimit(t *testing.T) {
 	tests := []struct {
 		name         string
 		expr         string
@@ -3736,27 +3736,28 @@ func TestParserExpressionNodeLimit(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(t *testing.T) {
 			opts := []EnvOption{
 				OptionalTypes(),
 				Variable("x", OptionalType(IntType)),
 			}
-			if tt.limit != 0 {
-				opts = append(opts, ExpressionNodeLimit(tt.limit), ParserExpressionNodeLimit(tt.limit))
+			if tc.limit != 0 {
+				opts = append(opts, ExpressionNodeLimit(tc.limit))
 			}
 			env := testEnv(t, opts...)
-			_, iss := env.Parse(tt.expr)
-			if tt.expectErr {
+			_, iss := env.Parse(tc.expr)
+			if tc.expectErr {
 				if iss.Err() == nil {
-					t.Fatalf("Parse(%q) succeeded, expected error containing %q", tt.expr, tt.errSubstring)
+					t.Fatalf("Parse(%q) succeeded, expected error containing %q", tc.expr, tc.errSubstring)
 				}
-				if !strings.Contains(iss.Err().Error(), tt.errSubstring) {
-					t.Errorf("Parse(%q) got error %v, expected substring %q", tt.expr, iss.Err(), tt.errSubstring)
+				if !strings.Contains(iss.Err().Error(), tc.errSubstring) {
+					t.Errorf("Parse(%q) got error %v, expected substring %q", tc.expr, iss.Err(), tc.errSubstring)
 				}
 			} else {
 				if iss.Err() != nil {
-					t.Errorf("Parse(%q) unexpectedly failed: %v", tt.expr, iss.Err())
+					t.Errorf("Parse(%q) unexpectedly failed: %v", tc.expr, iss.Err())
 				}
 			}
 		})

--- a/cel/env.go
+++ b/cel/env.go
@@ -406,6 +406,13 @@ func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
 		errs.ReportErrorString(common.NoLocation, ast.loadErr.Error())
 		return nil, NewIssuesWithSourceInfo(errs, ast.NativeRep().SourceInfo())
 	}
+	if nodeLimit := e.configuredExpressionNodeLimit(); nodeLimit > 0 && ast != nil && ast.NativeRep() != nil {
+		if count := celast.NodeCount(ast.NativeRep()); count > nodeLimit {
+			errs := common.NewErrors(ast.Source())
+			errs.ReportErrorString(common.NoLocation, fmt.Sprintf("expression node count exceeds limit: count %d, limit %d", count, nodeLimit))
+			return nil, NewIssuesWithSourceInfo(errs, ast.NativeRep().SourceInfo())
+		}
+	}
 	// Construct the internal checker env, erroring if there is an issue adding the declarations.
 	chk, err := e.initChecker()
 	if err != nil {
@@ -451,6 +458,15 @@ func (e *Env) Check(ast *Ast) (*Ast, *Issues) {
 // A zero value means "use the parser default".
 func (e *Env) configuredExpressionSizeLimit() int {
 	if l := e.limits[limitCodePointSize]; l != 0 {
+		return l
+	}
+	return 100_000
+}
+
+// configuredExpressionNodeLimit returns the effective expression node limit.
+// A zero value means "use default".
+func (e *Env) configuredExpressionNodeLimit() int {
+	if l := e.limits[limitExpressionNodeCount]; l != 0 {
 		return l
 	}
 	return 100_000
@@ -875,6 +891,9 @@ func (e *Env) configure(opts []EnvOption) (*Env, error) {
 	}
 	if l := e.limits[limitParseRecursionDepth]; l != 0 {
 		prsrOpts = append(prsrOpts, parser.MaxRecursionDepth(l))
+	}
+	if l := e.limits[limitExpressionNodeCount]; l != 0 {
+		prsrOpts = append(prsrOpts, parser.MaxExpressionNodeCount(l))
 	}
 	e.prsr, err = parser.NewParser(prsrOpts...)
 	if err != nil {

--- a/cel/options.go
+++ b/cel/options.go
@@ -112,6 +112,8 @@ const (
 	limitParseErrorRecovery
 	// The maximum nesting depth permitted for ASTs loaded outside the parser.
 	limitMaxASTDepth
+	// The maximum number of expression nodes permitted in parsing (including macro expansion).
+	limitExpressionNodeCount
 )
 
 // defaultMaxASTDepth mirrors the parser's default maxRecursionDepth (250) and
@@ -124,6 +126,7 @@ var limitIDsToNames = map[limitID]string{
 	limitParseErrorRecovery:  "cel.limit.parse_error_recovery",
 	limitParseRecursionDepth: "cel.limit.parse_recursion_depth",
 	limitMaxASTDepth:         "cel.limit.max_ast_depth",
+	limitExpressionNodeCount: "cel.limit.expression_node_count",
 }
 
 func limitNameByID(id limitID) (string, bool) {
@@ -998,6 +1001,20 @@ func ParserErrorRecoveryLimit(limit int) EnvOption {
 // Defaults are defined in the parser package. A negative value means unbounded.
 func ParserExpressionSizeLimit(limit int) EnvOption {
 	return setLimit(limitCodePointSize, limit)
+}
+
+// ExpressionNodeLimit adjusts the maximum number of expression nodes permitted during parsing
+// and checking, including nodes created by macro expansion. Defaults are defined in the parser
+// package (100,000). A negative value means unbounded.
+func ExpressionNodeLimit(limit int) EnvOption {
+	return setLimit(limitExpressionNodeCount, limit)
+}
+
+// ParserExpressionNodeLimit adjusts the maximum number of expression nodes the parser will allow,
+// including nodes created by macro expansion. Defaults are defined in the parser package.
+// A negative value means unbounded.
+func ParserExpressionNodeLimit(limit int) EnvOption {
+	return ExpressionNodeLimit(limit)
 }
 
 // ExpressionNestingDepthLimit records the maximum nesting depth permitted for ASTs in the

--- a/cel/options.go
+++ b/cel/options.go
@@ -1010,13 +1010,6 @@ func ExpressionNodeLimit(limit int) EnvOption {
 	return setLimit(limitExpressionNodeCount, limit)
 }
 
-// ParserExpressionNodeLimit adjusts the maximum number of expression nodes the parser will allow,
-// including nodes created by macro expansion. Defaults are defined in the parser package.
-// A negative value means unbounded.
-func ParserExpressionNodeLimit(limit int) EnvOption {
-	return ExpressionNodeLimit(limit)
-}
-
 // ExpressionNestingDepthLimit records the maximum nesting depth permitted for ASTs in the
 // environment configuration so that the value round-trips through env.Config export/import.
 //

--- a/common/ast/ast.go
+++ b/common/ast/ast.go
@@ -172,6 +172,14 @@ func (a *AST) IDs() map[int64]bool {
 	return visitor
 }
 
+// NodeCount returns the total number of expression nodes in the AST, including macro calls.
+func NodeCount(a *AST) int {
+	if a == nil {
+		return 0
+	}
+	return len(a.IDs())
+}
+
 // ClearUnusedIDs removes IDs not used in the AST or macro calls from SourceInfo.
 func (a *AST) ClearUnusedIDs() {
 	ids := a.IDs()

--- a/common/ast/ast_test.go
+++ b/common/ast/ast_test.go
@@ -393,6 +393,16 @@ func TestMaxID(t *testing.T) {
 	}
 }
 
+func TestNodeCount(t *testing.T) {
+	if ast.NodeCount(nil) != 0 {
+		t.Errorf("NodeCount(nil) got %d, wanted 0", ast.NodeCount(nil))
+	}
+	checked := mustTypeCheck(t, `1 + 2`)
+	if count := ast.NodeCount(checked); count != 3 {
+		t.Errorf("NodeCount(1 + 2) got %d, wanted 3", count)
+	}
+}
+
 func TestHeights(t *testing.T) {
 	tests := []struct {
 		expr   string

--- a/parser/helper.go
+++ b/parser/helper.go
@@ -45,6 +45,10 @@ func (p *parserHelper) getSourceInfo() *ast.SourceInfo {
 	return p.sourceInfo
 }
 
+func (p *parserHelper) expressionCount() int64 {
+	return p.nextID - 1
+}
+
 func (p *parserHelper) newLiteral(ctx any, value ref.Val) ast.Expr {
 	return p.exprFactory.NewLiteral(p.newID(ctx), value)
 }

--- a/parser/options.go
+++ b/parser/options.go
@@ -22,6 +22,7 @@ type options struct {
 	errorRecoveryTokenLookaheadLimit int
 	errorRecoveryLimit               int
 	expressionSizeCodePointLimit     int
+	maxExpressionNodeCount           int
 	macros                           map[string]Macro
 	populateMacroCalls               bool
 	enableOptionalSyntax             bool
@@ -93,6 +94,18 @@ func ExpressionSizeCodePointLimit(expressionSizeCodePointLimit int) Option {
 			return fmt.Errorf("expression size code point limit must be greater than or equal to -1: %d", expressionSizeCodePointLimit)
 		}
 		opts.expressionSizeCodePointLimit = expressionSizeCodePointLimit
+		return nil
+	}
+}
+
+// MaxExpressionNodeCount limits the maximum number of expression nodes that may be emitted by the parser,
+// including nodes created by macro expansion.
+func MaxExpressionNodeCount(limit int) Option {
+	return func(opts *options) error {
+		if limit < -1 {
+			return fmt.Errorf("max expression node count must be greater than or equal to -1: %d", limit)
+		}
+		opts.maxExpressionNodeCount = limit
 		return nil
 	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -72,6 +72,12 @@ func NewParser(opts ...Option) (*Parser, error) {
 	if p.expressionSizeCodePointLimit == -1 {
 		p.expressionSizeCodePointLimit = int((^uint(0)) >> 1)
 	}
+	if p.maxExpressionNodeCount == 0 {
+		p.maxExpressionNodeCount = 100_000
+	}
+	if p.maxExpressionNodeCount == -1 {
+		p.maxExpressionNodeCount = int((^uint(0)) >> 1)
+	}
 	// Bool is false by default, so populateMacroCalls will be false by default
 	return p, nil
 }
@@ -102,6 +108,7 @@ func (p *Parser) Parse(source common.Source) (*ast.AST, *common.Errors) {
 		helper:                           newParserHelper(source, fac),
 		macros:                           p.macros,
 		maxRecursionDepth:                p.maxRecursionDepth,
+		maxExpressionNodeCount:           p.maxExpressionNodeCount,
 		errorReportingLimit:              p.errorReportingLimit,
 		errorRecoveryLimit:               p.errorRecoveryLimit,
 		errorRecoveryLookaheadTokenLimit: p.errorRecoveryTokenLookaheadLimit,
@@ -319,6 +326,7 @@ type parser struct {
 	recursionDepth                   int
 	errorReports                     int
 	maxRecursionDepth                int
+	maxExpressionNodeCount           int
 	errorReportingLimit              int
 	errorRecoveryLimit               int
 	errorRecoveryLookaheadTokenLimit int
@@ -964,11 +972,21 @@ func (p *parser) expandMacro(exprID int64, function string, target ast.Expr, arg
 			return nil, false
 		}
 	}
+	if int(p.helper.expressionCount()) > p.maxExpressionNodeCount {
+		loc := p.helper.getLocation(exprID)
+		p.helper.deleteID(exprID)
+		return p.reportError(loc, "expression count exceeds limit of %d while expanding macro '%s'", p.maxExpressionNodeCount, function), true
+	}
 	eh := exprHelperPool.Get().(*exprHelper)
 	defer exprHelperPool.Put(eh)
 	eh.parserHelper = p.helper
 	eh.id = exprID
 	expr, err := macro.Expander()(eh, target, args)
+	if int(p.helper.expressionCount()) > p.maxExpressionNodeCount {
+		loc := p.helper.getLocation(exprID)
+		p.helper.deleteID(exprID)
+		return p.reportError(loc, "expression count exceeds limit of %d while expanding macro '%s'", p.maxExpressionNodeCount, function), true
+	}
 	// An error indicates that the macro was matched, but the arguments were not well-formed.
 	if err != nil {
 		loc := err.Location

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2317,6 +2317,21 @@ func TestExpressionSizeCodePointLimit(t *testing.T) {
 	}
 }
 
+func TestMaxExpressionNodeCount(t *testing.T) {
+	p, err := NewParser(Macros(AllMacros...), MaxExpressionNodeCount(10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := common.NewTextSource("a.exists(x, x.exists(y, y == 1))")
+	_, errs := p.Parse(src)
+	if len(errs.GetErrors()) == 0 {
+		t.Fatalf("expected errors, got none: %s", errs.ToDisplayString())
+	}
+	if !strings.Contains(errs.GetErrors()[0].Message, "expression count exceeds limit of 10 while expanding macro 'exists'") {
+		t.Fatalf("got %q, want substring matching limit error: %s", errs.GetErrors()[0].Message, errs.GetErrors()[0].ToDisplayString(src))
+	}
+}
+
 func TestParserOptionErrors(t *testing.T) {
 	if _, err := NewParser(Macros(AllMacros...), MaxRecursionDepth(-2)); err == nil {
 		t.Fatalf("got %q, want %q", err, "max recursion depth must be greater than or equal to -1: -2")
@@ -2332,6 +2347,9 @@ func TestParserOptionErrors(t *testing.T) {
 	}
 	if _, err := NewParser(ExpressionSizeCodePointLimit(-2)); err == nil {
 		t.Fatalf("got %q, want %q", err, "expression size code point limit must be greater than or equal to -1: -2")
+	}
+	if _, err := NewParser(MaxExpressionNodeCount(-2)); err == nil {
+		t.Fatalf("got %q, want %q", err, "max expression node count must be greater than or equal to -1: -2")
 	}
 }
 


### PR DESCRIPTION
In addition to limiting parser recursion depth and ast recursion depth,
also limit the number of AST nodes permitted in an expression generated
by the parser or accepted by the checker.