### PR TITLE
Simplify support for native object types

### DIFF
--- a/ext/native.go
+++ b/ext/native.go
@@ -720,12 +720,14 @@ func (t *nativeType) FindFieldType(fieldName string) (*types.FieldType, bool) {
 	return &types.FieldType{
 		Type: celType,
 		IsSet: func(obj any) bool {
+			// TODO: determine what to do if refVal is Invalid()
 			refVal := reflect.Indirect(reflect.ValueOf(obj))
 			// Check if field path exists and is set
 			refFieldVal := safeGetFieldByIndex(refVal, refField.Index)
 			return refFieldVal.IsValid() && !refFieldVal.IsZero()
 		},
 		GetFrom: func(obj any) (any, error) {
+			// TODO: determine what to do if refVal is Invalid()
 			refVal := reflect.Indirect(reflect.ValueOf(obj))
 			// Check if field path exists and is set
 			refFieldVal := safeGetFieldByIndex(refVal, refField.Index)

--- a/ext/native.go
+++ b/ext/native.go
@@ -581,8 +581,11 @@ func newNativeTypes(fieldNameHandler NativeTypesFieldNameHandler, rawType reflec
 		}
 		result = append(result, nt)
 
-		for idx := 0; idx < t.NumField(); idx++ {
-			iterateStructMembers(t.Field(idx).Type)
+		for _, field := range reflect.VisibleFields(t) {
+			if !field.IsExported() || !isSupportedType(field.Type) {
+				continue
+			}
+			iterateStructMembers(field.Type)
 		}
 	}
 	iterateStructMembers(rawType)
@@ -613,8 +616,7 @@ func newNativeType(fieldNameHandler NativeTypesFieldNameHandler, rawType reflect
 	// Collect the set of visible / exported fields, ensuring that unsupported types and sentinel
 	// 'skip' tags such as `-` are filtered out.
 	fieldsByName := make(map[string]reflect.StructField)
-	for idx := 0; idx < refType.NumField(); idx++ {
-		field := refType.Field(idx)
+	for _, field := range reflect.VisibleFields(refType) {
 		if !field.IsExported() || !isSupportedType(field.Type) {
 			continue
 		}

--- a/ext/native.go
+++ b/ext/native.go
@@ -181,14 +181,10 @@ type nativeTypeOptions struct {
 // ParseStructTags configures if native types field names should be overridable by CEL struct tags.
 // This is equivalent to ParseStructTag("cel")
 func ParseStructTags(enabled bool) NativeTypesOption {
-	return func(ntp *nativeTypeOptions) error {
-		if enabled {
-			ntp.fieldNameHandler = fieldNameByTag("cel")
-		} else {
-			ntp.fieldNameHandler = nil
-		}
-		return nil
+	if enabled {
+		return ParseStructTag("cel")
 	}
+	return ParseStructField(nil)
 }
 
 // ParseStructTag configures the struct tag to parse. The 0th item in the tag is used as the name of the CEL field.
@@ -196,10 +192,7 @@ func ParseStructTags(enabled bool) NativeTypesOption {
 // If the tag to parse is "cel" and the struct field has tag cel:"foo", the CEL struct field will be "foo".
 // If the tag to parse is "json" and the struct field has tag json:"foo,omitempty", the CEL struct field will be "foo".
 func ParseStructTag(tag string) NativeTypesOption {
-	return func(ntp *nativeTypeOptions) error {
-		ntp.fieldNameHandler = fieldNameByTag(tag)
-		return nil
-	}
+	return ParseStructField(fieldNameByTag(tag))
 }
 
 // ParseStructField configures how to parse Go struct fields. It can be used to customize struct field parsing.
@@ -270,18 +263,7 @@ func (tp *nativeTypeProvider) FindStructType(typeName string) (*types.Type, bool
 	if _, found := tp.nativeTypes[typeName]; found {
 		return types.NewTypeTypeWithParam(types.NewObjectType(typeName)), true
 	}
-	if celType, found := tp.baseProvider.FindStructType(typeName); found {
-		return celType, true
-	}
 	return tp.baseProvider.FindStructType(typeName)
-}
-
-func toFieldName(fieldNameHandler NativeTypesFieldNameHandler, f reflect.StructField) string {
-	if fieldNameHandler == nil {
-		return f.Name
-	}
-
-	return fieldNameHandler(f)
 }
 
 // FindStructFieldNames looks up the type definition first from the native types, then from
@@ -289,19 +271,7 @@ func toFieldName(fieldNameHandler NativeTypesFieldNameHandler, f reflect.StructF
 // will be returned.
 func (tp *nativeTypeProvider) FindStructFieldNames(typeName string) ([]string, bool) {
 	if t, found := tp.nativeTypes[typeName]; found {
-		fieldCount := t.refType.NumField()
-		fields := make([]string, 0, fieldCount)
-		for i := 0; i < fieldCount; i++ {
-			fieldName := toFieldName(tp.options.fieldNameHandler, t.refType.Field(i))
-			if isSkippedFieldName(fieldName) {
-				continue
-			}
-			fields = append(fields, fieldName)
-		}
-		return fields, true
-	}
-	if celTypeFields, found := tp.baseProvider.FindStructFieldNames(typeName); found {
-		return celTypeFields, true
+		return t.FieldNames(), true
 	}
 	return tp.baseProvider.FindStructFieldNames(typeName)
 }
@@ -309,55 +279,18 @@ func (tp *nativeTypeProvider) FindStructFieldNames(typeName string) ([]string, b
 // FindStructFieldType looks up a native type's field definition, and if the type name is not a native
 // type then proxies to the composed types.Provider
 func (tp *nativeTypeProvider) FindStructFieldType(typeName, fieldName string) (*types.FieldType, bool) {
-	t, found := tp.nativeTypes[typeName]
-	if !found {
-		return tp.baseProvider.FindStructFieldType(typeName, fieldName)
+	if t, found := tp.nativeTypes[typeName]; found {
+		return t.FindFieldType(fieldName)
 	}
-	refField, isDefined := t.hasField(fieldName)
-	if !found || !isDefined {
-		return nil, false
-	}
-	celType, ok := convertToCelType(refField.Type)
-	if !ok {
-		return nil, false
-	}
-	return &types.FieldType{
-		Type: celType,
-		IsSet: func(obj any) bool {
-			refVal := reflect.Indirect(reflect.ValueOf(obj))
-			refField := refVal.FieldByName(refField.Name)
-			return !refField.IsZero()
-		},
-		GetFrom: func(obj any) (any, error) {
-			refVal := reflect.Indirect(reflect.ValueOf(obj))
-			refField := refVal.FieldByName(refField.Name)
-			return getFieldValue(refField), nil
-		},
-	}, true
+	return tp.baseProvider.FindStructFieldType(typeName, fieldName)
 }
 
 // NewValue implements the ref.TypeProvider interface method.
 func (tp *nativeTypeProvider) NewValue(typeName string, fields map[string]ref.Val) ref.Val {
-	t, found := tp.nativeTypes[typeName]
-	if !found {
-		return tp.baseProvider.NewValue(typeName, fields)
+	if t, found := tp.nativeTypes[typeName]; found {
+		return t.NewValue(tp, fields)
 	}
-	refPtr := reflect.New(t.refType)
-	refVal := refPtr.Elem()
-	for fieldName, val := range fields {
-		refFieldDef, isDefined := t.hasField(fieldName)
-		if !isDefined {
-			return types.NewErr("no such field: %s", fieldName)
-		}
-		fieldVal, err := val.ConvertToNative(refFieldDef.Type)
-		if err != nil {
-			return types.NewErrFromString(err.Error())
-		}
-		refField := refVal.FieldByIndex(refFieldDef.Index)
-		refFieldVal := reflect.ValueOf(fieldVal)
-		refField.Set(refFieldVal)
-	}
-	return tp.NativeToValue(refPtr.Interface())
+	return tp.baseProvider.NewValue(typeName, fields)
 }
 
 // NewValue adapts native values to CEL values and will proxy to the composed type adapter
@@ -382,7 +315,7 @@ func (tp *nativeTypeProvider) NativeToValue(val any) ref.Val {
 		case []byte:
 			return tp.baseAdapter.NativeToValue(val)
 		default:
-			if refVal.Type().Elem() == reflect.TypeOf(byte(0)) {
+			if refVal.Type().Elem() == reflect.TypeFor[byte]() {
 				return tp.baseAdapter.NativeToValue(val)
 			}
 			return types.NewDynamicList(tp, val)
@@ -401,8 +334,8 @@ func (tp *nativeTypeProvider) NativeToValue(val any) ref.Val {
 			// a composed base adapter never sees unregistered structs it wants
 			// to convert itself.
 			typeName := fmt.Sprintf("%s.%s", simplePkgAlias(refVal.Type().PkgPath()), refVal.Type().Name())
-			if _, found := tp.nativeTypes[typeName]; found {
-				return tp.newNativeObject(val, rawVal)
+			if ntype, found := tp.nativeTypes[typeName]; found {
+				return tp.newNativeObject(val, ntype, rawVal)
 			}
 			return tp.baseAdapter.NativeToValue(val)
 		}
@@ -472,11 +405,7 @@ func convertToCelType(refType reflect.Type) (*cel.Type, bool) {
 	return nil, false
 }
 
-func (tp *nativeTypeProvider) newNativeObject(val any, refValue reflect.Value) ref.Val {
-	valType, err := newNativeType(tp.options.fieldNameHandler, refValue.Type())
-	if err != nil {
-		return types.NewErrFromString(err.Error())
-	}
+func (tp *nativeTypeProvider) newNativeObject(val any, valType *nativeType, refValue reflect.Value) ref.Val {
 	return &nativeObj{
 		Adapter:  tp,
 		val:      val,
@@ -517,16 +446,10 @@ func (o *nativeObj) ConvertToNative(typeDesc reflect.Type) (any, error) {
 		return structpb.NewStructValue(jsonStruct.(*structpb.Struct)), nil
 	case jsonStructType:
 		refVal := reflect.Indirect(o.refValue)
-		refType := refVal.Type()
 		fields := make(map[string]*structpb.Value, refVal.NumField())
-		for i := 0; i < refVal.NumField(); i++ {
-			fieldType := refType.Field(i)
-			fieldValue := refVal.Field(i)
+		for fieldName, fieldType := range o.valType.fieldsByName {
+			fieldValue := refVal.FieldByIndex(fieldType.Index)
 			if !fieldValue.IsValid() || fieldValue.IsZero() {
-				continue
-			}
-			fieldName := toFieldName(o.valType.fieldNameHandler, fieldType)
-			if isSkippedFieldName(fieldName) {
 				continue
 			}
 			fieldCELVal := o.NativeToValue(fieldValue.Interface())
@@ -671,6 +594,13 @@ var (
 	errDuplicatedFieldName = errors.New("field name already exists in struct")
 )
 
+func toFieldName(fieldNameHandler NativeTypesFieldNameHandler, f reflect.StructField) string {
+	if fieldNameHandler == nil {
+		return f.Name
+	}
+	return fieldNameHandler(f)
+}
+
 func newNativeType(fieldNameHandler NativeTypesFieldNameHandler, rawType reflect.Type) (*nativeType, error) {
 	refType := rawType
 	if refType.Kind() == reflect.Pointer {
@@ -680,35 +610,35 @@ func newNativeType(fieldNameHandler NativeTypesFieldNameHandler, rawType reflect
 		return nil, fmt.Errorf("unsupported reflect.Type %v, must be reflect.Struct", rawType)
 	}
 
-	// Since naming collisions can only happen with struct tag parsing, we only check for them if it is enabled.
-	if fieldNameHandler != nil {
-		fieldNames := make(map[string]struct{})
-
-		for idx := 0; idx < refType.NumField(); idx++ {
-			field := refType.Field(idx)
-			fieldName := toFieldName(fieldNameHandler, field)
-			if isSkippedFieldName(fieldName) {
-				continue
-			}
-			if _, found := fieldNames[fieldName]; found {
-				return nil, fmt.Errorf("invalid field name `%s` in struct `%s`: %w", fieldName, refType.Name(), errDuplicatedFieldName)
-			} else {
-				fieldNames[fieldName] = struct{}{}
-			}
+	// Collect the set of visible / exported fields, ensuring that unsupported types and sentinel
+	// 'skip' tags such as `-` are filtered out.
+	fieldsByName := make(map[string]reflect.StructField)
+	for idx := 0; idx < refType.NumField(); idx++ {
+		field := refType.Field(idx)
+		if !field.IsExported() || !isSupportedType(field.Type) {
+			continue
 		}
+		fieldName := toFieldName(fieldNameHandler, field)
+		if isSkippedFieldName(fieldName) {
+			continue
+		}
+		if _, found := fieldsByName[fieldName]; found {
+			return nil, fmt.Errorf("invalid field name `%s` in struct `%s`: %w", fieldName, refType.Name(), errDuplicatedFieldName)
+		}
+		fieldsByName[fieldName] = field
 	}
 
 	return &nativeType{
-		typeName:         fmt.Sprintf("%s.%s", simplePkgAlias(refType.PkgPath()), refType.Name()),
-		refType:          refType,
-		fieldNameHandler: fieldNameHandler,
+		typeName:     fmt.Sprintf("%s.%s", simplePkgAlias(refType.PkgPath()), refType.Name()),
+		refType:      refType,
+		fieldsByName: fieldsByName,
 	}, nil
 }
 
 type nativeType struct {
-	typeName         string
-	refType          reflect.Type
-	fieldNameHandler NativeTypesFieldNameHandler
+	typeName     string
+	refType      reflect.Type
+	fieldsByName map[string]reflect.StructField
 }
 
 // ConvertToNative implements ref.Val.ConvertToNative.
@@ -756,34 +686,67 @@ func (t *nativeType) Value() any {
 	return t.typeName
 }
 
-// fieldByName returns the corresponding reflect.StructField for the give name either by matching
-// field tag or field name.
-func (t *nativeType) fieldByName(fieldName string) (reflect.StructField, bool) {
-	if isSkippedFieldName(fieldName) {
-		return reflect.StructField{}, false
-	}
-
-	if t.fieldNameHandler == nil {
-		return t.refType.FieldByName(fieldName)
-	}
-
-	for i := 0; i < t.refType.NumField(); i++ {
-		f := t.refType.Field(i)
-		if toFieldName(t.fieldNameHandler, f) == fieldName {
-			return f, true
-		}
-	}
-
-	return reflect.StructField{}, false
-}
-
 // hasField returns whether a field name has a corresponding Golang reflect.StructField
 func (t *nativeType) hasField(fieldName string) (reflect.StructField, bool) {
-	f, found := t.fieldByName(fieldName)
-	if !found || !f.IsExported() || !isSupportedType(f.Type) {
+	f, found := t.fieldsByName[fieldName]
+	if !found {
 		return reflect.StructField{}, false
 	}
 	return f, true
+}
+
+// FieldNames provides the list of field names for this type.
+func (t *nativeType) FieldNames() []string {
+	fields := make([]string, 0, len(t.fieldsByName))
+	for fieldName := range t.fieldsByName {
+		fields = append(fields, fieldName)
+	}
+	return fields
+}
+
+// FindFieldType looks up a field by name and provides the type and accessor functions
+// required for type identification at check-time and accessors for use at runtime.
+func (t *nativeType) FindFieldType(fieldName string) (*types.FieldType, bool) {
+	refField, found := t.hasField(fieldName)
+	if !found {
+		return nil, false
+	}
+	celType, ok := convertToCelType(refField.Type)
+	if !ok {
+		return nil, false
+	}
+	return &types.FieldType{
+		Type: celType,
+		IsSet: func(obj any) bool {
+			refVal := reflect.Indirect(reflect.ValueOf(obj))
+			refField := refVal.FieldByIndex(refField.Index)
+			return !refField.IsZero()
+		},
+		GetFrom: func(obj any) (any, error) {
+			refVal := reflect.Indirect(reflect.ValueOf(obj))
+			refField := refVal.FieldByIndex(refField.Index)
+			return getFieldValue(refField), nil
+		},
+	}, true
+}
+
+// NewValue constructs a new native Go struct instance populated with the given field values.
+func (t *nativeType) NewValue(adapter types.Adapter, fields map[string]ref.Val) ref.Val {
+	refPtr := reflect.New(t.refType)
+	refVal := refPtr.Elem()
+	for fieldName, val := range fields {
+		refFieldDef, isDefined := t.hasField(fieldName)
+		if !isDefined {
+			return types.NewErr("no such field: %s", fieldName)
+		}
+		fieldVal, err := val.ConvertToNative(refFieldDef.Type)
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		refField := refVal.FieldByIndex(refFieldDef.Index)
+		refField.Set(reflect.ValueOf(fieldVal))
+	}
+	return adapter.NativeToValue(refPtr.Interface())
 }
 
 func adaptFieldValue(adapter types.Adapter, refField reflect.Value) ref.Val {

--- a/ext/native.go
+++ b/ext/native.go
@@ -536,7 +536,7 @@ func (o *nativeObj) getReflectedField(field ref.Val) (reflect.Value, ref.Val) {
 		return reflect.Value{}, types.NewErr("no such field: %s", fieldName)
 	}
 	refVal := reflect.Indirect(o.refValue)
-	return refVal.FieldByIndex(refField.Index), nil
+	return safeGetFieldByIndex(refVal, refField.Index), nil
 }
 
 // Type implements the ref.Val interface method.
@@ -721,13 +721,15 @@ func (t *nativeType) FindFieldType(fieldName string) (*types.FieldType, bool) {
 		Type: celType,
 		IsSet: func(obj any) bool {
 			refVal := reflect.Indirect(reflect.ValueOf(obj))
-			refField := refVal.FieldByIndex(refField.Index)
-			return !refField.IsZero()
+			// Check if field path exists and is set
+			refFieldVal := safeGetFieldByIndex(refVal, refField.Index)
+			return refFieldVal.IsValid() && !refFieldVal.IsZero()
 		},
 		GetFrom: func(obj any) (any, error) {
 			refVal := reflect.Indirect(reflect.ValueOf(obj))
-			refField := refVal.FieldByIndex(refField.Index)
-			return getFieldValue(refField), nil
+			// Check if field path exists and is set
+			refFieldVal := safeGetFieldByIndex(refVal, refField.Index)
+			return getFieldValue(refFieldVal), nil
 		},
 	}, true
 }
@@ -745,7 +747,10 @@ func (t *nativeType) NewValue(adapter types.Adapter, fields map[string]ref.Val) 
 		if err != nil {
 			return types.NewErrFromString(err.Error())
 		}
-		refField := refVal.FieldByIndex(refFieldDef.Index)
+		refField := safeSetFieldByIndex(refVal, refFieldDef.Index)
+		if !refField.IsValid() {
+			return types.NewErr("cannot set field: %s", fieldName)
+		}
 		refField.Set(reflect.ValueOf(fieldVal))
 	}
 	return adapter.NativeToValue(refPtr.Interface())
@@ -755,7 +760,49 @@ func adaptFieldValue(adapter types.Adapter, refField reflect.Value) ref.Val {
 	return adapter.NativeToValue(getFieldValue(refField))
 }
 
+// safeSetFieldByIndex traverses refField.Index to set a field value.
+// If an intermediate pointer along the path is nil, it allocates a new
+// instance of the struct that the pointer references.
+func safeSetFieldByIndex(v reflect.Value, index []int) reflect.Value {
+	for _, i := range index {
+		if v.Kind() == reflect.Pointer {
+			if v.IsNil() {
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+		if v.Kind() != reflect.Struct || i >= v.NumField() {
+			return reflect.Value{}
+		}
+		v = v.Field(i)
+	}
+	return v
+}
+
+// safeGetFieldByIndex traverses refField.Index. If an intermediate pointer along
+// the path is nil, it substitutes a pointer to an empty struct instance of that type.
+func safeGetFieldByIndex(v reflect.Value, index []int) reflect.Value {
+	for _, i := range index {
+		if v.Kind() == reflect.Pointer {
+			if v.IsNil() {
+				// Intermediate pointer to struct is nil: instantiate an empty struct
+				v = reflect.New(v.Type().Elem()).Elem()
+			} else {
+				v = v.Elem()
+			}
+		}
+		if v.Kind() != reflect.Struct || i >= v.NumField() {
+			return reflect.Value{}
+		}
+		v = v.Field(i)
+	}
+	return v
+}
+
 func getFieldValue(refField reflect.Value) any {
+	if !refField.IsValid() {
+		return nil
+	}
 	if refField.IsZero() {
 		switch refField.Kind() {
 		case reflect.Struct:

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -1024,6 +1024,79 @@ func TestNativeStructEmbedded(t *testing.T) {
 	}
 }
 
+func TestNativeStructEmbeddedPointer(t *testing.T) {
+	nativeTests := []struct {
+		expr string
+		in   map[string]any
+		out  any
+	}{
+		{
+			expr: `!has(test.custom_name) && test.custom_name == ""`,
+			in: map[string]any{
+				"test": &TestEmbeddedPointerTypes{
+					TestNestedType: nil,
+				},
+			},
+			out: true,
+		},
+		{
+			expr: `has(test.custom_name) && test.custom_name == "name"`,
+			in: map[string]any{
+				"test": &TestEmbeddedPointerTypes{
+					TestNestedType: &TestNestedType{NestedCustomName: "name"},
+				},
+			},
+			out: true,
+		},
+		{
+			expr: `ext.TestEmbeddedPointerTypes{custom_name: "name"}.custom_name == "name"`,
+			in:   nil,
+			out:  true,
+		},
+	}
+
+	envOpts := []cel.EnvOption{
+		NativeTypes(
+			reflect.TypeFor[*TestEmbeddedPointerTypes](),
+			reflect.TypeFor[*TestNestedType](),
+			ParseStructTag("json"),
+		),
+		cel.Variable("test", cel.ObjectType("ext.TestEmbeddedPointerTypes")),
+	}
+
+	env, err := cel.NewEnv(envOpts...)
+	if err != nil {
+		t.Fatalf("cel.NewEnv(NativeTypes()) failed: %v", err)
+	}
+
+	for i, tst := range nativeTests {
+		tc := tst
+		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
+			pAst, iss := env.Parse(tc.expr)
+			if iss.Err() != nil {
+				t.Fatalf("env.Parse(%v) failed: %v", tc.expr, iss.Err())
+			}
+			cAst, iss := env.Check(pAst)
+			if iss.Err() != nil {
+				t.Fatalf("env.Check(%v) failed: %v", tc.expr, iss.Err())
+			}
+			for _, ast := range []*cel.Ast{pAst, cAst} {
+				prg, err := env.Program(ast)
+				if err != nil {
+					t.Fatal(err)
+				}
+				out, _, err := prg.Eval(tc.in)
+				if err != nil {
+					t.Fatalf("prg.Eval() failed: %v", err)
+				}
+				if !reflect.DeepEqual(out.Value(), tc.out) {
+					t.Errorf("got %v, wanted %v for expr: %s", out.Value(), tc.out, tc.expr)
+				}
+			}
+		})
+	}
+}
+
 func TestNativeStructHiddenField(t *testing.T) {
 	envOpts := []cel.EnvOption{
 		NativeTypes(
@@ -1280,6 +1353,10 @@ type TestEmbeddedTypes struct {
 	Custom
 	TestNestedType `json:"embedded,omitempty"`
 	Skipped        string `json:"-"`
+}
+
+type TestEmbeddedPointerTypes struct {
+	*TestNestedType `json:"embedded,omitempty"`
 }
 
 type TestRefValFieldType struct {

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -874,7 +874,7 @@ func TestNativeTypeConvertToType(t *testing.T) {
 		tc := tst
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
 			handler := fieldNameByTag(tc.tag)
-			nt, err := newNativeType(handler, reflect.TypeOf(&TestAllTypes{}))
+			nt, err := newNativeType(handler, reflect.TypeFor[*TestAllTypes]())
 			if err != nil {
 				t.Fatalf("newNativeType() failed: %v", err)
 			}
@@ -889,7 +889,7 @@ func TestNativeTypeConvertToType(t *testing.T) {
 }
 
 func TestNativeTypeConvertToNative(t *testing.T) {
-	nt, err := newNativeType(fieldNameByTag("cel"), reflect.TypeOf(&TestAllTypes{}))
+	nt, err := newNativeType(fieldNameByTag("cel"), reflect.TypeFor[*TestAllTypes]())
 	if err != nil {
 		t.Fatalf("newNativeType() failed: %v", err)
 	}
@@ -900,7 +900,7 @@ func TestNativeTypeConvertToNative(t *testing.T) {
 }
 
 func TestNativeTypeHasTrait(t *testing.T) {
-	nt, err := newNativeType(fieldNameByTag("cel"), reflect.TypeOf(&TestAllTypes{}))
+	nt, err := newNativeType(fieldNameByTag("cel"), reflect.TypeFor[*TestAllTypes]())
 	if err != nil {
 		t.Fatalf("newNativeType() failed: %v", err)
 	}
@@ -910,7 +910,7 @@ func TestNativeTypeHasTrait(t *testing.T) {
 }
 
 func TestNativeTypeValue(t *testing.T) {
-	nt, err := newNativeType(fieldNameByTag("cel"), reflect.TypeOf(&TestAllTypes{}))
+	nt, err := newNativeType(fieldNameByTag("cel"), reflect.TypeFor[*TestAllTypes]())
 	if err != nil {
 		t.Fatalf("newNativeType() failed: %v", err)
 	}
@@ -920,7 +920,7 @@ func TestNativeTypeValue(t *testing.T) {
 }
 
 func TestNativeStructWithMultipleSameFieldNames(t *testing.T) {
-	_, err := newNativeType(fieldNameByTag("cel"), reflect.TypeOf(TestStructWithMultipleSameNames{}))
+	_, err := newNativeType(fieldNameByTag("cel"), reflect.TypeFor[TestStructWithMultipleSameNames]())
 	if err == nil {
 		t.Fatal("newNativeType() did not fail as expected")
 	}
@@ -1168,7 +1168,7 @@ func TestTypeResolutionRace(t *testing.T) {
 }
 
 // testEnv initializes the test environment common to all tests.
-func testNativeEnv(t *testing.T, opts ...any) *cel.Env {
+func testNativeEnv(t testing.TB, opts ...any) *cel.Env {
 	t.Helper()
 	envOpts := []cel.EnvOption{
 		cel.Container("ext"),
@@ -1217,8 +1217,8 @@ type Custom struct {
 }
 
 type TestStructWithMultipleSameNames struct {
-	Name        string
-	custom_name string `cel:"Name"`
+	Name       string
+	CustomName string `cel:"Name"`
 }
 
 type TestNestedType struct {
@@ -1334,4 +1334,172 @@ func TestNativeToValueDelegatesUnregisteredStructs(t *testing.T) {
 	if tn := gotReg.Type().TypeName(); !strings.Contains(tn, "registeredNativeStruct") {
 		t.Errorf("NativeToValue(registeredNativeStruct).Type() = %q, want a native object type", tn)
 	}
+}
+
+func BenchmarkNativeTypesEval(b *testing.B) {
+	benchmarks := []struct {
+		name    string
+		expr    string
+		in      any
+		envOpts []any
+	}{
+		{
+			name: "FieldAccess",
+			expr: "t.Int32Val + t.Int64Val",
+			in: map[string]any{
+				"t": &TestAllTypes{Int32Val: 10, Int64Val: 20},
+			},
+		},
+		{
+			name: "NestedFieldAccess",
+			expr: "t.NestedVal.NestedCustomName == 'name'",
+			in: map[string]any{
+				"t": &TestAllTypes{
+					NestedVal: &TestNestedType{NestedCustomName: "name"},
+				},
+			},
+		},
+		{
+			name: "StructCreation",
+			expr: `ext.TestAllTypes{
+				BoolVal: true,
+				Int32Val: 10,
+				Int64Val: 20,
+				StringVal: 'hello world',
+			}`,
+		},
+		{
+			name: "FieldPresence",
+			expr: "has(t.BoolVal) && has(t.NestedVal)",
+			in: map[string]any{
+				"t": &TestAllTypes{
+					BoolVal:   true,
+					NestedVal: &TestNestedType{},
+				},
+			},
+		},
+		{
+			name:    "StructTagFieldAccess",
+			expr:    "t.custom_name == 'name'",
+			envOpts: []any{ParseStructTags(true)},
+			in: map[string]any{
+				"t": &TestAllTypes{CustomName: "name"},
+			},
+		},
+		{
+			name: "ListExists",
+			expr: "tests.exists(t, t.Int32Val > 15)",
+			in: map[string]any{
+				"tests": []*TestAllTypes{
+					{Int32Val: 10},
+					{Int32Val: 20},
+				},
+			},
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			envOpts := append([]any{
+				cel.Variable("t", cel.ObjectType("ext.TestAllTypes")),
+			}, bm.envOpts...)
+			env := testNativeEnv(b, envOpts...)
+			ast, iss := env.Compile(bm.expr)
+			if iss.Err() != nil {
+				b.Fatalf("env.Compile(%q) failed: %v", bm.expr, iss.Err())
+			}
+			prg, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize))
+			if err != nil {
+				b.Fatalf("env.Program() failed: %v", err)
+			}
+			input := bm.in
+			if input == nil {
+				input = cel.NoVars()
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				prg.Eval(input)
+			}
+		})
+	}
+}
+
+func BenchmarkNativeToValue(b *testing.B) {
+	env := testNativeEnv(b)
+	adapter := env.CELTypeAdapter()
+
+	nested := &TestNestedType{
+		NestedListVal:    []string{"a", "b", "c"},
+		NestedMapVal:     map[int64]bool{1: true},
+		NestedCustomName: "test",
+	}
+	allTypes := &TestAllTypes{
+		BoolVal:   true,
+		Int32Val:  10,
+		Int64Val:  20,
+		StringVal: "hello world",
+		NestedVal: nested,
+		ListVal:   []*TestNestedType{nested},
+	}
+	allTypesSlice := []*TestAllTypes{allTypes, allTypes}
+
+	benchmarks := []struct {
+		name string
+		val  any
+	}{
+		{name: "TestNestedType", val: nested},
+		{name: "TestAllTypes", val: allTypes},
+		{name: "SliceTestAllTypes", val: allTypesSlice},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				adapter.NativeToValue(bm.val)
+			}
+		})
+	}
+}
+
+func BenchmarkConvertToNative(b *testing.B) {
+	env := testNativeEnv(b)
+	adapter := env.CELTypeAdapter()
+
+	allTypes := &TestAllTypes{
+		BoolVal:   true,
+		Int32Val:  10,
+		Int64Val:  20,
+		StringVal: "hello world",
+	}
+	celVal := adapter.NativeToValue(allTypes)
+	targetType := reflect.TypeOf(&TestAllTypes{})
+
+	allTypesSlice := []*TestAllTypes{allTypes, allTypes}
+	celSliceVal := adapter.NativeToValue(allTypesSlice)
+	sliceTargetType := reflect.TypeOf([]*TestAllTypes{})
+
+	b.Run("TestAllTypes", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, err := celVal.ConvertToNative(targetType)
+			if err != nil {
+				b.Fatalf("ConvertToNative failed: %v", err)
+			}
+		}
+	})
+
+	b.Run("SliceTestAllTypes", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, err := celSliceVal.ConvertToNative(sliceTargetType)
+			if err != nil {
+				b.Fatalf("ConvertToNative failed: %v", err)
+			}
+		}
+	})
 }

--- a/ext/native_test.go
+++ b/ext/native_test.go
@@ -965,6 +965,15 @@ func TestNativeStructEmbedded(t *testing.T) {
 			},
 			out: true,
 		},
+		{
+			expr: `test.Name == "name"`,
+			in: map[string]any{
+				"test": &TestEmbeddedTypes{
+					Custom: Custom{Name: "name"},
+				},
+			},
+			out: true,
+		},
 	}
 
 	envOpts := []cel.EnvOption{
@@ -1268,6 +1277,7 @@ type TestMapVal struct {
 }
 
 type TestEmbeddedTypes struct {
+	Custom
 	TestNestedType `json:"embedded,omitempty"`
 	Skipped        string `json:"-"`
 }


### PR DESCRIPTION
Shift most of the logic from the NativeTypeProvider over to the NativeObject wrappers. 

This change is a stepping stone to consolidating type providers into the common/types
package and making it less painful to manage custom type adaptation.