### PR TITLE
Charge base call cost when a strict call short-circuits on an error operand

### DIFF
--- a/interpreter/runtimecost.go
+++ b/interpreter/runtimecost.go
@@ -155,6 +155,14 @@ func (ct *costTrackerFactory) Observe(vars Activation, id int64, programStep any
 	case InterpretableCall:
 		if argVals, ok := tracker.stack.dropArgs(t.Args()); ok {
 			tracker.cost += tracker.costCall(t, argVals, val)
+		} else if types.IsError(val) {
+			switch t.(type) {
+			case *evalEq, *evalNe, *evalBinary:
+				// The call short-circuited on an error operand without evaluating all of
+				// its arguments. Charge the base call cost so that the observed cost does
+				// not depend on which operand produced the error.
+				tracker.cost++
+			}
 		}
 	case InterpretableConstructor:
 		tracker.stack.dropArgs(t.InitVals())

--- a/interpreter/runtimecost_test.go
+++ b/interpreter/runtimecost_test.go
@@ -268,6 +268,26 @@ func TestRuntimeCost(t *testing.T) {
 			want: 0,
 		},
 		{
+			name: "eq error operand short-circuits",
+			expr: `1 / 0 == 2`,
+			want: 2,
+		},
+		{
+			name: "eq error operand commuted",
+			expr: `2 == 1 / 0`,
+			want: 2,
+		},
+		{
+			name: "ne error operand short-circuits",
+			expr: `1 / 0 != 2`,
+			want: 2,
+		},
+		{
+			name: "binary call error operand short-circuits",
+			expr: `1 / 0 + 2`,
+			want: 2,
+		},
+		{
 			name: "identity",
 			expr: `input`,
 			vars: []*decls.VariableDecl{decls.NewVariable("input", intList)},


### PR DESCRIPTION
Lazy operand evaluation (#1369) stopped executing the right hand side of `==`, `!=`, and strict binary calls when the left hand side is an error. The cost observer only charges a call when it has observed all of the argument values. Because of that, these calls stopped being charged at all when the left side errors.

This has two effects:

- The observed cost now depends on which operand produced the error. `2 == 1 / 0` charges the call and `1 / 0 == 2` does not.
- The observed cost of these expressions dropped between v0.29.2 and v0.30.0. Kubernetes pins the runtime cost of a fixed set of expressions in its tests, and two of them changed when v0.30.0 was released (https://testgrid.k8s.io/sig-arch-code-organization#unit-master-dependencies).

This change keeps lazy evaluation as it is and only fixes the accounting. When a strict eq, ne, or binary call produces an error without all of its arguments observed, the tracker charges the base call cost of 1. That makes the cost independent of operand order and restores the cost these expressions reported before v0.30.0.

`evalVarArgs` is left alone on purpose. Variadic calls already short-circuited on errors before v0.30.0, so charging them now would change their observed cost in the other direction.

I verified this by running the full cel-go test suite, and by running the Kubernetes CEL cost stability tests against v0.30.0 plus this change. The Kubernetes tests pass with no changes on their side.