### PR TITLE
Improve the efficiency of optMap / optFlatMap

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -3107,6 +3107,18 @@ func TestOptionalValuesEval(t *testing.T) {
 			out: types.OptionalOf(types.Int(43)),
 		},
 		{
+			expr: `{0: 10}[?0].optMap(v, v + 1)`,
+			out:  types.OptionalOf(types.Int(11)),
+		},
+		{
+			expr: `{0: 10}[?0].optMap(a, a + 1).optMap(b, b * 2)`,
+			out:  types.OptionalOf(types.Int(22)),
+		},
+		{
+			expr: `{0: 10}[?1].optMap(a, a + 1).optMap(b, b * 2)`,
+			out:  types.OptionalNone,
+		},
+		{
 			expr: `optional.ofNonZeroValue(z).or(optional.of(10)).value() == 42`,
 			in: map[string]any{
 				"z": 42,

--- a/cel/library.go
+++ b/cel/library.go
@@ -43,6 +43,7 @@ const (
 	optionalUnwrapFunc         = "optional.unwrap"
 	valueFunc                  = "value"
 	unusedIterVar              = "#unused"
+	targetVar                  = "@target"
 )
 
 // Library provides a collection of EnvOption and ProgramOption values used to configure a CEL
@@ -609,22 +610,38 @@ func optMap(meh MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *
 		return nil, meh.NewError(varIdent.ID(), "optMap() variable name must be a simple identifier")
 	}
 	mapExpr := args[1]
-	return meh.NewCall(
+	targetIdent := target
+	if target.Kind() != ast.IdentKind {
+		targetIdent = meh.NewIdent(targetVar)
+	}
+	res := meh.NewCall(
 		operators.Conditional,
-		meh.NewMemberCall(hasValueFunc, target),
+		meh.NewMemberCall(hasValueFunc, targetIdent),
 		meh.NewCall(optionalOfFunc,
 			meh.NewComprehension(
 				meh.NewList(),
 				unusedIterVar,
 				varName,
-				meh.NewMemberCall(valueFunc, meh.Copy(target)),
+				meh.NewMemberCall(valueFunc, meh.Copy(targetIdent)),
 				meh.NewLiteral(types.False),
 				meh.NewIdent(varName),
 				mapExpr,
 			),
 		),
 		meh.NewCall(optionalNoneFunc),
-	), nil
+	)
+	if target.Kind() != ast.IdentKind {
+		return meh.NewComprehension(
+			meh.NewList(),
+			unusedIterVar,
+			targetVar,
+			target,
+			meh.NewLiteral(types.False),
+			meh.NewIdent(targetVar),
+			res,
+		), nil
+	}
+	return res, nil
 }
 
 func optFlatMap(meh MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *Error) {
@@ -637,20 +654,36 @@ func optFlatMap(meh MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Exp
 		return nil, meh.NewError(varIdent.ID(), "optFlatMap() variable name must be a simple identifier")
 	}
 	mapExpr := args[1]
-	return meh.NewCall(
+	targetIdent := target
+	if target.Kind() != ast.IdentKind {
+		targetIdent = meh.NewIdent(targetVar)
+	}
+	res := meh.NewCall(
 		operators.Conditional,
-		meh.NewMemberCall(hasValueFunc, target),
+		meh.NewMemberCall(hasValueFunc, targetIdent),
 		meh.NewComprehension(
 			meh.NewList(),
 			unusedIterVar,
 			varName,
-			meh.NewMemberCall(valueFunc, meh.Copy(target)),
+			meh.NewMemberCall(valueFunc, meh.Copy(targetIdent)),
 			meh.NewLiteral(types.False),
 			meh.NewIdent(varName),
 			mapExpr,
 		),
 		meh.NewCall(optionalNoneFunc),
-	), nil
+	)
+	if target.Kind() != ast.IdentKind {
+		return meh.NewComprehension(
+			meh.NewList(),
+			unusedIterVar,
+			targetVar,
+			target,
+			meh.NewLiteral(types.False),
+			meh.NewIdent(targetVar),
+			res,
+		), nil
+	}
+	return res, nil
 }
 
 func optUnwrap(value ref.Val) ref.Val {


### PR DESCRIPTION
Ensure that optMap / optFlatMap don't replicate the `target` expression unless it's a simple identifier.