### PR TITLE
Support self-describing, self-adapting struct types

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -4132,9 +4132,9 @@ func TestJSONFieldNamesInvalidProvider(t *testing.T) {
 	type wrapperRegistry struct {
 		*types.Registry
 	}
-	reg, err := types.NewProtoRegistry(types.JSONFieldNames(true))
+	reg, err := types.NewRegistry(types.JSONFieldNames(true))
 	if err != nil {
-		t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+		t.Fatalf("types.NewRegistry() failed: %v", err)
 	}
 	wrapped := wrapperRegistry{Registry: reg}
 	_, err = NewEnv(CustomTypeProvider(wrapped), CustomTypeAdapter(reg), JSONFieldNames(true))

--- a/cel/env.go
+++ b/cel/env.go
@@ -365,7 +365,7 @@ func NewEnv(opts ...EnvOption) (*Env, error) {
 // See the EnvOption helper functions for the options that can be used to configure the
 // environment.
 func NewCustomEnv(opts ...EnvOption) (*Env, error) {
-	registry, err := types.NewProtoRegistry()
+	registry, err := types.NewRegistry()
 	if err != nil {
 		return nil, err
 	}

--- a/cel/env_test.go
+++ b/cel/env_test.go
@@ -198,9 +198,9 @@ func TestEnvPartialVarsError(t *testing.T) {
 }
 
 func TestTypeProviderInterop(t *testing.T) {
-	reg, err := types.NewProtoRegistry(types.ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	reg, err := types.NewRegistry(&proto3pb.TestAllTypes{})
 	if err != nil {
-		t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+		t.Fatalf("types.NewRegistry() failed: %v", err)
 	}
 	tests := []struct {
 		name     string

--- a/cel/options.go
+++ b/cel/options.go
@@ -920,7 +920,11 @@ func ContextProtoVars(ctx proto.Message, opts ...types.RegistryOption) (Activati
 	}
 	regOpts := []types.RegistryOption{types.ProtoTypeDefs(ctx)}
 	regOpts = append(regOpts, opts...)
-	reg, err := types.NewProtoRegistry(regOpts...)
+	var ro []any
+	for _, opt := range regOpts {
+		ro = append(ro, opt)
+	}
+	reg, err := types.NewRegistry(ro...)
 	if err != nil {
 		return nil, err
 	}

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -2542,12 +2542,12 @@ func TestCheck(t *testing.T) {
 				t.Fatalf("Unexpected parse errors: %v", errors.ToDisplayString())
 			}
 
-			reg, err := types.NewProtoRegistry(
+			reg, err := types.NewRegistry(
 				types.JSONFieldNames(tc.env.jsonFieldNames),
 				types.ProtoTypeDefs(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{}),
 			)
 			if err != nil {
-				t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+				t.Fatalf("types.NewRegistry() failed: %v", err)
 			}
 			if tc.env.optionalSyntax {
 				if err := reg.RegisterType(types.OptionalType); err != nil {
@@ -2654,9 +2654,9 @@ func BenchmarkCheck(b *testing.B) {
 			if len(errors.GetErrors()) > 0 {
 				b.Fatalf("Unexpected parse errors: %v", errors.ToDisplayString())
 			}
-			reg, err := types.NewProtoRegistry(types.ProtoTypeDefs(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{}))
+			reg, err := types.NewRegistry(types.ProtoTypeDefs(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{}))
 			if err != nil {
-				b.Fatalf("types.NewProtoRegistry() failed: %v", err)
+				b.Fatalf("types.NewRegistry() failed: %v", err)
 			}
 			if tc.env.optionalSyntax {
 				if err := reg.RegisterType(types.OptionalType); err != nil {
@@ -2723,9 +2723,9 @@ func BenchmarkCheck(b *testing.B) {
 }
 
 func TestAddDuplicateDeclarations(t *testing.T) {
-	reg, err := types.NewProtoRegistry(types.ProtoTypeDefs(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{}))
+	reg, err := types.NewRegistry(types.ProtoTypeDefs(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{}))
 	if err != nil {
-		t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+		t.Fatalf("types.NewRegistry() failed: %v", err)
 	}
 	env, err := NewEnv(containers.DefaultContainer, reg, CrossTypeNumericComparisons(true))
 	if err != nil {
@@ -2742,9 +2742,9 @@ func TestAddDuplicateDeclarations(t *testing.T) {
 }
 
 func TestAddEquivalentDeclarations(t *testing.T) {
-	reg, err := types.NewProtoRegistry(types.ProtoTypeDefs(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{}))
+	reg, err := types.NewRegistry(types.ProtoTypeDefs(&proto2pb.TestAllTypes{}, &proto3pb.TestAllTypes{}))
 	if err != nil {
-		t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+		t.Fatalf("types.NewRegistry() failed: %v", err)
 	}
 	env, err := NewEnv(containers.DefaultContainer, reg, CrossTypeNumericComparisons(true))
 	if err != nil {

--- a/checker/cost_test.go
+++ b/checker/cost_test.go
@@ -766,9 +766,9 @@ func TestCost(t *testing.T) {
 			if len(errs.GetErrors()) != 0 {
 				t.Fatalf("parser.Parse(%v) failed: %v", tc.expr, errs.ToDisplayString())
 			}
-			reg, err := types.NewProtoRegistry(types.ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+			reg, err := types.NewRegistry(types.ProtoTypeDefs(&proto3pb.TestAllTypes{}))
 			if err != nil {
-				t.Fatalf("types.NewProtoRegistry(...) failed: %v", err)
+				t.Fatalf("types.NewRegistry(...) failed: %v", err)
 			}
 
 			e, err := NewEnv(containers.DefaultContainer, reg)

--- a/common/ast/navigable_test.go
+++ b/common/ast/navigable_test.go
@@ -669,9 +669,13 @@ func mustTypeCheck(t testing.TB, expr string, opts ...any) *ast.AST {
 
 func newTestRegistry(t testing.TB, opts ...types.RegistryOption) *types.Registry {
 	t.Helper()
-	reg, err := types.NewProtoRegistry(opts...)
+	var o []any
+	for _, opt := range opts {
+		o = append(o, opt)
+	}
+	reg, err := types.NewRegistry(o...)
 	if err != nil {
-		t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+		t.Fatalf("types.NewRegistry() failed: %v", err)
 	}
 	return reg
 }

--- a/common/env/env_test.go
+++ b/common/env/env_test.go
@@ -748,9 +748,9 @@ func TestVariableAsCELVariable(t *testing.T) {
 		},
 	}
 
-	tp, err := types.NewProtoRegistry()
+	tp, err := types.NewRegistry()
 	if err != nil {
-		t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+		t.Fatalf("types.NewRegistry() failed: %v", err)
 	}
 	tp.RegisterType(types.NewOpaqueType("set", types.NewTypeParamType("T")))
 	for _, tst := range tests {
@@ -936,9 +936,9 @@ func TestFunctionAsCELFunction(t *testing.T) {
 					types.NewTypeParamType("T"))),
 		},
 	}
-	tp, err := types.NewProtoRegistry()
+	tp, err := types.NewRegistry()
 	if err != nil {
-		t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+		t.Fatalf("types.NewRegistry() failed: %v", err)
 	}
 	tp.RegisterType(types.NewOpaqueType("set", types.NewTypeParamType("T")))
 	for _, tst := range tests {
@@ -1047,9 +1047,9 @@ func TestTypeDescAsCELTypeErrors(t *testing.T) {
 			want: errors.New("undefined type"),
 		},
 	}
-	tp, err := types.NewProtoRegistry()
+	tp, err := types.NewRegistry()
 	if err != nil {
-		t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+		t.Fatalf("types.NewRegistry() failed: %v", err)
 	}
 	tp.RegisterType(types.NewOpaqueType("set", types.NewTypeParamType("T")))
 	for _, tst := range tests {

--- a/common/types/BUILD.bazel
+++ b/common/types/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "provider.go",
         "regex.go",
         "string.go",
+        "struct.go",
         "timestamp.go",
         "types.go",
         "uint.go",

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -476,11 +476,24 @@ func (p *Registry) RegisterMessage(message proto.Message) error {
 // to CEL, even when they're not based on protobuf types.
 func (p *Registry) RegisterType(types ...ref.Type) error {
 	for _, t := range types {
-		if st, ok := t.(StructTypeDescriptor); ok {
-			typeName := t.TypeName()
-			if celType, isCelType := t.(*Type); isCelType && celType.Kind() == TypeKind && len(celType.parameters) > 0 {
-				typeName = celType.parameters[0].TypeName()
+		existing, found := p.revTypeMap[t.TypeName()]
+		celType := maybeForeignType(t)
+		if found {
+			if !existing.IsEquivalentType(celType) {
+				return fmt.Errorf("type registration conflict. found: %v, input: %v", existing, celType)
 			}
+			if existing.traitMask != celType.traitMask {
+				return fmt.Errorf(
+					"type registered with conflicting traits: %v with traits %v, input: %v",
+					existing.TypeName(), existing.traitMask, celType.traitMask)
+			}
+			continue
+		}
+
+		typeName := t.TypeName()
+		p.revTypeMap[typeName] = celType
+		if st, ok := t.(StructTypeDescriptor); ok {
+			// Conflicts are gated above so if we see a struct here, it's safe to register.
 			p.structTypes[typeName] = st
 			if rt := st.ReflectType(); rt != nil {
 				p.reflectTypes[rt] = st
@@ -490,20 +503,6 @@ func (p *Registry) RegisterType(types ...ref.Type) error {
 					p.reflectTypes[reflect.PointerTo(rt)] = st
 				}
 			}
-		}
-		celType := maybeForeignType(t)
-		existing, found := p.revTypeMap[t.TypeName()]
-		if !found {
-			p.revTypeMap[t.TypeName()] = celType
-			continue
-		}
-		if !existing.IsEquivalentType(celType) {
-			return fmt.Errorf("type registration conflict. found: %v, input: %v", existing, celType)
-		}
-		if existing.traitMask != celType.traitMask {
-			return fmt.Errorf(
-				"type registered with conflicting traits: %v with traits %v, input: %v",
-				existing.TypeName(), existing.traitMask, celType.traitMask)
 		}
 	}
 	return nil

--- a/common/types/provider.go
+++ b/common/types/provider.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"time"
 
@@ -54,11 +55,11 @@ type Provider interface {
 	// Returns false if not found.
 	FindStructType(structType string) (*Type, bool)
 
-	// FindStructFieldNames returns thet field names associated with the type, if the type
+	// FindStructFieldNames returns the field names associated with the type, if the type
 	// is found.
 	FindStructFieldNames(structType string) ([]string, bool)
 
-	// FieldStructFieldType returns the field type for a checked type value. Returns
+	// FindStructFieldType returns the field type for a checked type value. Returns
 	// false if the field could not be found.
 	FindStructFieldType(structType, fieldName string) (*FieldType, bool)
 
@@ -88,15 +89,27 @@ type FieldType struct {
 
 // Registry provides type information for a set of registered types.
 type Registry struct {
-	revTypeMap map[string]*Type
-	pbdb       *pb.Db
+	revTypeMap   map[string]*Type
+	structTypes  map[string]StructTypeDescriptor
+	reflectTypes map[reflect.Type]StructTypeDescriptor
+	pbdb         *pb.Db
+	provider     Provider
+	adapter      Adapter
 }
 
-// NewRegistry accepts a list of proto message instances and returns a type
-// provider which can create new instances of the provided message or any
-// message that proto depends upon in its FileDescriptor.
-func NewRegistry(types ...proto.Message) (*Registry, error) {
-	return NewProtoRegistry(ProtoTypeDefs(types...))
+// NewRegistry accepts a list of proto message instances, ref.Type instances, or RegistryOption
+// functions and returns a type provider.
+func NewRegistry(types ...any) (*Registry, error) {
+	r, err := NewProtoRegistry()
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range types {
+		if err := registerTypeItem(r, t); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
 }
 
 // RegistryOption configures the behavior of the registry.
@@ -123,12 +136,20 @@ func ProtoTypeDefs(types ...proto.Message) RegistryOption {
 	}
 }
 
+// Types creates a RegistryOption which registers individual custom type references or descriptors with the registry.
+func Types(types ...ref.Type) RegistryOption {
+	return func(r *Registry) (*Registry, error) {
+		err := r.RegisterType(types...)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+}
+
 // NewProtoRegistry creates a proto-based registry with a set of configurable options.
 func NewProtoRegistry(opts ...RegistryOption) (*Registry, error) {
-	r := &Registry{
-		revTypeMap: make(map[string]*Type),
-		pbdb:       pb.NewDb(),
-	}
+	r := NewEmptyRegistry()
 	err := r.RegisterType(
 		BoolType,
 		BytesType,
@@ -164,20 +185,49 @@ func NewProtoRegistry(opts ...RegistryOption) (*Registry, error) {
 // NewEmptyRegistry returns a registry which is completely unconfigured.
 func NewEmptyRegistry() *Registry {
 	return &Registry{
-		revTypeMap: make(map[string]*Type),
-		pbdb:       pb.NewDb(),
+		revTypeMap:   make(map[string]*Type),
+		structTypes:  make(map[string]StructTypeDescriptor),
+		reflectTypes: make(map[reflect.Type]StructTypeDescriptor),
+		pbdb:         pb.NewDb(),
 	}
+}
+
+// ComposeTypes accepts a provider, adapter, and a list of types (ref.Type, proto.Message, protoreflect.FileDescriptor, or RegistryOption)
+// and either:
+//   - Determines the provider and adapter are the same instance and a *Registry and registers the listed types via RegisterType or
+//     one of the other registration methods as appropriate.
+//   - Determines the provider and adapter are not the same, or not a *Registry and creates a new composed *Registry which references
+//     the new type information first and then proxies to the underlying provider and adapter methods as appropriate.
+func ComposeTypes(provider Provider, adapter Adapter, types ...any) (Provider, Adapter, error) {
+	reg, isReg := provider.(*Registry)
+	aReg, isAdapterReg := adapter.(*Registry)
+	if isReg && isAdapterReg && reg == aReg {
+		for _, t := range types {
+			if err := registerTypeItem(reg, t); err != nil {
+				return nil, nil, err
+			}
+		}
+		return reg, reg, nil
+	}
+
+	composedReg, err := NewRegistry(types...)
+	if err != nil {
+		return nil, nil, err
+	}
+	composedReg.provider = provider
+	composedReg.adapter = adapter
+	return composedReg, composedReg, nil
 }
 
 // Copy copies the current state of the registry into its own memory space.
 func (p *Registry) Copy() *Registry {
-	copy := &Registry{
-		revTypeMap: make(map[string]*Type),
-		pbdb:       p.pbdb.Copy(),
-	}
-	for k, v := range p.revTypeMap {
-		copy.revTypeMap[k] = v
-	}
+	copy := NewEmptyRegistry()
+	copy.pbdb = p.pbdb.Copy()
+	copy.provider = p.provider
+	copy.adapter = p.adapter
+	maps.Copy(copy.revTypeMap, p.revTypeMap)
+	maps.Copy(copy.structTypes, p.structTypes)
+	maps.Copy(copy.reflectTypes, p.reflectTypes)
 	return copy
 }
 
@@ -207,6 +257,9 @@ func (p *Registry) WithJSONFieldNames(enabled bool) error {
 func (p *Registry) EnumValue(enumName string) ref.Val {
 	enumVal, found := p.pbdb.DescribeEnum(enumName)
 	if !found {
+		if p.provider != nil {
+			return p.provider.EnumValue(enumName)
+		}
 		return NewErr("unknown enum name '%s'", enumName)
 	}
 	return Int(enumVal.Value())
@@ -217,70 +270,98 @@ func (p *Registry) EnumValue(enumName string) ref.Val {
 //
 // Deprecated: use FindStructFieldType
 func (p *Registry) FindFieldType(structType, fieldName string) (*ref.FieldType, bool) {
-	msgType, found := p.pbdb.DescribeType(structType)
-	if !found {
-		return nil, false
+	structType = sanitizeStructTypeName(structType)
+	if st, found := p.structTypes[structType]; found {
+		if ft, found := st.FindFieldType(fieldName); found {
+			exprType, err := TypeToExprType(ft.Type)
+			if err != nil {
+				return nil, false
+			}
+			return makeRefFieldType(exprType, ft.IsSet, ft.GetFrom, ft.IsJSONField), true
+		}
 	}
-	field, found := msgType.FieldByName(fieldName)
-	if !found {
-		return nil, false
+	if msgType, found := p.pbdb.DescribeType(structType); found {
+		if field, found := msgType.FieldByName(fieldName); found {
+			return makeRefFieldType(field.CheckedType(), field.IsSet, field.GetFrom, p.pbdb.JSONFieldNames() && fieldName == field.JSONName()), true
+		}
 	}
-	return &ref.FieldType{
-		Type:        field.CheckedType(),
-		IsSet:       field.IsSet,
-		GetFrom:     field.GetFrom,
-		IsJSONField: p.pbdb.JSONFieldNames() && fieldName == field.JSONName(),
-	}, true
+	if p.provider != nil {
+		if ft, ok := p.provider.FindStructFieldType(structType, fieldName); ok && ft != nil {
+			exprType, err := TypeToExprType(ft.Type)
+			if err != nil {
+				return nil, false
+			}
+			return makeRefFieldType(exprType, ft.IsSet, ft.GetFrom, ft.IsJSONField), true
+		}
+	}
+	return nil, false
 }
 
 // FindStructFieldNames returns the set of field names for the given struct type,
 // if the type exists in the registry.
 func (p *Registry) FindStructFieldNames(structType string) ([]string, bool) {
-	msgType, found := p.pbdb.DescribeType(structType)
-	if !found {
-		return []string{}, false
+	structType = sanitizeStructTypeName(structType)
+	if st, found := p.structTypes[structType]; found {
+		return st.FieldNames(), true
 	}
-	fieldMap := msgType.FieldMap()
-	fields := make([]string, len(fieldMap))
-	idx := 0
-	for f := range fieldMap {
-		fields[idx] = f
-		idx++
+	if msgType, found := p.pbdb.DescribeType(structType); found {
+		fieldMap := msgType.FieldMap()
+		fields := make([]string, len(fieldMap))
+		idx := 0
+		for f := range fieldMap {
+			fields[idx] = f
+			idx++
+		}
+		return fields, true
 	}
-	return fields, true
+	if p.provider != nil {
+		return p.provider.FindStructFieldNames(structType)
+	}
+	return []string{}, false
 }
 
 // FindStructFieldType returns the field type for a checked type value. Returns
 // false if the field could not be found.
 func (p *Registry) FindStructFieldType(structType, fieldName string) (*FieldType, bool) {
-	msgType, found := p.pbdb.DescribeType(structType)
-	if !found {
-		return nil, false
+	structType = sanitizeStructTypeName(structType)
+	if st, found := p.structTypes[structType]; found {
+		if ft, found := st.FindFieldType(fieldName); found {
+			return ft, true
+		}
 	}
-	field, found := msgType.FieldByName(fieldName)
-	if !found {
-		return nil, false
+	if msgType, found := p.pbdb.DescribeType(structType); found {
+		if field, found := msgType.FieldByName(fieldName); found {
+			return &FieldType{
+				Type:        fieldDescToCELType(field),
+				IsSet:       field.IsSet,
+				GetFrom:     field.GetFrom,
+				IsJSONField: p.pbdb.JSONFieldNames() && fieldName == field.JSONName(),
+			}, true
+		}
 	}
-	return &FieldType{
-		Type:        fieldDescToCELType(field),
-		IsSet:       field.IsSet,
-		GetFrom:     field.GetFrom,
-		IsJSONField: p.pbdb.JSONFieldNames() && fieldName == field.JSONName(),
-	}, true
+	if p.provider != nil {
+		return p.provider.FindStructFieldType(structType, fieldName)
+	}
+	return nil, false
 }
 
 // FindStructFieldDescription returns documentation for a field if available.
 // Returns false if the field could not be found.
 func (p *Registry) FindStructFieldDescription(structType, fieldName string) (string, bool) {
-	msgType, found := p.pbdb.DescribeType(structType)
-	if !found {
-		return "", false
+	structType = sanitizeStructTypeName(structType)
+	if msgType, found := p.pbdb.DescribeType(structType); found {
+		if field, found := msgType.FieldByName(fieldName); found {
+			return field.Documentation(), true
+		}
 	}
-	field, found := msgType.FieldByName(fieldName)
-	if !found {
-		return "", false
+	if p.provider != nil {
+		if pd, ok := p.provider.(interface {
+			FindStructFieldDescription(string, string) (string, bool)
+		}); ok {
+			return pd.FindStructFieldDescription(structType, fieldName)
+		}
 	}
-	return field.Documentation(), true
+	return "", false
 }
 
 // FindIdent takes a qualified identifier name and returns a ref.Val if one exists.
@@ -291,6 +372,9 @@ func (p *Registry) FindIdent(identName string) (ref.Val, bool) {
 	if enumVal, found := p.pbdb.DescribeEnum(identName); found {
 		return Int(enumVal.Value()), true
 	}
+	if p.provider != nil {
+		return p.provider.FindIdent(identName)
+	}
 	return nil, false
 }
 
@@ -298,17 +382,19 @@ func (p *Registry) FindIdent(identName string) (ref.Val, bool) {
 //
 // Deprecated: use FindStructType
 func (p *Registry) FindType(structType string) (*exprpb.Type, bool) {
-	if _, found := p.pbdb.DescribeType(structType); !found {
-		return nil, false
+	structType = sanitizeStructTypeName(structType)
+	if p.hasStructType(structType) {
+		return makeExprMessageType(structType), true
 	}
-	if structType != "" && structType[0] == '.' {
-		structType = structType[1:]
+	if p.provider != nil {
+		if tp, ok := p.provider.(ref.TypeProvider); ok {
+			return tp.FindType(structType)
+		}
+		if _, ok := p.provider.FindStructType(structType); ok {
+			return makeExprMessageType(structType), true
+		}
 	}
-	return &exprpb.Type{
-		TypeKind: &exprpb.Type_Type{
-			Type: &exprpb.Type{
-				TypeKind: &exprpb.Type_MessageType{
-					MessageType: structType}}}}, true
+	return nil, false
 }
 
 // FindStructType returns the Type give a qualified type name.
@@ -319,13 +405,14 @@ func (p *Registry) FindType(structType string) (*exprpb.Type, bool) {
 //
 // Returns false if not found.
 func (p *Registry) FindStructType(structType string) (*Type, bool) {
-	if _, found := p.pbdb.DescribeType(structType); !found {
-		return nil, false
+	structType = sanitizeStructTypeName(structType)
+	if p.hasStructType(structType) {
+		return NewTypeTypeWithParam(NewObjectType(structType)), true
 	}
-	if structType != "" && structType[0] == '.' {
-		structType = structType[1:]
+	if p.provider != nil {
+		return p.provider.FindStructType(structType)
 	}
-	return NewTypeTypeWithParam(NewObjectType(structType)), true
+	return nil, false
 }
 
 // NewValue creates a new type value from a qualified name and map of field
@@ -335,8 +422,15 @@ func (p *Registry) FindStructType(structType string) (*Type, bool) {
 // to convert the Val to the field's native type. If an error occurs during
 // conversion, the NewValue will be a types.Err.
 func (p *Registry) NewValue(structType string, fields map[string]ref.Val) ref.Val {
+	structType = sanitizeStructTypeName(structType)
+	if st, found := p.structTypes[structType]; found {
+		return st.NewValue(p, fields)
+	}
 	td, found := p.pbdb.DescribeType(structType)
 	if !found {
+		if p.provider != nil {
+			return p.provider.NewValue(structType, fields)
+		}
 		return NewErr("unknown type '%s'", structType)
 	}
 	msg := td.New()
@@ -382,6 +476,21 @@ func (p *Registry) RegisterMessage(message proto.Message) error {
 // to CEL, even when they're not based on protobuf types.
 func (p *Registry) RegisterType(types ...ref.Type) error {
 	for _, t := range types {
+		if st, ok := t.(StructTypeDescriptor); ok {
+			typeName := t.TypeName()
+			if celType, isCelType := t.(*Type); isCelType && celType.Kind() == TypeKind && len(celType.parameters) > 0 {
+				typeName = celType.parameters[0].TypeName()
+			}
+			p.structTypes[typeName] = st
+			if rt := st.ReflectType(); rt != nil {
+				p.reflectTypes[rt] = st
+				if rt.Kind() == reflect.Ptr {
+					p.reflectTypes[rt.Elem()] = st
+				} else {
+					p.reflectTypes[reflect.PointerTo(rt)] = st
+				}
+			}
+		}
 		celType := maybeForeignType(t)
 		existing, found := p.revTypeMap[t.TypeName()]
 		if !found {
@@ -400,6 +509,25 @@ func (p *Registry) RegisterType(types ...ref.Type) error {
 	return nil
 }
 
+func (p *Registry) findStructDescriptorByReflectType(rt reflect.Type) (StructTypeDescriptor, bool) {
+	if rt == nil {
+		return nil, false
+	}
+	if st, found := p.reflectTypes[rt]; found {
+		return st, true
+	}
+	if rt.Kind() == reflect.Ptr {
+		if st, found := p.reflectTypes[rt.Elem()]; found {
+			return st, true
+		}
+	} else {
+		if st, found := p.reflectTypes[reflect.PointerTo(rt)]; found {
+			return st, true
+		}
+	}
+	return nil, false
+}
+
 // NativeToValue converts various "native" types to ref.Val with this specific implementation
 // providing support for custom proto-based types.
 //
@@ -413,6 +541,9 @@ func (p *Registry) NativeToValue(value any) ref.Val {
 		typeName := string(v.ProtoReflect().Descriptor().FullName())
 		td, found := p.pbdb.DescribeType(typeName)
 		if !found {
+			if p.adapter != nil {
+				return p.adapter.NativeToValue(value)
+			}
 			return NewErr("unknown type: '%s'", typeName)
 		}
 		unwrapped, isUnwrapped, err := td.MaybeUnwrap(v)
@@ -435,6 +566,19 @@ func (p *Registry) NativeToValue(value any) ref.Val {
 		return p.NativeToValue(v.Interface())
 	case protoreflect.Value:
 		return p.NativeToValue(v.Interface())
+	default:
+		if len(p.reflectTypes) > 0 && value != nil {
+			if st, found := p.findStructDescriptorByReflectType(reflect.TypeOf(value)); found {
+				val := reflect.ValueOf(value)
+				if val.Kind() == reflect.Ptr && val.IsNil() {
+					return NullValue
+				}
+				return st.Adapt(p, value)
+			}
+		}
+	}
+	if p.adapter != nil {
+		return p.adapter.NativeToValue(value)
 	}
 	return UnsupportedRefValConversionErr(value)
 }
@@ -452,6 +596,58 @@ func (p *Registry) registerAllTypes(fd *pb.FileDescription) error {
 		}
 	}
 	return nil
+}
+
+func (p *Registry) hasStructType(structType string) bool {
+	if _, found := p.structTypes[structType]; found {
+		return true
+	}
+	_, found := p.pbdb.DescribeType(structType)
+	return found
+}
+
+func sanitizeStructTypeName(structType string) string {
+	if len(structType) > 0 && structType[0] == '.' {
+		return structType[1:]
+	}
+	return structType
+}
+
+func registerTypeItem(r *Registry, t any) error {
+	switch v := t.(type) {
+	case proto.Message:
+		return r.RegisterMessage(v)
+	case protoreflect.FileDescriptor:
+		return r.RegisterDescriptor(v)
+	case ref.Type:
+		return r.RegisterType(v)
+	case RegistryOption:
+		_, err := v(r)
+		return err
+	default:
+		return fmt.Errorf("unsupported type: %T", t)
+	}
+}
+
+func makeExprMessageType(structType string) *exprpb.Type {
+	return &exprpb.Type{
+		TypeKind: &exprpb.Type_Type{
+			Type: &exprpb.Type{
+				TypeKind: &exprpb.Type_MessageType{
+					MessageType: structType,
+				},
+			},
+		},
+	}
+}
+
+func makeRefFieldType(t *exprpb.Type, isSet ref.FieldTester, getFrom ref.FieldGetter, isJSONField bool) *ref.FieldType {
+	return &ref.FieldType{
+		Type:        t,
+		IsSet:       isSet,
+		GetFrom:     getFrom,
+		IsJSONField: isJSONField,
+	}
 }
 
 func fieldDescToCELType(field *pb.FieldDescription) *Type {
@@ -522,6 +718,8 @@ func nativeToValue(a Adapter, value any) (ref.Val, bool) {
 		if v != nil {
 			return *v, true
 		}
+	case ref.Val:
+		return v, true
 	case bool:
 		return Bool(v), true
 	case int:
@@ -620,8 +818,6 @@ func nativeToValue(a Adapter, value any) (ref.Val, bool) {
 		return NewJSONList(a, v), true
 	case *structpb.Struct:
 		return NewJSONStruct(a, v), true
-	case ref.Val:
-		return v, true
 	case protoreflect.EnumNumber:
 		return Int(v), true
 	case proto.Message:
@@ -649,7 +845,7 @@ func nativeToValue(a Adapter, value any) (ref.Val, bool) {
 		refValue := reflect.ValueOf(v)
 		if refValue.Kind() == reflect.Ptr {
 			if refValue.IsNil() {
-				return UnsupportedRefValConversionErr(v), true
+				return nil, false
 			}
 			refValue = refValue.Elem()
 		}

--- a/common/types/provider_test.go
+++ b/common/types/provider_test.go
@@ -1082,6 +1082,9 @@ func TestRegistryStructTypeDescriptor_FindStructType(t *testing.T) {
 			if st.TypeName() != tc.wantType {
 				t.Errorf("FindStructType(%q).TypeName() = %s, want %s", tc.name, st.TypeName(), tc.wantType)
 			}
+			if st.Parameters()[0].TypeName() != "custom.MyStruct" {
+				t.Errorf("FindStructType(%q) TypeName() = %s, want 'custom.MyStruct'", tc.name, st.Parameters()[0].TypeName())
+			}
 		})
 	}
 }

--- a/common/types/provider_test.go
+++ b/common/types/provider_test.go
@@ -37,48 +37,72 @@ import (
 )
 
 func TestRegistryCopy(t *testing.T) {
-	reg := NewEmptyRegistry()
-	reg2 := reg.Copy()
-	if !reflect.DeepEqual(reg, reg2) {
-		t.Fatal("type registry copy did not produce equivalent values.")
+	tests := []struct {
+		name string
+		reg  *Registry
+	}{
+		{
+			name: "empty",
+			reg:  NewEmptyRegistry(),
+		},
+		{
+			name: "populated",
+			reg:  newTestRegistry(t),
+		},
 	}
-	reg = newTestRegistry(t)
-	reg2 = reg.Copy()
-	if !reflect.DeepEqual(reg, reg2) {
-		t.Fatal("type registry copy did not produce equivalent values.")
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			reg2 := tc.reg.Copy()
+			if !reflect.DeepEqual(tc.reg, reg2) {
+				t.Fatal("type registry copy did not produce equivalent values.")
+			}
+		})
 	}
 }
 
 func TestRegistryRegisterType(t *testing.T) {
-	reg := newTestRegistry(t)
-	err := reg.RegisterType(
-		NewTypeValue("http.Request", traits.ReceiverType),
-		NewObjectType("http.Request", traits.ReceiverType),
-	)
-	if err == nil {
-		t.Error("RegisterType() for differing type definitions with the same name did not fail")
+	tests := []struct {
+		name    string
+		types   []ref.Type
+		wantErr bool
+	}{
+		{
+			name: "differing type definitions same name",
+			types: []ref.Type{
+				NewTypeValue("http.Request", traits.ReceiverType),
+				NewObjectType("http.Request", traits.ReceiverType),
+			},
+			wantErr: true,
+		},
+		{
+			name: "equivalent opaque types no conflict",
+			types: []ref.Type{
+				NewOpaqueType("http.Request", NewTypeParamType("T")),
+				NewOpaqueType("http.Request", NewTypeParamType("V")),
+			},
+			wantErr: false,
+		},
+		{
+			name: "differing opaque types conflict",
+			types: []ref.Type{
+				NewOpaqueType("http.Request", NewTypeParamType("T"), NewTypeParamType("V")),
+				NewOpaqueType("http.Request", NewTypeParamType("V")),
+			},
+			wantErr: true,
+		},
 	}
-}
 
-func TestRegistryRegisterTypeNoConflict(t *testing.T) {
-	reg := newTestRegistry(t)
-	err := reg.RegisterType(
-		NewOpaqueType("http.Request", NewTypeParamType("T")),
-		NewOpaqueType("http.Request", NewTypeParamType("V")),
-	)
-	if err != nil {
-		t.Errorf("RegisterType() failed for equivalent types: %v", err)
-	}
-}
-
-func TestRegistryRegisterTypeConflict(t *testing.T) {
-	reg := newTestRegistry(t)
-	err := reg.RegisterType(
-		NewOpaqueType("http.Request", NewTypeParamType("T"), NewTypeParamType("V")),
-		NewOpaqueType("http.Request", NewTypeParamType("V")),
-	)
-	if err == nil {
-		t.Error("RegisterType() for differing type definitions with the same name did not fail")
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			reg := newTestRegistry(t)
+			err := reg.RegisterType(tc.types...)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("RegisterType() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
 	}
 }
 
@@ -88,17 +112,24 @@ func TestRegistryEnumValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RegisterDescriptor() failed: %v", err)
 	}
-	enumVal := reg.EnumValue("google.expr.proto3.test.GlobalEnum.GOO")
-	if Int(proto3pb.GlobalEnum_GOO.Number()) != enumVal.(Int) {
-		t.Errorf("enum values were not equal between registry and proto: %v", enumVal)
-	}
-	enumVal2, found := reg.FindIdent("google.expr.proto3.test.GlobalEnum.GOO")
-	if !found {
-		t.Fatal("Ident not found google.expr.proto3.test.GlobalEnum.GOO")
-	}
-	if enumVal.(Int) != enumVal2.(Int) {
-		t.Errorf("got enum value %v, wanted %v", enumVal2, enumVal)
-	}
+
+	t.Run("EnumValue", func(t *testing.T) {
+		enumVal := reg.EnumValue("google.expr.proto3.test.GlobalEnum.GOO")
+		if IsError(enumVal) || Int(proto3pb.GlobalEnum_GOO.Number()) != enumVal.(Int) {
+			t.Errorf("enum values were not equal between registry and proto: %v", enumVal)
+		}
+	})
+
+	t.Run("FindIdent", func(t *testing.T) {
+		enumVal := reg.EnumValue("google.expr.proto3.test.GlobalEnum.GOO")
+		enumVal2, found := reg.FindIdent("google.expr.proto3.test.GlobalEnum.GOO")
+		if !found {
+			t.Fatal("Ident not found google.expr.proto3.test.GlobalEnum.GOO")
+		}
+		if enumVal.(Int) != enumVal2.(Int) {
+			t.Errorf("got enum value %v, wanted %v", enumVal2, enumVal)
+		}
+	})
 }
 
 func TestRegistryFindStructType(t *testing.T) {
@@ -107,60 +138,80 @@ func TestRegistryFindStructType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RegisterDescriptor() failed: %v", err)
 	}
-	msgTypeName := ".google.expr.proto3.test.TestAllTypes"
-	exprType, found := reg.FindType(msgTypeName)
-	if !found {
-		t.Fatalf("FindType() did not find: %q", msgTypeName)
+
+	tests := []struct {
+		typeName  string
+		wantFound bool
+	}{
+		{
+			typeName:  ".google.expr.proto3.test.TestAllTypes",
+			wantFound: true,
+		},
+		{
+			typeName:  ".google.expr.proto3.test.TestAllTypesUndefined",
+			wantFound: false,
+		},
 	}
-	celType, found := reg.FindStructType(msgTypeName)
-	if !found {
-		t.Fatalf("FindStructType() did not find %q", msgTypeName)
-	}
-	exprConvType, err := ExprTypeToType(exprType)
-	if err != nil {
-		t.Fatalf("ExprTypeToType(%v) failed: %v", exprType, err)
-	}
-	if !exprConvType.IsExactType(celType) {
-		t.Errorf("Got %v type, wanted %v", exprConvType, celType)
-	}
-	_, found = reg.FindType(msgTypeName + "Undefined")
-	if found {
-		t.Fatalf("FindType() found: %q", msgTypeName+"Undefined")
-	}
-	_, found = reg.FindStructType(msgTypeName + "Undefined")
-	if found {
-		t.Fatalf("FindStructType() found: %q", msgTypeName+"Undefined")
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.typeName, func(t *testing.T) {
+			exprType, foundType := reg.FindType(tc.typeName)
+			celType, foundStruct := reg.FindStructType(tc.typeName)
+
+			if foundType != tc.wantFound {
+				t.Errorf("FindType(%q) found = %v, want %v", tc.typeName, foundType, tc.wantFound)
+			}
+			if foundStruct != tc.wantFound {
+				t.Errorf("FindStructType(%q) found = %v, want %v", tc.typeName, foundStruct, tc.wantFound)
+			}
+
+			if tc.wantFound {
+				exprConvType, err := ExprTypeToType(exprType)
+				if err != nil {
+					t.Fatalf("ExprTypeToType(%v) failed: %v", exprType, err)
+				}
+				if !exprConvType.IsExactType(celType) {
+					t.Errorf("Got %v type, wanted %v", exprConvType, celType)
+				}
+			}
+		})
 	}
 }
 
 func TestRegistryFindStructFieldNames(t *testing.T) {
 	tests := []struct {
+		name           string
 		typeName       string
 		fields         []string
 		jsonFieldNames bool
 	}{
 		{
+			name:     "Reference",
 			typeName: "google.api.expr.v1alpha1.Reference",
 			fields:   []string{"name", "overload_id", "value"},
 		},
 		{
+			name:     "Decl",
 			typeName: "google.api.expr.v1alpha1.Decl",
 			fields:   []string{"name", "ident", "function"},
 		},
 		{
+			name:     "invalid type",
 			typeName: "invalid.TypeName",
 			fields:   []string{},
 		},
 		{
+			name:           "Reference JSON field names",
 			typeName:       "google.api.expr.v1alpha1.Reference",
 			fields:         []string{"name", "overloadId", "value"},
 			jsonFieldNames: true,
 		},
 	}
 
-	for _, tst := range tests {
-		tc := tst
-		t.Run(fmt.Sprintf("%s", tc.typeName), func(t *testing.T) {
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
 			reg := newTestRegistry(t,
 				ProtoTypeDefs(&exprpb.Decl{}, &exprpb.Reference{}),
 				JSONFieldNames(tc.jsonFieldNames))
@@ -185,11 +236,6 @@ func TestRegistryFindStructFieldType(t *testing.T) {
 		{
 			typeName: msgTypeName,
 			field:    "single_bool",
-			found:    true,
-		},
-		{
-			typeName: msgTypeName,
-			field:    "single_nested_message",
 			found:    true,
 		},
 		{
@@ -505,116 +551,145 @@ func TestRegistryNewValueErrors(t *testing.T) {
 
 func TestRegistryGetters(t *testing.T) {
 	reg := newTestRegistry(t, ProtoTypeDefs(&exprpb.ParsedExpr{}))
-	if sourceInfo := reg.NewValue(
+	sourceInfo := reg.NewValue(
 		"google.api.expr.v1alpha1.SourceInfo",
 		map[string]ref.Val{
 			"location":     String("TestTypeRegistryGetFieldValue"),
 			"line_offsets": NewDynamicList(reg, []int64{0, 2}),
 			"positions":    NewDynamicMap(reg, map[int64]int64{1: 2, 2: 4}),
-		}); IsError(sourceInfo) {
-		t.Error(sourceInfo)
-	} else {
-		si := sourceInfo.(traits.Indexer)
-		if loc := si.Get(String("location")); IsError(loc) {
-			t.Error(loc)
-		} else if loc.(String) != "TestTypeRegistryGetFieldValue" {
+		})
+	if IsError(sourceInfo) {
+		t.Fatalf("NewValue(SourceInfo) failed: %v", sourceInfo)
+	}
+
+	si := sourceInfo.(traits.Indexer)
+
+	t.Run("location", func(t *testing.T) {
+		loc := si.Get(String("location"))
+		if IsError(loc) {
+			t.Fatal(loc)
+		}
+		if loc.(String) != "TestTypeRegistryGetFieldValue" {
 			t.Errorf("Expected %s, got %s", "TestTypeRegistryGetFieldValue", loc)
 		}
-		if pos := si.Get(String("positions")); IsError(pos) {
-			t.Error(pos)
-		} else if pos.Equal(NewDynamicMap(reg, map[int64]int32{1: 2, 2: 4})) != True {
+	})
+
+	t.Run("positions", func(t *testing.T) {
+		pos := si.Get(String("positions"))
+		if IsError(pos) {
+			t.Fatal(pos)
+		}
+		if pos.Equal(NewDynamicMap(reg, map[int64]int32{1: 2, 2: 4})) != True {
 			t.Errorf("Expected map[int64]int32, got %v", pos)
-		} else if posKeyVal := pos.(traits.Indexer).Get(Int(1)); IsError(posKeyVal) {
-			t.Error(posKeyVal)
-		} else if posKeyVal.(Int) != 2 {
+		}
+		posKeyVal := pos.(traits.Indexer).Get(Int(1))
+		if IsError(posKeyVal) {
+			t.Fatal(posKeyVal)
+		}
+		if posKeyVal.(Int) != 2 {
 			t.Error("Expected value to be int64, not int32")
 		}
-		if offsets := si.Get(String("line_offsets")); IsError(offsets) {
-			t.Error(offsets)
-		} else if offset1 := offsets.(traits.Lister).Get(Int(1)); IsError(offset1) {
-			t.Error(offset1)
-		} else if offset1.(Int) != 2 {
+	})
+
+	t.Run("line_offsets", func(t *testing.T) {
+		offsets := si.Get(String("line_offsets"))
+		if IsError(offsets) {
+			t.Fatal(offsets)
+		}
+		offset1 := offsets.(traits.Lister).Get(Int(1))
+		if IsError(offset1) {
+			t.Fatal(offset1)
+		}
+		if offset1.(Int) != 2 {
 			t.Errorf("Expected index 1 to be value 2, was %v", offset1)
 		}
-	}
+	})
 }
 
 func TestConvertToNative(t *testing.T) {
 	reg := newTestRegistry(t, ProtoTypeDefs(&exprpb.ParsedExpr{}))
-
-	// Core type conversion tests.
-	expectValueToNative(t, True, true)
-	expectValueToNative(t, True, True)
-	expectValueToNative(t, NewDynamicList(reg, []Bool{True, False}), []any{true, false})
-	expectValueToNative(t, NewDynamicList(reg, []Bool{True, False}), []ref.Val{True, False})
-	expectValueToNative(t, Int(-1), int32(-1))
-	expectValueToNative(t, Int(2), int64(2))
-	expectValueToNative(t, Int(-1), Int(-1))
-	expectValueToNative(t, NewDynamicList(reg, []Int{4}), []any{int64(4)})
-	expectValueToNative(t, NewDynamicList(reg, []Int{5}), []ref.Val{Int(5)})
-	expectValueToNative(t, Uint(3), uint32(3))
-	expectValueToNative(t, Uint(4), uint64(4))
-	expectValueToNative(t, Uint(5), Uint(5))
-	expectValueToNative(t, NewDynamicList(reg, []Uint{4}), []any{uint64(4)})
-	expectValueToNative(t, NewDynamicList(reg, []Uint{5}), []ref.Val{Uint(5)})
-	expectValueToNative(t, Double(5.5), float32(5.5))
-	expectValueToNative(t, Double(-5.5), float64(-5.5))
-	expectValueToNative(t, NewDynamicList(reg, []Double{-5.5}), []any{-5.5})
-	expectValueToNative(t, NewDynamicList(reg, []Double{-5.5}), []ref.Val{Double(-5.5)})
-	expectValueToNative(t, Double(-5.5), Double(-5.5))
-	expectValueToNative(t, String("hello"), "hello")
-	expectValueToNative(t, String("hello"), String("hello"))
-	expectValueToNative(t, NullValue, structpb.NullValue_NULL_VALUE)
-	expectValueToNative(t, NullValue, NullValue)
-	expectValueToNative(t, NewDynamicList(reg, []Null{NullValue}), []any{structpb.NullValue_NULL_VALUE})
-	expectValueToNative(t, NewDynamicList(reg, []Null{NullValue}), []ref.Val{NullValue})
-	expectValueToNative(t, Bytes("world"), []byte("world"))
-	expectValueToNative(t, Bytes("world"), Bytes("world"))
-	expectValueToNative(t, NewDynamicList(reg, []Bytes{Bytes("hello")}), []any{[]byte("hello")})
-	expectValueToNative(t, NewDynamicList(reg, []Bytes{Bytes("hello")}), []ref.Val{Bytes("hello")})
-	expectValueToNative(t, NewDynamicList(reg, []int64{1, 2, 3}), []int32{1, 2, 3})
-	expectValueToNative(t, Duration{Duration: time.Duration(500)}, time.Duration(500))
-	expectValueToNative(t, Duration{Duration: time.Duration(500)}, Duration{Duration: time.Duration(500)})
-	expectValueToNative(t, Timestamp{Time: time.Unix(12345, 0)}, time.Unix(12345, 0))
-	expectValueToNative(t, Timestamp{Time: time.Unix(12345, 0)}, Timestamp{Time: time.Unix(12345, 0)})
-	expectValueToNative(t, NewDynamicMap(reg,
-		map[int64]int64{1: 1, 2: 1, 3: 1}),
-		map[int32]int32{1: 1, 2: 1, 3: 1})
-
-	// Null conversion tests.
-	expectValueToNative(t, Null(structpb.NullValue_NULL_VALUE), structpb.NullValue_NULL_VALUE)
-
-	// Proto conversion tests.
 	parsedExpr := &exprpb.ParsedExpr{}
-	expectValueToNative(t, reg.NativeToValue(parsedExpr), parsedExpr)
 
-	// Custom scalars
-	expectValueToNative(t, Int(1), testInt(1))
-	expectValueToNative(t, Int(1), testInt8(1))
-	expectValueToNative(t, Int(1), testInt16(1))
-	expectValueToNative(t, Int(1), testInt32(1))
-	expectValueToNative(t, Int(1), testInt64(1))
-	expectValueToNative(t, Uint(1), testUint(1))
-	expectValueToNative(t, Uint(1), testUint8(1))
-	expectValueToNative(t, Uint(1), testUint16(1))
-	expectValueToNative(t, Uint(1), testUint32(1))
-	expectValueToNative(t, Uint(1), testUint64(1))
-	expectValueToNative(t, Double(4.5), testFloat32(4.5))
-	expectValueToNative(t, Double(-5.1), testFloat64(-5.1))
-	expectValueToNative(t, String("foo"), testString("foo"))
+	tests := []struct {
+		name string
+		in   ref.Val
+		want any
+	}{
+		// Core type conversion tests.
+		{name: "bool to bool", in: True, want: true},
+		{name: "bool to ref.Val Bool", in: True, want: True},
+		{name: "bool list to []any", in: NewDynamicList(reg, []Bool{True, False}), want: []any{true, false}},
+		{name: "bool list to []ref.Val", in: NewDynamicList(reg, []Bool{True, False}), want: []ref.Val{True, False}},
+		{name: "int to int32", in: Int(-1), want: int32(-1)},
+		{name: "int to int64", in: Int(2), want: int64(2)},
+		{name: "int to ref.Val Int", in: Int(-1), want: Int(-1)},
+		{name: "int list to []any", in: NewDynamicList(reg, []Int{4}), want: []any{int64(4)}},
+		{name: "int list to []ref.Val", in: NewDynamicList(reg, []Int{5}), want: []ref.Val{Int(5)}},
+		{name: "uint to uint32", in: Uint(3), want: uint32(3)},
+		{name: "uint to uint64", in: Uint(4), want: uint64(4)},
+		{name: "uint to ref.Val Uint", in: Uint(5), want: Uint(5)},
+		{name: "uint list to []any", in: NewDynamicList(reg, []Uint{4}), want: []any{uint64(4)}},
+		{name: "uint list to []ref.Val", in: NewDynamicList(reg, []Uint{5}), want: []ref.Val{Uint(5)}},
+		{name: "double to float32", in: Double(5.5), want: float32(5.5)},
+		{name: "double to float64", in: Double(-5.5), want: float64(-5.5)},
+		{name: "double list to []any", in: NewDynamicList(reg, []Double{-5.5}), want: []any{-5.5}},
+		{name: "double list to []ref.Val", in: NewDynamicList(reg, []Double{-5.5}), want: []ref.Val{Double(-5.5)}},
+		{name: "double to ref.Val Double", in: Double(-5.5), want: Double(-5.5)},
+		{name: "string to string", in: String("hello"), want: "hello"},
+		{name: "string to ref.Val String", in: String("hello"), want: String("hello")},
+		{name: "null to structpb.NullValue", in: NullValue, want: structpb.NullValue_NULL_VALUE},
+		{name: "null to ref.Val NullValue", in: NullValue, want: NullValue},
+		{name: "null list to []any", in: NewDynamicList(reg, []Null{NullValue}), want: []any{structpb.NullValue_NULL_VALUE}},
+		{name: "null list to []ref.Val", in: NewDynamicList(reg, []Null{NullValue}), want: []ref.Val{NullValue}},
+		{name: "bytes to []byte", in: Bytes("world"), want: []byte("world")},
+		{name: "bytes to ref.Val Bytes", in: Bytes("world"), want: Bytes("world")},
+		{name: "bytes list to []any", in: NewDynamicList(reg, []Bytes{Bytes("hello")}), want: []any{[]byte("hello")}},
+		{name: "bytes list to []ref.Val", in: NewDynamicList(reg, []Bytes{Bytes("hello")}), want: []ref.Val{Bytes("hello")}},
+		{name: "int64 list to []int32", in: NewDynamicList(reg, []int64{1, 2, 3}), want: []int32{1, 2, 3}},
+		{name: "duration to time.Duration", in: Duration{Duration: time.Duration(500)}, want: time.Duration(500)},
+		{name: "duration to ref.Val Duration", in: Duration{Duration: time.Duration(500)}, want: Duration{Duration: time.Duration(500)}},
+		{name: "timestamp to time.Time", in: Timestamp{Time: time.Unix(12345, 0)}, want: time.Unix(12345, 0)},
+		{name: "timestamp to ref.Val Timestamp", in: Timestamp{Time: time.Unix(12345, 0)}, want: Timestamp{Time: time.Unix(12345, 0)}},
+		{name: "map[int64]int64 to map[int32]int32", in: NewDynamicMap(reg, map[int64]int64{1: 1, 2: 1, 3: 1}), want: map[int32]int32{1: 1, 2: 1, 3: 1}},
+
+		// Null conversion tests.
+		{name: "Null(NULL_VALUE) to structpb.NullValue", in: Null(structpb.NullValue_NULL_VALUE), want: structpb.NullValue_NULL_VALUE},
+
+		// Proto conversion tests.
+		{name: "parsedExpr proto to proto message", in: reg.NativeToValue(parsedExpr), want: parsedExpr},
+
+		// Custom scalars
+		{name: "int to testInt", in: Int(1), want: testInt(1)},
+		{name: "int to testInt8", in: Int(1), want: testInt8(1)},
+		{name: "int to testInt16", in: Int(1), want: testInt16(1)},
+		{name: "int to testInt32", in: Int(1), want: testInt32(1)},
+		{name: "int to testInt64", in: Int(1), want: testInt64(1)},
+		{name: "uint to testUint", in: Uint(1), want: testUint(1)},
+		{name: "uint to testUint8", in: Uint(1), want: testUint8(1)},
+		{name: "uint to testUint16", in: Uint(1), want: testUint16(1)},
+		{name: "uint to testUint32", in: Uint(1), want: testUint32(1)},
+		{name: "uint to testUint64", in: Uint(1), want: testUint64(1)},
+		{name: "double to testFloat32", in: Double(4.5), want: testFloat32(4.5)},
+		{name: "double to testFloat64", in: Double(-5.1), want: testFloat64(-5.1)},
+		{name: "string to testString", in: String("foo"), want: testString("foo")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expectValueToNative(t, tc.in, tc.want)
+		})
+	}
 }
 
 func TestNativeToValue_Any(t *testing.T) {
 	reg := newTestRegistry(t, ProtoTypeDefs(&exprpb.ParsedExpr{}))
-	// NullValue
-	anyValue, err := NullValue.ConvertToNative(anyValueType)
-	if err != nil {
-		t.Error(err)
-	}
-	expectNativeToValue(t, anyValue, NullValue)
 
-	// Json Struct
-	anyValue, err = anypb.New(
+	nullAny, err := NullValue.ConvertToNative(anyValueType)
+	if err != nil {
+		t.Fatalf("NullValue.ConvertToNative() failed: %v", err)
+	}
+
+	jsonStructAny, err := anypb.New(
 		structpb.NewStructValue(
 			&structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -625,18 +700,10 @@ func TestNativeToValue_Any(t *testing.T) {
 		),
 	)
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("anypb.New(NewStructValue) failed: %v", err)
 	}
-	expected := NewJSONStruct(reg, &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"a": structpb.NewStringValue("world"),
-			"b": structpb.NewStringValue("five!"),
-		},
-	})
-	expectNativeToValue(t, anyValue, expected)
 
-	//Json List
-	anyValue, err = anypb.New(structpb.NewListValue(
+	jsonListAny, err := anypb.New(structpb.NewListValue(
 		&structpb.ListValue{
 			Values: []*structpb.Value{
 				structpb.NewStringValue("world"),
@@ -645,183 +712,266 @@ func TestNativeToValue_Any(t *testing.T) {
 		},
 	))
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("anypb.New(NewListValue) failed: %v", err)
 	}
-	expectedList := NewJSONList(reg, &structpb.ListValue{
-		Values: []*structpb.Value{
-			structpb.NewStringValue("world"),
-			structpb.NewStringValue("five!"),
-		}})
-	expectNativeToValue(t, anyValue, expectedList)
 
-	// Object
 	pbMessage := exprpb.ParsedExpr{
 		SourceInfo: &exprpb.SourceInfo{
-			LineOffsets: []int32{1, 2, 3}}}
-	anyValue, err = anypb.New(&pbMessage)
-	if err != nil {
-		t.Error(err)
+			LineOffsets: []int32{1, 2, 3},
+		},
 	}
-	expectNativeToValue(t, anyValue, reg.NativeToValue(&pbMessage))
-}
+	pbMessageAny, err := anypb.New(&pbMessage)
+	if err != nil {
+		t.Fatalf("anypb.New(ParsedExpr) failed: %v", err)
+	}
 
-func TestNativeToValue_Json(t *testing.T) {
-	reg := newTestRegistry(t, ProtoTypeDefs(&exprpb.ParsedExpr{}))
-	// Json primitive conversion test.
-	expectNativeToValue(t, structpb.NewBoolValue(false), False)
-	expectNativeToValue(t, structpb.NewNumberValue(1.1), Double(1.1))
-	expectNativeToValue(t, structpb.NewNullValue(), Null(structpb.NullValue_NULL_VALUE))
-	expectNativeToValue(t, structpb.NewStringValue("hello"), String("hello"))
-
-	// Json list conversion.
-	expectNativeToValue(t,
-		structpb.NewListValue(
-			&structpb.ListValue{
-				Values: []*structpb.Value{
-					structpb.NewStringValue("world"),
-					structpb.NewStringValue("five!"),
-				},
-			},
-		),
-		NewJSONList(reg, &structpb.ListValue{
-			Values: []*structpb.Value{
-				structpb.NewStringValue("world"),
-				structpb.NewStringValue("five!"),
-			},
-		}))
-
-	// Json struct conversion.
-	expectNativeToValue(t,
-		structpb.NewStructValue(
-			&structpb.Struct{
+	tests := []struct {
+		name string
+		in   any
+		want ref.Val
+	}{
+		{
+			name: "NullValue",
+			in:   nullAny,
+			want: NullValue,
+		},
+		{
+			name: "JSON Struct",
+			in:   jsonStructAny,
+			want: NewJSONStruct(reg, &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"a": structpb.NewStringValue("world"),
 					"b": structpb.NewStringValue("five!"),
 				},
-			},
-		),
-		NewJSONStruct(reg, &structpb.Struct{
-			Fields: map[string]*structpb.Value{
-				"a": structpb.NewStringValue("world"),
-				"b": structpb.NewStringValue("five!"),
-			},
-		}))
+			}),
+		},
+		{
+			name: "JSON List",
+			in:   jsonListAny,
+			want: NewJSONList(reg, &structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("world"),
+					structpb.NewStringValue("five!"),
+				},
+			}),
+		},
+		{
+			name: "Proto Message",
+			in:   pbMessageAny,
+			want: reg.NativeToValue(&pbMessage),
+		},
+	}
 
-	// Proto conversion test.
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expectNativeToValue(t, tc.in, tc.want)
+		})
+	}
+}
+
+func TestNativeToValue_Json(t *testing.T) {
+	reg := newTestRegistry(t, ProtoTypeDefs(&exprpb.ParsedExpr{}))
 	parsedExpr := &exprpb.ParsedExpr{}
-	expectNativeToValue(t, parsedExpr, reg.NativeToValue(parsedExpr))
+
+	tests := []struct {
+		name string
+		in   any
+		want ref.Val
+	}{
+		// Json primitive conversion test.
+		{name: "bool value", in: structpb.NewBoolValue(false), want: False},
+		{name: "number value", in: structpb.NewNumberValue(1.1), want: Double(1.1)},
+		{name: "null value", in: structpb.NewNullValue(), want: Null(structpb.NullValue_NULL_VALUE)},
+		{name: "string value", in: structpb.NewStringValue("hello"), want: String("hello")},
+
+		// Json list conversion.
+		{
+			name: "list value",
+			in: structpb.NewListValue(
+				&structpb.ListValue{
+					Values: []*structpb.Value{
+						structpb.NewStringValue("world"),
+						structpb.NewStringValue("five!"),
+					},
+				},
+			),
+			want: NewJSONList(reg, &structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("world"),
+					structpb.NewStringValue("five!"),
+				},
+			}),
+		},
+
+		// Json struct conversion.
+		{
+			name: "struct value",
+			in: structpb.NewStructValue(
+				&structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"a": structpb.NewStringValue("world"),
+						"b": structpb.NewStringValue("five!"),
+					},
+				},
+			),
+			want: NewJSONStruct(reg, &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"a": structpb.NewStringValue("world"),
+					"b": structpb.NewStringValue("five!"),
+				},
+			}),
+		},
+
+		// Proto conversion test.
+		{
+			name: "proto message",
+			in:   parsedExpr,
+			want: reg.NativeToValue(parsedExpr),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expectNativeToValue(t, tc.in, tc.want)
+		})
+	}
 }
 
 func TestNativeToValue_Wrappers(t *testing.T) {
-	// Wrapper conversion test.
-	expectNativeToValue(t, wrapperspb.Bool(true), True)
-	expectNativeToValue(t, &wrapperspb.BoolValue{}, False)
-	expectNativeToValue(t, (*wrapperspb.BoolValue)(nil), NullValue)
-	expectNativeToValue(t, &wrapperspb.BytesValue{}, Bytes{})
-	expectNativeToValue(t, wrapperspb.Bytes([]byte("hi")), Bytes("hi"))
-	expectNativeToValue(t, (*wrapperspb.BytesValue)(nil), NullValue)
-	expectNativeToValue(t, &wrapperspb.DoubleValue{}, Double(0.0))
-	expectNativeToValue(t, wrapperspb.Double(6.4), Double(6.4))
-	expectNativeToValue(t, (*wrapperspb.DoubleValue)(nil), NullValue)
-	expectNativeToValue(t, &wrapperspb.FloatValue{}, Double(0.0))
-	expectNativeToValue(t, wrapperspb.Float(3.0), Double(3.0))
-	expectNativeToValue(t, (*wrapperspb.FloatValue)(nil), NullValue)
-	expectNativeToValue(t, &wrapperspb.Int32Value{}, IntZero)
-	expectNativeToValue(t, wrapperspb.Int32(-32), Int(-32))
-	expectNativeToValue(t, (*wrapperspb.Int32Value)(nil), NullValue)
-	expectNativeToValue(t, &wrapperspb.Int64Value{}, IntZero)
-	expectNativeToValue(t, wrapperspb.Int64(-64), Int(-64))
-	expectNativeToValue(t, (*wrapperspb.Int64Value)(nil), NullValue)
-	expectNativeToValue(t, &wrapperspb.StringValue{}, String(""))
-	expectNativeToValue(t, wrapperspb.String("hello"), String("hello"))
-	expectNativeToValue(t, (*wrapperspb.StringValue)(nil), NullValue)
-	expectNativeToValue(t, &wrapperspb.UInt32Value{}, Uint(0))
-	expectNativeToValue(t, wrapperspb.UInt32(32), Uint(32))
-	expectNativeToValue(t, (*wrapperspb.UInt32Value)(nil), NullValue)
-	expectNativeToValue(t, &wrapperspb.UInt64Value{}, Uint(0))
-	expectNativeToValue(t, wrapperspb.UInt64(64), Uint(64))
-	expectNativeToValue(t, (*wrapperspb.UInt64Value)(nil), NullValue)
+	tests := []struct {
+		name string
+		in   any
+		want ref.Val
+	}{
+		{name: "bool wrapper true", in: wrapperspb.Bool(true), want: True},
+		{name: "bool wrapper zero value", in: &wrapperspb.BoolValue{}, want: False},
+		{name: "bool wrapper nil", in: (*wrapperspb.BoolValue)(nil), want: NullValue},
+		{name: "bytes wrapper zero value", in: &wrapperspb.BytesValue{}, want: Bytes{}},
+		{name: "bytes wrapper value", in: wrapperspb.Bytes([]byte("hi")), want: Bytes("hi")},
+		{name: "bytes wrapper nil", in: (*wrapperspb.BytesValue)(nil), want: NullValue},
+		{name: "double wrapper zero value", in: &wrapperspb.DoubleValue{}, want: Double(0.0)},
+		{name: "double wrapper value", in: wrapperspb.Double(6.4), want: Double(6.4)},
+		{name: "double wrapper nil", in: (*wrapperspb.DoubleValue)(nil), want: NullValue},
+		{name: "float wrapper zero value", in: &wrapperspb.FloatValue{}, want: Double(0.0)},
+		{name: "float wrapper value", in: wrapperspb.Float(3.0), want: Double(3.0)},
+		{name: "float wrapper nil", in: (*wrapperspb.FloatValue)(nil), want: NullValue},
+		{name: "int32 wrapper zero value", in: &wrapperspb.Int32Value{}, want: IntZero},
+		{name: "int32 wrapper value", in: wrapperspb.Int32(-32), want: Int(-32)},
+		{name: "int32 wrapper nil", in: (*wrapperspb.Int32Value)(nil), want: NullValue},
+		{name: "int64 wrapper zero value", in: &wrapperspb.Int64Value{}, want: IntZero},
+		{name: "int64 wrapper value", in: wrapperspb.Int64(-64), want: Int(-64)},
+		{name: "int64 wrapper nil", in: (*wrapperspb.Int64Value)(nil), want: NullValue},
+		{name: "string wrapper zero value", in: &wrapperspb.StringValue{}, want: String("")},
+		{name: "string wrapper value", in: wrapperspb.String("hello"), want: String("hello")},
+		{name: "string wrapper nil", in: (*wrapperspb.StringValue)(nil), want: NullValue},
+		{name: "uint32 wrapper zero value", in: &wrapperspb.UInt32Value{}, want: Uint(0)},
+		{name: "uint32 wrapper value", in: wrapperspb.UInt32(32), want: Uint(32)},
+		{name: "uint32 wrapper nil", in: (*wrapperspb.UInt32Value)(nil), want: NullValue},
+		{name: "uint64 wrapper zero value", in: &wrapperspb.UInt64Value{}, want: Uint(0)},
+		{name: "uint64 wrapper value", in: wrapperspb.UInt64(64), want: Uint(64)},
+		{name: "uint64 wrapper nil", in: (*wrapperspb.UInt64Value)(nil), want: NullValue},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expectNativeToValue(t, tc.in, tc.want)
+		})
+	}
 }
 
 func TestNativeToValue_Primitive(t *testing.T) {
 	reg := newTestRegistry(t)
 
-	// Core type conversions.
-	expectNativeToValue(t, true, True)
-	expectNativeToValue(t, int(-10), Int(-10))
-	expectNativeToValue(t, int32(-1), Int(-1))
-	expectNativeToValue(t, int64(2), Int(2))
-	expectNativeToValue(t, uint(6), Uint(6))
-	expectNativeToValue(t, uint32(3), Uint(3))
-	expectNativeToValue(t, uint64(4), Uint(4))
-	expectNativeToValue(t, float32(5.5), Double(5.5))
-	expectNativeToValue(t, float64(-5.5), Double(-5.5))
-	expectNativeToValue(t, "hello", String("hello"))
-	expectNativeToValue(t, []byte("world"), Bytes("world"))
-	expectNativeToValue(t, [4]byte{1, 2, 3, 4}, Bytes([]byte{1, 2, 3, 4}))
-	expectNativeToValue(t, &[4]byte{1, 2, 3, 4}, Bytes([]byte{1, 2, 3, 4}))
-	expectNativeToValue(t, time.Duration(500), Duration{Duration: time.Duration(500)})
-	expectNativeToValue(t, time.Unix(12345, 0), Timestamp{Time: time.Unix(12345, 0)})
-	expectNativeToValue(t, dpb.New(time.Duration(500)), Duration{Duration: time.Duration(500)})
-	expectNativeToValue(t, tpb.New(time.Unix(12345, 0)), Timestamp{Time: time.Unix(12345, 0)})
-	expectNativeToValue(t, []int32{1, 2, 3}, NewDynamicList(reg, []int32{1, 2, 3}))
-	expectNativeToValue(t, map[int32]int32{1: 1, 2: 1, 3: 1},
-		NewDynamicMap(reg, map[int32]int32{1: 1, 2: 1, 3: 1}))
-
-	// Pointers to core types.
 	pBool := true
-	expectNativeToValue(t, &pBool, True)
 	pDub32 := float32(2.5)
 	pDub64 := float64(-1000.2)
-	expectNativeToValue(t, &pDub32, Double(2.5))
-	expectNativeToValue(t, &pDub64, Double(-1000.2))
 	pInt := int(1)
 	pInt32 := int32(2)
 	pInt64 := int64(-1000)
-	expectNativeToValue(t, &pInt, Int(1))
-	expectNativeToValue(t, &pInt32, Int(2))
-	expectNativeToValue(t, &pInt64, Int(-1000))
 	pStr := "hello"
-	expectNativeToValue(t, &pStr, String("hello"))
 	pUint := uint(1)
 	pUint32 := uint32(2)
 	pUint64 := uint64(1000)
-	expectNativeToValue(t, &pUint, Uint(1))
-	expectNativeToValue(t, &pUint32, Uint(2))
-	expectNativeToValue(t, &pUint64, Uint(1000))
 
-	// Pointers to ref.Val extensions of core types.
 	rBool := True
-	expectNativeToValue(t, &rBool, True)
 	rDub := Double(32.1)
-	expectNativeToValue(t, &rDub, rDub)
 	rInt := Int(-12)
-	expectNativeToValue(t, &rInt, rInt)
 	rStr := String("hello")
-	expectNativeToValue(t, &rStr, rStr)
 	rUint := Uint(12405)
-	expectNativeToValue(t, &rUint, rUint)
 	rBytes := Bytes([]byte("hello"))
-	expectNativeToValue(t, &rBytes, rBytes)
 
-	// Extensions to core types.
-	expectNativeToValue(t, testInt(1), Int(1))
-	expectNativeToValue(t, testInt8(1), Int(1))
-	expectNativeToValue(t, testInt16(1), Int(1))
-	expectNativeToValue(t, testInt32(1), Int(1))
-	expectNativeToValue(t, testInt64(-100), Int(-100))
-	expectNativeToValue(t, testUint(1), Uint(1))
-	expectNativeToValue(t, testUint8(1), Uint(1))
-	expectNativeToValue(t, testUint16(1), Uint(1))
-	expectNativeToValue(t, testUint32(2), Uint(2))
-	expectNativeToValue(t, testUint64(3), Uint(3))
-	expectNativeToValue(t, testFloat32(4.5), Double(4.5))
-	expectNativeToValue(t, testFloat64(-5.1), Double(-5.1))
-	expectNativeToValue(t, testString("foo"), String("foo"))
+	tests := []struct {
+		name string
+		in   any
+		want ref.Val
+	}{
+		// Core type conversions.
+		{name: "bool", in: true, want: True},
+		{name: "int", in: int(-10), want: Int(-10)},
+		{name: "int32", in: int32(-1), want: Int(-1)},
+		{name: "int64", in: int64(2), want: Int(2)},
+		{name: "uint", in: uint(6), want: Uint(6)},
+		{name: "uint32", in: uint32(3), want: Uint(3)},
+		{name: "uint64", in: uint64(4), want: Uint(4)},
+		{name: "float32", in: float32(5.5), want: Double(5.5)},
+		{name: "float64", in: float64(-5.5), want: Double(-5.5)},
+		{name: "string", in: "hello", want: String("hello")},
+		{name: "bytes slice", in: []byte("world"), want: Bytes("world")},
+		{name: "bytes array", in: [4]byte{1, 2, 3, 4}, want: Bytes([]byte{1, 2, 3, 4})},
+		{name: "bytes array pointer", in: &[4]byte{1, 2, 3, 4}, want: Bytes([]byte{1, 2, 3, 4})},
+		{name: "time duration", in: time.Duration(500), want: Duration{Duration: time.Duration(500)}},
+		{name: "time timestamp", in: time.Unix(12345, 0), want: Timestamp{Time: time.Unix(12345, 0)}},
+		{name: "proto duration", in: dpb.New(time.Duration(500)), want: Duration{Duration: time.Duration(500)}},
+		{name: "proto timestamp", in: tpb.New(time.Unix(12345, 0)), want: Timestamp{Time: time.Unix(12345, 0)}},
+		{name: "slice of int32", in: []int32{1, 2, 3}, want: NewDynamicList(reg, []int32{1, 2, 3})},
+		{name: "map of int32", in: map[int32]int32{1: 1, 2: 1, 3: 1}, want: NewDynamicMap(reg, map[int32]int32{1: 1, 2: 1, 3: 1})},
 
-	// Null conversion test.
-	expectNativeToValue(t, nil, NullValue)
-	expectNativeToValue(t, structpb.NullValue_NULL_VALUE, Null(structpb.NullValue_NULL_VALUE))
+		// Pointers to core types.
+		{name: "pointer to bool", in: &pBool, want: True},
+		{name: "pointer to float32", in: &pDub32, want: Double(2.5)},
+		{name: "pointer to float64", in: &pDub64, want: Double(-1000.2)},
+		{name: "pointer to int", in: &pInt, want: Int(1)},
+		{name: "pointer to int32", in: &pInt32, want: Int(2)},
+		{name: "pointer to int64", in: &pInt64, want: Int(-1000)},
+		{name: "pointer to string", in: &pStr, want: String("hello")},
+		{name: "pointer to uint", in: &pUint, want: Uint(1)},
+		{name: "pointer to uint32", in: &pUint32, want: Uint(2)},
+		{name: "pointer to uint64", in: &pUint64, want: Uint(1000)},
+
+		// Pointers to ref.Val extensions of core types.
+		{name: "pointer to ref.Val bool", in: &rBool, want: True},
+		{name: "pointer to ref.Val double", in: &rDub, want: rDub},
+		{name: "pointer to ref.Val int", in: &rInt, want: rInt},
+		{name: "pointer to ref.Val string", in: &rStr, want: rStr},
+		{name: "pointer to ref.Val uint", in: &rUint, want: rUint},
+		{name: "pointer to ref.Val bytes", in: &rBytes, want: rBytes},
+
+		// Extensions to core types.
+		{name: "custom testInt", in: testInt(1), want: Int(1)},
+		{name: "custom testInt8", in: testInt8(1), want: Int(1)},
+		{name: "custom testInt16", in: testInt16(1), want: Int(1)},
+		{name: "custom testInt32", in: testInt32(1), want: Int(1)},
+		{name: "custom testInt64", in: testInt64(-100), want: Int(-100)},
+		{name: "custom testUint", in: testUint(1), want: Uint(1)},
+		{name: "custom testUint8", in: testUint8(1), want: Uint(1)},
+		{name: "custom testUint16", in: testUint16(1), want: Uint(1)},
+		{name: "custom testUint32", in: testUint32(2), want: Uint(2)},
+		{name: "custom testUint64", in: testUint64(3), want: Uint(3)},
+		{name: "custom testFloat32", in: testFloat32(4.5), want: Double(4.5)},
+		{name: "custom testFloat64", in: testFloat64(-5.1), want: Double(-5.1)},
+		{name: "custom testString", in: testString("foo"), want: String("foo")},
+
+		// Null conversion test.
+		{name: "nil", in: nil, want: NullValue},
+		{name: "proto null value", in: structpb.NullValue_NULL_VALUE, want: Null(structpb.NullValue_NULL_VALUE)},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			expectNativeToValue(t, tc.in, tc.want)
+		})
+	}
 }
 
 func TestUnsupportedConversion(t *testing.T) {
@@ -868,28 +1018,209 @@ func expectNativeToValue(t *testing.T, in any, out ref.Val) {
 }
 
 func BenchmarkNativeToValue(b *testing.B) {
-	reg, err := NewRegistry()
+	reg, err := NewRegistry(ProtoTypeDefs(&proto3pb.TestAllTypes{}))
 	if err != nil {
 		b.Fatalf("NewRegistry() failed: %v", err)
 	}
-	inputs := []any{
-		true,
-		false,
-		float32(-1.2),
-		float64(-2.4),
-		1,
-		int32(2),
-		int64(3),
-		"",
-		"hello",
-		String("hello world"),
+
+	dummyDesc := &testDummyStructDescriptor{
+		Type:        NewObjectType("dummy.Struct"),
+		reflectType: reflect.TypeOf(dummyNativeStruct{}),
+		fieldType:   &FieldType{Type: StringType},
 	}
-	for _, in := range inputs {
-		input := in
-		b.Run(fmt.Sprintf("%T/%v", in, in), func(b *testing.B) {
+	if err := reg.RegisterType(dummyDesc); err != nil {
+		b.Fatalf("RegisterType() failed: %v", err)
+	}
+
+	protoMsg := &proto3pb.TestAllTypes{SingleInt32: 42}
+	nativeStructVal := dummyNativeStruct{}
+	nativeStructPtr := &dummyNativeStruct{}
+
+	inputs := []struct {
+		name string
+		val  any
+	}{
+		{name: "bool/true", val: true},
+		{name: "int/1", val: 1},
+		{name: "int64/3", val: int64(3)},
+		{name: "string/hello", val: "hello"},
+		{name: "ref.Val/String", val: String("hello world")},
+		{name: "ref.Val/Int", val: Int(42)},
+		{name: "ref.Val/Bool", val: Bool(true)},
+		{name: "proto/TestAllTypes", val: protoMsg},
+		{name: "nativeStruct/value", val: nativeStructVal},
+		{name: "nativeStruct/pointer", val: nativeStructPtr},
+	}
+
+	for _, tc := range inputs {
+		input := tc.val
+		b.Run(tc.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				reg.NativeToValue(input)
 			}
+		})
+	}
+}
+
+func TestRegistryStructTypeDescriptor_FindStructType(t *testing.T) {
+	reg := newTestStructTypeRegistry(t)
+	tests := []struct {
+		name     string
+		wantType string
+	}{
+		{name: "custom.MyStruct", wantType: "type"},
+		{name: ".custom.MyStruct", wantType: "type"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st, found := reg.FindStructType(tc.name)
+			if !found || st == nil {
+				t.Fatalf("FindStructType(%q) not found", tc.name)
+			}
+			if st.TypeName() != tc.wantType {
+				t.Errorf("FindStructType(%q).TypeName() = %s, want %s", tc.name, st.TypeName(), tc.wantType)
+			}
+		})
+	}
+}
+
+func TestRegistryStructTypeDescriptor_FindStructFieldNames(t *testing.T) {
+	reg := newTestStructTypeRegistry(t)
+	names, found := reg.FindStructFieldNames("custom.MyStruct")
+	if !found {
+		t.Fatalf("FindStructFieldNames('custom.MyStruct') not found")
+	}
+	want := []string{"Bar", "Foo"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("FindStructFieldNames() = %v, want %v", names, want)
+	}
+}
+
+func TestRegistryStructTypeDescriptor_FindStructFieldType(t *testing.T) {
+	reg := newTestStructTypeRegistry(t)
+	tests := []struct {
+		fieldName string
+		wantType  *Type
+	}{
+		{fieldName: "Foo", wantType: StringType},
+		{fieldName: "Bar", wantType: IntType},
+	}
+	for _, tc := range tests {
+		t.Run(tc.fieldName, func(t *testing.T) {
+			ft, found := reg.FindStructFieldType("custom.MyStruct", tc.fieldName)
+			if !found || ft == nil {
+				t.Fatalf("FindStructFieldType(%q) not found", tc.fieldName)
+			}
+			if ft.Type != tc.wantType {
+				t.Errorf("FindStructFieldType(%q).Type = %v, want %v", tc.fieldName, ft.Type, tc.wantType)
+			}
+		})
+	}
+}
+
+func TestRegistryStructTypeDescriptor_FindIdent(t *testing.T) {
+	reg := newTestStructTypeRegistry(t)
+	ident, found := reg.FindIdent("custom.MyStruct")
+	if !found || ident == nil {
+		t.Fatalf("FindIdent('custom.MyStruct') not found")
+	}
+}
+
+func TestRegistryStructTypeDescriptor_NewValue(t *testing.T) {
+	reg := newTestStructTypeRegistry(t)
+	val := reg.NewValue("custom.MyStruct", map[string]ref.Val{"Foo": String("hello"), "Bar": Int(42)})
+	if IsError(val) {
+		t.Fatalf("NewValue() failed: %v", val)
+	}
+
+	t.Run("Foo", func(t *testing.T) {
+		fooVal := val.(traits.Indexer).Get(String("Foo"))
+		if fooVal.Equal(String("hello")) != True {
+			t.Errorf("Get('Foo') = %v, want 'hello'", fooVal)
+		}
+	})
+
+	t.Run("Bar", func(t *testing.T) {
+		barVal := val.(traits.Indexer).Get(String("Bar"))
+		if barVal.Equal(Int(42)) != True {
+			t.Errorf("Get('Bar') = %v, want 42", barVal)
+		}
+	})
+}
+
+func TestRegistryStructTypeDescriptor_NativeToValue(t *testing.T) {
+	reg := newTestStructTypeRegistry(t)
+	tests := []struct {
+		name  string
+		in    any
+		check func(t *testing.T, val ref.Val)
+	}{
+		{
+			name: "struct instance",
+			in:   dummyNativeStruct{Foo: "hello", Bar: 42},
+			check: func(t *testing.T, val ref.Val) {
+				fooVal := val.(traits.Indexer).Get(String("Foo"))
+				if fooVal.Equal(String("hello")) != True {
+					t.Errorf("Get('Foo') = %v, want 'hello'", fooVal)
+				}
+			},
+		},
+		{
+			name: "pointer to struct instance",
+			in:   &dummyNativeStruct{Foo: "world", Bar: 99},
+			check: func(t *testing.T, val ref.Val) {
+				barVal := val.(traits.Indexer).Get(String("Bar"))
+				if barVal.Equal(Int(99)) != True {
+					t.Errorf("Get('Bar') = %v, want 99", barVal)
+				}
+			},
+		},
+		{
+			name: "slice of struct instances",
+			in:   []dummyNativeStruct{{Foo: "e1"}, {Foo: "e2"}},
+			check: func(t *testing.T, val ref.Val) {
+				lister := val.(traits.Lister)
+				if lister.Size().Equal(Int(2)) != True {
+					t.Errorf("Size() = %v, want 2", lister.Size())
+				}
+				e1 := lister.Get(Int(0)).(traits.Indexer).Get(String("Foo"))
+				if e1.Equal(String("e1")) != True {
+					t.Errorf("element 0 Foo = %v, want 'e1'", e1)
+				}
+			},
+		},
+		{
+			name: "map of struct instances",
+			in:   map[string]dummyNativeStruct{"k1": {Foo: "v1"}},
+			check: func(t *testing.T, val ref.Val) {
+				mapper := val.(traits.Mapper)
+				k1Val := mapper.Get(String("k1")).(traits.Indexer).Get(String("Foo"))
+				if k1Val.Equal(String("v1")) != True {
+					t.Errorf("map k1 Foo = %v, want 'v1'", k1Val)
+				}
+			},
+		},
+		{
+			name: "typed nil pointer to struct instance",
+			in:   (*dummyNativeStruct)(nil),
+			check: func(t *testing.T, val ref.Val) {
+				if val != NullValue {
+					t.Errorf("NativeToValue((*dummyNativeStruct)(nil)) = %v, want NullValue", val)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			val := reg.NativeToValue(tc.in)
+			if IsError(val) {
+				t.Fatalf("NativeToValue(%s) error: %v", tc.name, val)
+			}
+			tc.check(t, val)
 		})
 	}
 }
@@ -941,9 +1272,1146 @@ type testString string
 
 func newTestRegistry(t *testing.T, opts ...RegistryOption) *Registry {
 	t.Helper()
-	reg, err := NewProtoRegistry(opts...)
+	var o []any
+	for _, opt := range opts {
+		o = append(o, opt)
+	}
+	reg, err := NewRegistry(o...)
 	if err != nil {
-		t.Fatalf("NewProtoRegistry() failed: %v", err)
+		t.Fatalf("NewRegistry() failed: %v", err)
 	}
 	return reg
+}
+
+type dummyNativeStruct struct {
+	Foo string
+	Bar int64
+}
+
+type testStructType struct {
+	typeName    string
+	reflectType reflect.Type
+	fields      map[string]*FieldType
+	celType     *Type
+}
+
+func (d *testStructType) HasTrait(trait int) bool {
+	return d.objectType().HasTrait(trait)
+}
+
+func (d *testStructType) TypeName() string {
+	return d.typeName
+}
+
+func (d *testStructType) objectType() *Type {
+	if d.celType == nil {
+		d.celType = NewObjectType(d.typeName)
+	}
+	return d.celType
+}
+
+func (d *testStructType) ReflectType() reflect.Type {
+	return d.reflectType
+}
+
+func (d *testStructType) FieldNames() []string {
+	names := make([]string, 0, len(d.fields))
+	for name := range d.fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (d *testStructType) FindFieldType(fieldName string) (*FieldType, bool) {
+	ft, found := d.fields[fieldName]
+	return ft, found
+}
+
+func (d *testStructType) NewValue(adapter Adapter, fields map[string]ref.Val) ref.Val {
+	if d.reflectType == nil {
+		return &testStructVal{
+			adapter: adapter,
+			st:      d,
+			value:   fields,
+		}
+	}
+	refPtr := reflect.New(d.reflectType)
+	refVal := refPtr.Elem()
+	for fieldName, val := range fields {
+		refField := refVal.FieldByName(fieldName)
+		if !refField.IsValid() || !refField.CanSet() {
+			return NewErr("no such field: %s", fieldName)
+		}
+		nativeVal, err := val.ConvertToNative(refField.Type())
+		if err != nil {
+			return NewErrFromString(err.Error())
+		}
+		refField.Set(reflect.ValueOf(nativeVal))
+	}
+	var inst any
+	if d.reflectType.Kind() == reflect.Pointer {
+		inst = refPtr.Interface()
+	} else {
+		inst = refVal.Interface()
+	}
+	return d.Adapt(adapter, inst)
+}
+
+func (d *testStructType) Adapt(adapter Adapter, value any) ref.Val {
+	return &testStructVal{
+		adapter: adapter,
+		st:      d,
+		value:   value,
+	}
+}
+
+type testStructVal struct {
+	adapter Adapter
+	st      *testStructType
+	value   any
+}
+
+func (o *testStructVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	if reflect.TypeOf(o.value).AssignableTo(typeDesc) {
+		return o.value, nil
+	}
+	if reflect.TypeOf(o).AssignableTo(typeDesc) {
+		return o, nil
+	}
+	return nil, fmt.Errorf("type conversion error for type to '%v'", typeDesc)
+}
+
+func (o *testStructVal) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	case TypeType:
+		return NewTypeTypeWithParam(o.Type().(*Type))
+	default:
+		if o.Type().TypeName() == typeVal.TypeName() {
+			return o
+		}
+	}
+	return NewErr("type conversion error from '%s' to '%s'", o.Type(), typeVal)
+}
+
+func (o *testStructVal) Equal(other ref.Val) ref.Val {
+	return Bool(reflect.DeepEqual(o.value, other.Value()))
+}
+
+func (o *testStructVal) HasTrait(trait int) bool {
+	return (traits.FieldTesterType|traits.IndexerType)&trait == trait
+}
+
+func (o *testStructVal) Get(index ref.Val) ref.Val {
+	fieldName, ok := index.(String)
+	if !ok {
+		return MaybeNoSuchOverloadErr(index)
+	}
+	ft, found := o.st.FindFieldType(string(fieldName))
+	if !found {
+		return NewErr("no such field: %s", index)
+	}
+	if ft.GetFrom == nil {
+		return NewErr("field '%s' is not readable", index)
+	}
+	fv, err := ft.GetFrom(o.value)
+	if err != nil {
+		return NewErrFromString(err.Error())
+	}
+	return o.adapter.NativeToValue(fv)
+}
+
+func (o *testStructVal) IsSet(field ref.Val) ref.Val {
+	fieldName, ok := field.(String)
+	if !ok {
+		return MaybeNoSuchOverloadErr(field)
+	}
+	ft, found := o.st.FindFieldType(string(fieldName))
+	if !found {
+		return NewErr("no such field: %s", field)
+	}
+	if ft.IsSet == nil {
+		return False
+	}
+	return Bool(ft.IsSet(o.value))
+}
+
+func (o *testStructVal) Type() ref.Type {
+	return o.st
+}
+
+func (o *testStructVal) Value() any {
+	return o.value
+}
+
+func newTestStructTypeRegistry(t *testing.T) *Registry {
+	t.Helper()
+	desc := &testStructType{
+		typeName:    "custom.MyStruct",
+		reflectType: reflect.TypeOf(dummyNativeStruct{}),
+		fields: map[string]*FieldType{
+			"Foo": {
+				Type: StringType,
+				GetFrom: func(obj any) (any, error) {
+					if s, ok := obj.(dummyNativeStruct); ok {
+						return s.Foo, nil
+					}
+					if s, ok := obj.(*dummyNativeStruct); ok {
+						return s.Foo, nil
+					}
+					return nil, fmt.Errorf("unexpected type: %T", obj)
+				},
+				IsSet: func(obj any) bool { return true },
+			},
+			"Bar": {
+				Type: IntType,
+				GetFrom: func(obj any) (any, error) {
+					if s, ok := obj.(dummyNativeStruct); ok {
+						return s.Bar, nil
+					}
+					if s, ok := obj.(*dummyNativeStruct); ok {
+						return s.Bar, nil
+					}
+					return nil, fmt.Errorf("unexpected type: %T", obj)
+				},
+				IsSet: func(obj any) bool { return true },
+			},
+		},
+	}
+	reg, err := NewRegistry(Types(desc))
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+	return reg
+}
+
+type testCustomProvider struct {
+	enumVal    ref.Val
+	identVal   ref.Val
+	structType *Type
+	fieldNames []string
+	fieldType  *FieldType
+	newValue   ref.Val
+}
+
+func (p *testCustomProvider) EnumValue(enumName string) ref.Val {
+	if enumName == "custom.Enum.VAL" {
+		return p.enumVal
+	}
+	return NewErr("unknown enum name '%s'", enumName)
+}
+
+func (p *testCustomProvider) FindIdent(identName string) (ref.Val, bool) {
+	if identName == "customIdent" {
+		return p.identVal, true
+	}
+	return nil, false
+}
+
+func (p *testCustomProvider) FindStructType(structType string) (*Type, bool) {
+	if structType == "custom.ProviderStruct" {
+		return p.structType, true
+	}
+	return nil, false
+}
+
+func (p *testCustomProvider) FindStructFieldNames(structType string) ([]string, bool) {
+	if structType == "custom.ProviderStruct" {
+		return p.fieldNames, true
+	}
+	return []string{}, false
+}
+
+func (p *testCustomProvider) FindStructFieldType(structType, fieldName string) (*FieldType, bool) {
+	if structType == "custom.ProviderStruct" && fieldName == "customField" {
+		return p.fieldType, true
+	}
+	return nil, false
+}
+
+func (p *testCustomProvider) NewValue(structType string, fields map[string]ref.Val) ref.Val {
+	if structType == "custom.ProviderStruct" {
+		return p.newValue
+	}
+	return NewErr("unknown type '%s'", structType)
+}
+
+func (p *testCustomProvider) FindStructFieldDescription(structType, fieldName string) (string, bool) {
+	if structType == "custom.ProviderStruct" && fieldName == "customField" {
+		return "Custom field documentation", true
+	}
+	return "", false
+}
+
+func (p *testCustomProvider) FindType(structType string) (*exprpb.Type, bool) {
+	if structType == "custom.ProviderStruct" {
+		return &exprpb.Type{
+			TypeKind: &exprpb.Type_MessageType{MessageType: structType},
+		}, true
+	}
+	return nil, false
+}
+
+func (p *testCustomProvider) FindFieldType(structType, fieldName string) (*ref.FieldType, bool) {
+	if structType == "custom.ProviderStruct" && fieldName == "customField" {
+		return &ref.FieldType{
+			Type: &exprpb.Type{TypeKind: &exprpb.Type_Primitive{Primitive: exprpb.Type_STRING}},
+		}, true
+	}
+	return nil, false
+}
+
+type customNativeType struct{}
+
+type testCustomAdapter struct {
+	adaptedVal ref.Val
+}
+
+func (a *testCustomAdapter) NativeToValue(value any) ref.Val {
+	if _, ok := value.(customNativeType); ok {
+		return a.adaptedVal
+	}
+	return UnsupportedRefValConversionErr(value)
+}
+
+type testCustomCombined struct {
+	testCustomProvider
+	testCustomAdapter
+}
+
+func TestComposeTypes_SameRegistry(t *testing.T) {
+	reg, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+
+	p, a, err := ComposeTypes(reg, reg, ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	if p != reg || a != reg {
+		t.Errorf("ComposeTypes() with same registry instance returned different instances: p=%v, a=%v, wanted reg=%v", p, a, reg)
+	}
+
+	// Verify type was registered directly on reg
+	_, found := reg.FindStructType("google.expr.proto3.test.TestAllTypes")
+	if !found {
+		t.Errorf("FindStructType() did not find registered type on same registry instance")
+	}
+}
+
+func TestComposeTypes_DifferentRegistries(t *testing.T) {
+	reg1, err := NewRegistry(ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	if err != nil {
+		t.Fatalf("NewRegistry(reg1) failed: %v", err)
+	}
+	reg2, err := NewRegistry(ProtoTypeDefs(&exprpb.ParsedExpr{}))
+	if err != nil {
+		t.Fatalf("NewRegistry(reg2) failed: %v", err)
+	}
+
+	p, a, err := ComposeTypes(reg1, reg2, ProtoTypeDefs(&exprpb.SourceInfo{}))
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	if p == reg1 || p == reg2 {
+		t.Errorf("ComposeTypes() should return a new composed registry, got p=%v", p)
+	}
+	if any(p) != any(a) {
+		t.Errorf("ComposeTypes() returned different provider and adapter: p=%v, a=%v", p, a)
+	}
+
+	composedReg := p.(*Registry)
+
+	t.Run("registered type on composed registry", func(t *testing.T) {
+		_, found := composedReg.FindStructType("google.api.expr.v1alpha1.SourceInfo")
+		if !found {
+			t.Errorf("FindStructType() failed for newly registered type on composed registry")
+		}
+	})
+
+	t.Run("provider type via proxy", func(t *testing.T) {
+		_, found := composedReg.FindStructType("google.expr.proto3.test.TestAllTypes")
+		if !found {
+			t.Errorf("FindStructType() failed for provider (reg1) type on composed registry")
+		}
+	})
+
+	t.Run("adapter NativeToValue via proxy", func(t *testing.T) {
+		parsedExpr := &exprpb.ParsedExpr{}
+		val := composedReg.NativeToValue(parsedExpr)
+		if IsError(val) {
+			t.Errorf("NativeToValue() failed for adapter (reg2) type on composed registry: %v", val)
+		}
+	})
+}
+
+func TestComposeTypes_RegistryProviderCustomAdapter(t *testing.T) {
+	reg, err := NewRegistry(ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+	customAdapt := &testCustomAdapter{adaptedVal: String("adapted_success")}
+
+	p, a, err := ComposeTypes(reg, customAdapt)
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	if any(p) != any(a) {
+		t.Errorf("ComposeTypes() returned different provider and adapter: p=%v, a=%v", p, a)
+	}
+	composedReg := p.(*Registry)
+
+	t.Run("provider delegation", func(t *testing.T) {
+		_, found := composedReg.FindStructType("google.expr.proto3.test.TestAllTypes")
+		if !found {
+			t.Errorf("FindStructType() failed to delegate to provider registry")
+		}
+	})
+
+	t.Run("adapter delegation", func(t *testing.T) {
+		val := composedReg.NativeToValue(customNativeType{})
+		if IsError(val) || val.(String) != "adapted_success" {
+			t.Errorf("NativeToValue() failed to delegate to custom adapter: got %v, wanted adapted_success", val)
+		}
+	})
+}
+
+func TestComposeTypes_CustomProviderRegistryAdapter(t *testing.T) {
+	customProv := &testCustomProvider{
+		enumVal:    Int(42),
+		identVal:   String("ident_ok"),
+		structType: NewTypeTypeWithParam(NewObjectType("custom.ProviderStruct")),
+		fieldNames: []string{"customField"},
+		fieldType:  &FieldType{Type: StringType},
+		newValue:   String("new_val_ok"),
+	}
+	reg, err := NewRegistry(ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+
+	p, a, err := ComposeTypes(customProv, reg)
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	if any(p) != any(a) {
+		t.Errorf("ComposeTypes() returned different provider and adapter: p=%v, a=%v", p, a)
+	}
+	composedReg := p.(*Registry)
+
+	t.Run("EnumValue", func(t *testing.T) {
+		if enumVal := composedReg.EnumValue("custom.Enum.VAL"); IsError(enumVal) || enumVal.(Int) != 42 {
+			t.Errorf("EnumValue() proxy failed: got %v, wanted 42", enumVal)
+		}
+	})
+
+	t.Run("FindIdent", func(t *testing.T) {
+		if ident, found := composedReg.FindIdent("customIdent"); !found || ident.(String) != "ident_ok" {
+			t.Errorf("FindIdent() proxy failed: got %v, found %v", ident, found)
+		}
+	})
+
+	t.Run("FindStructType", func(t *testing.T) {
+		if st, found := composedReg.FindStructType("custom.ProviderStruct"); !found || st == nil {
+			t.Errorf("FindStructType() proxy failed: got %v, found %v", st, found)
+		}
+	})
+
+	t.Run("FindStructFieldNames", func(t *testing.T) {
+		if fields, found := composedReg.FindStructFieldNames("custom.ProviderStruct"); !found || len(fields) != 1 || fields[0] != "customField" {
+			t.Errorf("FindStructFieldNames() proxy failed: got %v, found %v", fields, found)
+		}
+	})
+
+	t.Run("FindStructFieldType", func(t *testing.T) {
+		if ft, found := composedReg.FindStructFieldType("custom.ProviderStruct", "customField"); !found || ft.Type != StringType {
+			t.Errorf("FindStructFieldType() proxy failed: got %v, found %v", ft, found)
+		}
+	})
+
+	t.Run("NewValue", func(t *testing.T) {
+		if nv := composedReg.NewValue("custom.ProviderStruct", nil); IsError(nv) || nv.(String) != "new_val_ok" {
+			t.Errorf("NewValue() proxy failed: got %v", nv)
+		}
+	})
+
+	t.Run("NativeToValue adapter proxy", func(t *testing.T) {
+		msg := &proto3pb.TestAllTypes{}
+		val := composedReg.NativeToValue(msg)
+		if IsError(val) {
+			t.Errorf("NativeToValue() proxy to registry adapter failed: %v", val)
+		}
+	})
+}
+
+func TestComposeTypes_CustomProviderAndAdapter(t *testing.T) {
+	customProv := &testCustomProvider{
+		identVal: String("ident_val"),
+	}
+	customAdapt := &testCustomAdapter{
+		adaptedVal: String("adapted_val"),
+	}
+
+	p, a, err := ComposeTypes(customProv, customAdapt)
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	if any(p) != any(a) {
+		t.Errorf("ComposeTypes() returned different provider and adapter: p=%v, a=%v", p, a)
+	}
+	composedReg := p.(*Registry)
+
+	t.Run("FindIdent", func(t *testing.T) {
+		if ident, found := composedReg.FindIdent("customIdent"); !found || ident.(String) != "ident_val" {
+			t.Errorf("FindIdent() failed on composed registry: got %v", ident)
+		}
+	})
+
+	t.Run("NativeToValue", func(t *testing.T) {
+		if val := composedReg.NativeToValue(customNativeType{}); IsError(val) || val.(String) != "adapted_val" {
+			t.Errorf("NativeToValue() failed on composed registry: got %v", val)
+		}
+	})
+}
+
+func TestComposeTypes_SameCustomInstance(t *testing.T) {
+	customBoth := &testCustomCombined{
+		testCustomProvider: testCustomProvider{identVal: String("combined_ident")},
+		testCustomAdapter:  testCustomAdapter{adaptedVal: String("combined_adapt")},
+	}
+
+	p, a, err := ComposeTypes(customBoth, customBoth)
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	if any(p) != any(a) {
+		t.Errorf("ComposeTypes() returned different provider and adapter: p=%v, a=%v", p, a)
+	}
+	if _, ok := p.(*Registry); !ok {
+		t.Fatalf("ComposeTypes() should return a *Registry instance, got %T", p)
+	}
+
+	composedReg := p.(*Registry)
+
+	t.Run("FindIdent", func(t *testing.T) {
+		if ident, found := composedReg.FindIdent("customIdent"); !found || ident.(String) != "combined_ident" {
+			t.Errorf("FindIdent() failed: got %v", ident)
+		}
+	})
+
+	t.Run("NativeToValue", func(t *testing.T) {
+		if val := composedReg.NativeToValue(customNativeType{}); IsError(val) || val.(String) != "combined_adapt" {
+			t.Errorf("NativeToValue() failed: got %v", val)
+		}
+	})
+}
+
+func TestComposeTypes_ErrorCases(t *testing.T) {
+	reg, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		types []any
+	}{
+		{
+			name:  "unsupported type",
+			types: []any{12345},
+		},
+		{
+			name: "conflicting type definitions",
+			types: []any{
+				NewTypeValue("http.Request", traits.ReceiverType),
+				NewObjectType("http.Request", traits.ReceiverType),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := ComposeTypes(reg, reg, tc.types...)
+			if err == nil {
+				t.Errorf("ComposeTypes() expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestComposeTypes_CopyPreservesProxy(t *testing.T) {
+	customProv := &testCustomProvider{identVal: String("copied_ident")}
+	customAdapt := &testCustomAdapter{adaptedVal: String("copied_adapt")}
+
+	p, _, err := ComposeTypes(customProv, customAdapt)
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+
+	reg := p.(*Registry)
+	copiedReg := reg.Copy()
+
+	t.Run("FindIdent", func(t *testing.T) {
+		if ident, found := copiedReg.FindIdent("customIdent"); !found || ident.(String) != "copied_ident" {
+			t.Errorf("Copied registry FindIdent() failed: got %v", ident)
+		}
+	})
+
+	t.Run("NativeToValue", func(t *testing.T) {
+		if val := copiedReg.NativeToValue(customNativeType{}); IsError(val) || val.(String) != "copied_adapt" {
+			t.Errorf("Copied registry NativeToValue() failed: got %v", val)
+		}
+	})
+}
+
+func TestRegistryJSONFieldNamesDefault(t *testing.T) {
+	reg, err := NewRegistry(ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+	if reg.JSONFieldNames() {
+		t.Errorf("JSONFieldNames() default expected false, got true")
+	}
+}
+
+func TestRegistryWithJSONFieldNames(t *testing.T) {
+	reg, err := NewRegistry(ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+	err = reg.WithJSONFieldNames(true)
+	if err != nil {
+		t.Fatalf("WithJSONFieldNames(true) failed: %v", err)
+	}
+	if !reg.JSONFieldNames() {
+		t.Errorf("JSONFieldNames() after enabling expected true, got false")
+	}
+}
+
+func TestRegistryWithJSONFieldNamesIdempotent(t *testing.T) {
+	reg, err := NewRegistry(ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+	err = reg.WithJSONFieldNames(true)
+	if err != nil {
+		t.Fatalf("WithJSONFieldNames(true) failed: %v", err)
+	}
+	err = reg.WithJSONFieldNames(true)
+	if err != nil {
+		t.Fatalf("WithJSONFieldNames(true) idempotent failed: %v", err)
+	}
+	if !reg.JSONFieldNames() {
+		t.Errorf("JSONFieldNames() expected true, got false")
+	}
+}
+
+func TestRegistryWithJSONFieldNamesDisabled(t *testing.T) {
+	reg, err := NewRegistry(ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+	err = reg.WithJSONFieldNames(true)
+	if err != nil {
+		t.Fatalf("WithJSONFieldNames(true) failed: %v", err)
+	}
+	err = reg.WithJSONFieldNames(false)
+	if err != nil {
+		t.Fatalf("WithJSONFieldNames(false) failed: %v", err)
+	}
+	if reg.JSONFieldNames() {
+		t.Errorf("JSONFieldNames() after disabling expected false, got true")
+	}
+}
+
+func TestRegistry_EnumValueEdgeCases(t *testing.T) {
+	customProv := &testCustomProvider{
+		enumVal: Int(99),
+	}
+	reg := newTestRegistry(t, ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	err := reg.RegisterDescriptor(proto3pb.GlobalEnum_GOO.Descriptor().ParentFile())
+	if err != nil {
+		t.Fatalf("RegisterDescriptor() failed: %v", err)
+	}
+
+	p, _, err := ComposeTypes(customProv, reg)
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	composedReg := p.(*Registry)
+
+	tests := []struct {
+		enumName string
+		target   *Registry
+		wantVal  ref.Val
+		isErr    bool
+	}{
+		{
+			enumName: "google.expr.proto3.test.GlobalEnum.GOO",
+			target:   reg,
+			wantVal:  Int(proto3pb.GlobalEnum_GOO.Number()),
+		},
+		{
+			enumName: "custom.Enum.VAL",
+			target:   composedReg,
+			wantVal:  Int(99),
+		},
+		{
+			enumName: "non.existent.Enum",
+			target:   reg,
+			isErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.enumName, func(t *testing.T) {
+			got := tc.target.EnumValue(tc.enumName)
+			if tc.isErr {
+				if !IsError(got) {
+					t.Errorf("EnumValue(%s) expected error, got %v", tc.enumName, got)
+				}
+			} else {
+				if IsError(got) || got.Equal(tc.wantVal) != True {
+					t.Errorf("EnumValue(%s) got %v, wanted %v", tc.enumName, got, tc.wantVal)
+				}
+			}
+		})
+	}
+}
+
+func TestRegistry_FindIdentEdgeCases(t *testing.T) {
+	customProv := &testCustomProvider{
+		identVal: String("ident_found"),
+	}
+	reg := newTestRegistry(t, ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+	err := reg.RegisterDescriptor(proto3pb.GlobalEnum_GOO.Descriptor().ParentFile())
+	if err != nil {
+		t.Fatalf("RegisterDescriptor() failed: %v", err)
+	}
+
+	p, _, err := ComposeTypes(customProv, reg)
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	composedReg := p.(*Registry)
+
+	tests := []struct {
+		identName string
+		target    *Registry
+		wantFound bool
+	}{
+		{
+			identName: "int",
+			target:    composedReg,
+			wantFound: true,
+		},
+		{
+			identName: "google.expr.proto3.test.GlobalEnum.GOO",
+			target:    reg,
+			wantFound: true,
+		},
+		{
+			identName: "customIdent",
+			target:    composedReg,
+			wantFound: true,
+		},
+		{
+			identName: "nonExistentIdent",
+			target:    composedReg,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.identName, func(t *testing.T) {
+			_, found := tc.target.FindIdent(tc.identName)
+			if found != tc.wantFound {
+				t.Errorf("FindIdent(%s) found=%v, wanted %v", tc.identName, found, tc.wantFound)
+			}
+		})
+	}
+}
+
+func TestRegistry_FindTypeEdgeCases(t *testing.T) {
+	customProv := &testCustomProvider{}
+	reg := newTestRegistry(t, ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+
+	p, _, err := ComposeTypes(reg, &testCustomAdapter{})
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	composedReg := p.(*Registry)
+
+	p2, _, err := ComposeTypes(customProv, reg)
+	if err != nil {
+		t.Fatalf("ComposeTypes(customProv, reg) failed: %v", err)
+	}
+	composedReg2 := p2.(*Registry)
+
+	tests := []struct {
+		typeName  string
+		target    *Registry
+		wantFound bool
+	}{
+		{
+			typeName:  "google.expr.proto3.test.TestAllTypes",
+			target:    composedReg,
+			wantFound: true,
+		},
+		{
+			typeName:  ".google.expr.proto3.test.TestAllTypes",
+			target:    composedReg,
+			wantFound: true,
+		},
+		{
+			typeName:  "custom.ProviderStruct",
+			target:    composedReg2,
+			wantFound: true,
+		},
+		{
+			typeName:  "non.existent.Type",
+			target:    composedReg,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.typeName, func(t *testing.T) {
+			got, found := tc.target.FindType(tc.typeName)
+			if found != tc.wantFound {
+				t.Errorf("FindType(%s) found=%v, wanted %v", tc.typeName, found, tc.wantFound)
+			}
+			if found && got == nil {
+				t.Errorf("FindType(%s) returned nil type despite found=true", tc.typeName)
+			}
+		})
+	}
+}
+
+func TestRegistry_FindFieldTypeEdgeCases(t *testing.T) {
+	customProv := &testCustomProvider{}
+	reg := newTestRegistry(t, ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+
+	p, _, err := ComposeTypes(reg, &testCustomAdapter{})
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	composedReg := p.(*Registry)
+
+	p2, _, err := ComposeTypes(customProv, reg)
+	if err != nil {
+		t.Fatalf("ComposeTypes(customProv, reg) failed: %v", err)
+	}
+	composedReg2 := p2.(*Registry)
+
+	tests := []struct {
+		structType string
+		fieldName  string
+		target     *Registry
+		wantFound  bool
+	}{
+		{
+			structType: "google.expr.proto3.test.TestAllTypes",
+			fieldName:  "single_int32",
+			target:     composedReg,
+			wantFound:  true,
+		},
+		{
+			structType: ".google.expr.proto3.test.TestAllTypes",
+			fieldName:  "single_int32",
+			target:     composedReg,
+			wantFound:  true,
+		},
+		{
+			structType: "custom.ProviderStruct",
+			fieldName:  "customField",
+			target:     composedReg2,
+			wantFound:  false,
+		},
+		{
+			structType: "google.expr.proto3.test.TestAllTypes",
+			fieldName:  "non_existent_field",
+			target:     composedReg,
+			wantFound:  false,
+		},
+		{
+			structType: "non.existent.Type",
+			fieldName:  "some_field",
+			target:     composedReg,
+			wantFound:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.structType+"."+tc.fieldName, func(t *testing.T) {
+			got, found := tc.target.FindFieldType(tc.structType, tc.fieldName)
+			if found != tc.wantFound {
+				t.Errorf("FindFieldType(%s, %s) found=%v, wanted %v", tc.structType, tc.fieldName, found, tc.wantFound)
+			}
+			if found && got == nil {
+				t.Errorf("FindFieldType(%s, %s) returned nil field type despite found=true", tc.structType, tc.fieldName)
+			}
+		})
+	}
+}
+
+func TestRegistry_FindStructFieldDescriptionEdgeCases(t *testing.T) {
+	customProv := &testCustomProvider{}
+	reg := newTestRegistry(t, ProtoTypeDefs(&proto3pb.TestAllTypes{}))
+
+	p, _, err := ComposeTypes(customProv, reg)
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	composedReg := p.(*Registry)
+
+	tests := []struct {
+		structType string
+		fieldName  string
+		wantFound  bool
+	}{
+		{
+			structType: "custom.ProviderStruct",
+			fieldName:  "customField",
+			wantFound:  true,
+		},
+		{
+			structType: "google.expr.proto3.test.TestAllTypes",
+			fieldName:  "non_existent_field",
+			wantFound:  false,
+		},
+		{
+			structType: "non.existent.Type",
+			fieldName:  "some_field",
+			wantFound:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.structType+"."+tc.fieldName, func(t *testing.T) {
+			_, found := composedReg.FindStructFieldDescription(tc.structType, tc.fieldName)
+			if found != tc.wantFound {
+				t.Errorf("FindStructFieldDescription(%s, %s) found=%v, wanted %v", tc.structType, tc.fieldName, found, tc.wantFound)
+			}
+		})
+	}
+}
+
+type testDummyStructDescriptor struct {
+	*Type
+	reflectType reflect.Type
+	fieldType   *FieldType
+}
+
+func (d *testDummyStructDescriptor) ReflectType() reflect.Type {
+	return d.reflectType
+}
+
+func (d *testDummyStructDescriptor) FieldNames() []string {
+	return []string{"DummyField"}
+}
+
+func (d *testDummyStructDescriptor) FindFieldType(fieldName string) (*FieldType, bool) {
+	if fieldName == "DummyField" {
+		return d.fieldType, true
+	}
+	return nil, false
+}
+
+func (d *testDummyStructDescriptor) NewValue(adapter Adapter, fields map[string]ref.Val) ref.Val {
+	return String("dummy_struct_new")
+}
+
+func (d *testDummyStructDescriptor) Adapt(adapter Adapter, value any) ref.Val {
+	return String("dummy_struct_adapted")
+}
+
+type testSimpleProvider struct{}
+
+func (p *testSimpleProvider) EnumValue(enumName string) ref.Val          { return NewErr("no enum") }
+func (p *testSimpleProvider) FindIdent(identName string) (ref.Val, bool) { return nil, false }
+func (p *testSimpleProvider) FindStructType(structType string) (*Type, bool) {
+	if structType == "simple.Struct" {
+		return NewTypeTypeWithParam(NewObjectType("simple.Struct")), true
+	}
+	return nil, false
+}
+func (p *testSimpleProvider) FindStructFieldNames(structType string) ([]string, bool) {
+	return nil, false
+}
+func (p *testSimpleProvider) FindStructFieldType(structType, fieldName string) (*FieldType, bool) {
+	if structType == "simple.Struct" && fieldName == "simpleField" {
+		return &FieldType{Type: StringType}, true
+	}
+	return nil, false
+}
+func (p *testSimpleProvider) NewValue(structType string, fields map[string]ref.Val) ref.Val {
+	return NewErr("no value")
+}
+
+func TestRegistry_FindStructDescriptorByReflectType(t *testing.T) {
+	reg, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+
+	st := &testDummyStructDescriptor{
+		Type:        NewObjectType("dummy.Struct"),
+		reflectType: reflect.TypeOf(dummyNativeStruct{}),
+		fieldType:   &FieldType{Type: StringType},
+	}
+
+	err = reg.RegisterType(st)
+	if err != nil {
+		t.Fatalf("RegisterType() failed: %v", err)
+	}
+
+	t.Run("Pointer lookup when registered as value", func(t *testing.T) {
+		val := reg.NativeToValue(&dummyNativeStruct{})
+		if IsError(val) || val.(String) != "dummy_struct_adapted" {
+			t.Errorf("NativeToValue(&dummyNativeStruct{}) = %v, wanted dummy_struct_adapted", val)
+		}
+	})
+
+	t.Run("Value lookup when registered as value", func(t *testing.T) {
+		val := reg.NativeToValue(dummyNativeStruct{})
+		if IsError(val) || val.(String) != "dummy_struct_adapted" {
+			t.Errorf("NativeToValue(dummyNativeStruct{}) = %v, wanted dummy_struct_adapted", val)
+		}
+	})
+
+	t.Run("Direct findStructDescriptorByReflectType tests", func(t *testing.T) {
+		pNil, foundNil := reg.findStructDescriptorByReflectType(nil)
+		if foundNil || pNil != nil {
+			t.Errorf("findStructDescriptorByReflectType(nil) expected false, got %v", foundNil)
+		}
+
+		// Manually set pointer-only key in reflectTypes
+		reg.reflectTypes[reflect.TypeOf(&dummyNativeStruct{})] = st
+		delete(reg.reflectTypes, reflect.TypeOf(dummyNativeStruct{}))
+
+		// Pass value type (kind != Ptr) -> hits else branch looking up PointerTo
+		stFound, foundVal := reg.findStructDescriptorByReflectType(reflect.TypeOf(dummyNativeStruct{}))
+		if !foundVal || stFound != st {
+			t.Errorf("findStructDescriptorByReflectType(value) expected st, got %v", stFound)
+		}
+
+		// Manually set value-only key in reflectTypes
+		reg.reflectTypes[reflect.TypeOf(dummyNativeStruct{})] = st
+		delete(reg.reflectTypes, reflect.TypeOf(&dummyNativeStruct{}))
+
+		// Pass pointer type (kind == Ptr) -> hits Ptr branch looking up Elem
+		stFound, foundPtr := reg.findStructDescriptorByReflectType(reflect.TypeOf(&dummyNativeStruct{}))
+		if !foundPtr || stFound != st {
+			t.Errorf("findStructDescriptorByReflectType(pointer) expected st, got %v", stFound)
+		}
+	})
+
+	t.Run("FindFieldType on registered StructTypeDescriptor", func(t *testing.T) {
+		ft, found := reg.FindFieldType("dummy.Struct", "DummyField")
+		if !found || ft == nil {
+			t.Fatalf("FindFieldType(dummy.Struct, DummyField) failed")
+		}
+	})
+
+	t.Run("Invalid field type conversion error", func(t *testing.T) {
+		stInvalid := &testDummyStructDescriptor{
+			Type:        NewObjectType("invalid.Struct"),
+			reflectType: reflect.TypeOf(customNativeType{}),
+			fieldType:   &FieldType{Type: &Type{}},
+		}
+		err := reg.RegisterType(stInvalid)
+		if err != nil {
+			t.Fatalf("RegisterType(stInvalid) failed: %v", err)
+		}
+		_, found := reg.FindFieldType("invalid.Struct", "DummyField")
+		if found {
+			t.Errorf("FindFieldType(invalid.Struct, DummyField) expected false due to TypeToExprType error, got true")
+		}
+	})
+}
+
+func TestRegistry_FindFieldType_SimpleProviderFallback(t *testing.T) {
+	baseReg, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() failed: %v", err)
+	}
+
+	simpleProv := &testSimpleProvider{}
+	p, _, err := ComposeTypes(simpleProv, baseReg)
+	if err != nil {
+		t.Fatalf("ComposeTypes() failed: %v", err)
+	}
+	composedReg := p.(*Registry)
+
+	t.Run("fallback to FindStructFieldType", func(t *testing.T) {
+		ft, found := composedReg.FindFieldType("simple.Struct", "simpleField")
+		if !found || ft == nil {
+			t.Fatalf("FindFieldType(simple.Struct, simpleField) failed on fallback provider")
+		}
+	})
+
+	t.Run("FindStructFieldDescription without interface", func(t *testing.T) {
+		_, found := composedReg.FindStructFieldDescription("simple.Struct", "simpleField")
+		if found {
+			t.Errorf("FindStructFieldDescription() on simpleProv expected false, got true")
+		}
+	})
+}
+
+func TestRegistry_NewRegistry_OptionErrors(t *testing.T) {
+	optErr := RegistryOption(func(r *Registry) (*Registry, error) {
+		return nil, fmt.Errorf("registry option error")
+	})
+
+	t.Run("NewProtoRegistry", func(t *testing.T) {
+		_, err := NewProtoRegistry(optErr)
+		if err == nil || err.Error() != "registry option error" {
+			t.Errorf("NewProtoRegistry() expected 'registry option error', got %v", err)
+		}
+	})
+
+	t.Run("NewRegistry", func(t *testing.T) {
+		_, err := NewRegistry(optErr)
+		if err == nil || err.Error() != "registry option error" {
+			t.Errorf("NewRegistry() expected 'registry option error', got %v", err)
+		}
+	})
+}
+
+func TestRegistry_RegisterTypeEdgeCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetType *Type
+	}{
+		{
+			name:       "conflicting traits",
+			targetType: NewTypeValue("bool", traits.ContainerType),
+		},
+		{
+			name:       "conflicting type definition",
+			targetType: NewObjectType("bool"),
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			reg, err := NewRegistry()
+			if err != nil {
+				t.Fatalf("NewRegistry() failed: %v", err)
+			}
+			err = reg.RegisterType(tc.targetType)
+			if err == nil {
+				t.Errorf("RegisterType() expected error, got nil")
+			}
+		})
+	}
 }

--- a/common/types/struct.go
+++ b/common/types/struct.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// StructTypeDescriptor describes a CEL struct type, providing field metadata and value instantiation.
+type StructTypeDescriptor interface {
+	// ReflectType returns the backing Go reflect.Type associated with the struct (or nil if non-reflected).
+	ReflectType() reflect.Type
+
+	// FieldNames returns the list of field names defined on the struct.
+	FieldNames() []string
+
+	// FindFieldType returns the field type and a boolean indicating if the field exists.
+	FindFieldType(fieldName string) (*FieldType, bool)
+
+	// NewValue creates a new CEL struct value from the given map of field values.
+	NewValue(adapter Adapter, fields map[string]ref.Val) ref.Val
+
+	// Adapt converts a native Go value (struct instance or pointer) to a CEL ref.Val.
+	Adapt(adapter Adapter, value any) ref.Val
+}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -2639,9 +2639,13 @@ func newTestEnv(t testing.TB, cont *containers.Container, reg *types.Registry) *
 
 func newTestRegistry(t testing.TB, opts ...types.RegistryOption) *types.Registry {
 	t.Helper()
-	reg, err := types.NewProtoRegistry(opts...)
+	var o []any
+	for _, opt := range opts {
+		o = append(o, opt)
+	}
+	reg, err := types.NewRegistry(o...)
 	if err != nil {
-		t.Fatalf("types.NewProtoRegistry() failed: %v", err)
+		t.Fatalf("types.NewRegistry() failed: %v", err)
 	}
 	return reg
 }


### PR DESCRIPTION
The `StructTypeDescriptor` interface allows structs to self-describe
their own fields, field types, value creation, as well as how they should
be adapted when their `reflect.Type` is encountered during data reads