### PR TITLE
reject out-of-range hours in timezone offset parsing

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -2790,6 +2790,27 @@ func TestDefaultUTCTimeZoneError(t *testing.T) {
 	}
 }
 
+func TestTimeZoneOffsetOutOfRange(t *testing.T) {
+	env := testEnv(t, Variable("x", TimestampType))
+	vars := map[string]any{"x": time.Unix(7506, 0).UTC()}
+	// Offsets whose hour or minute component falls outside a signed HH:MM field
+	// shift the resolved instant, so they must be rejected at evaluation time.
+	for _, tz := range []string{"+24:00", "-24:00", "+99:00", "-50:30", "+00:99", "+05:-30"} {
+		out, err := interpret(t, env, `x.getHours('`+tz+`') >= 0`, vars)
+		if err == nil {
+			t.Errorf("getHours(%q) got %v, wanted error", tz, out)
+		}
+	}
+	// A boundary offset within the field ranges keeps resolving.
+	out, err := interpret(t, env, `x.getHours('23:15')`, vars)
+	if err != nil {
+		t.Fatalf("getHours('23:15') failed: %v", err)
+	}
+	if out.Equal(types.Int(1)) != types.True {
+		t.Errorf("getHours('23:15') got %v, wanted 1", out)
+	}
+}
+
 func TestParserRecursionLimit(t *testing.T) {
 	testCases := []struct {
 		expr        string

--- a/common/stdlib/standard.go
+++ b/common/stdlib/standard.go
@@ -16,6 +16,7 @@
 package stdlib
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -1053,7 +1054,7 @@ func inTimeZone(ts, tz ref.Val) (time.Time, error) {
 	}
 
 	// If the input is not the name of a timezone (for example, 'US/Central'), it should be a numerical offset from UTC
-	// in the format ^(+|-)(0[0-9]|1[0-4]):[0-5][0-9]$. The numerical input is parsed in terms of hours and minutes.
+	// in the format ^(+|-)([01]\d|2[0-3]):[0-5][0-9]$. The numerical input is parsed in terms of hours and minutes.
 	hr, err := strconv.Atoi(string(val[0:ind]))
 	if err != nil {
 		return time.Time{}, err
@@ -1061,6 +1062,12 @@ func inTimeZone(ts, tz ref.Val) (time.Time, error) {
 	min, err := strconv.Atoi(string(val[ind+1:]))
 	if err != nil {
 		return time.Time{}, err
+	}
+	if hr < -23 || hr > 23 {
+		return time.Time{}, fmt.Errorf("timezone offset hours out of range [-23, 23]: %s", val)
+	}
+	if min < 0 || min > 59 {
+		return time.Time{}, fmt.Errorf("timezone offset minutes out of range [0, 59]: %s", val)
 	}
 	var offset int
 	if string(val[0]) == "-" {

--- a/common/types/timestamp.go
+++ b/common/types/timestamp.go
@@ -368,7 +368,7 @@ func timeZone(tz ref.Val, visitor timestampVisitor) timestampVisitor {
 		}
 
 		// If the input is not the name of a timezone (for example, 'US/Central'), it should be a numerical offset from UTC
-		// in the format ^(+|-)(0[0-9]|1[0-4]):[0-5][0-9]$. The numerical input is parsed in terms of hours and minutes.
+		// in the format ^(+|-)([01]\d|2[0-3]):[0-5][0-9]$. The numerical input is parsed in terms of hours and minutes.
 		hr, err := strconv.Atoi(string(val[0:ind]))
 		if err != nil {
 			return WrapErr(err)
@@ -376,6 +376,9 @@ func timeZone(tz ref.Val, visitor timestampVisitor) timestampVisitor {
 		min, err := strconv.Atoi(string(val[ind+1:]))
 		if err != nil {
 			return WrapErr(err)
+		}
+		if hr < -23 || hr > 23 {
+			return WrapErr(fmt.Errorf("timezone offset hours out of range [-23, 23]: %s", val))
 		}
 		if min < 0 || min > 59 {
 			return WrapErr(fmt.Errorf("timezone offset minutes out of range [0, 59]: %s", val))

--- a/common/types/timestamp_test.go
+++ b/common/types/timestamp_test.go
@@ -439,6 +439,13 @@ func TestTimestampGetHours(t *testing.T) {
 	if !hrTz.Equal(Int(19)).(Bool) {
 		t.Errorf("ts.getHours('America/Phoenix') got %v, wanted 19 hours", hrTz)
 	}
+	// Out-of-range hour offsets are rejected rather than silently shifting the instant.
+	for _, tz := range []string{"+24:00", "-24:00", "+99:00", "-50:30"} {
+		if got := ts.Receive(overloads.TimeGetHours, overloads.TimestampToHoursWithTz,
+			[]ref.Val{String(tz)}); !IsError(got) {
+			t.Errorf("ts.getHours(%q) got %v, wanted error", tz, got)
+		}
+	}
 }
 
 func TestTimestampGetMinutes(t *testing.T) {


### PR DESCRIPTION
**Timezone offset parser accepts out-of-range hours**
The numeric UTC offset accepted by `getHours`/`getMinutes`/`getFullYear` and the sibling timestamp getters is a signed `HH:MM` field, but the stdlib `inTimeZone` validated neither component while the legacy `timeZone` bounded only the minutes, so an offset like `+99:00` or `-50:30` was accepted and silently shifted the resolved instant (and via the stdlib path even `+00:99` minutes slipped through). Both paths now reject any hour outside `[-23, 23]`, mirroring the minute check added in #1336 and keeping the `23:15` boundary that existing tests rely on.