### PR TITLE
Program plan optimizations

### DIFF
--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -4002,6 +4002,58 @@ func BenchmarkDynamicDispatch(b *testing.B) {
 	})
 }
 
+func BenchmarkProgramPlan(b *testing.B) {
+	env, err := NewEnv(
+		Variable("ai", IntType),
+		Variable("ar", MapType(StringType, StringType)),
+	)
+	if err != nil {
+		b.Fatalf("NewEnv() failed: %v", err)
+	}
+	astSimple, iss := env.Compile("ai == 20 || ar['foo'] == 'bar'")
+	if iss.Err() != nil {
+		b.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+	astOpt, iss := env.Compile("ai in [10, 20, 30] || 'foo' in ar")
+	if iss.Err() != nil {
+		b.Fatalf("env.Compile() failed: %v", iss.Err())
+	}
+
+	b.Run("Default", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := env.Program(astSimple)
+			if err != nil {
+				b.Fatalf("env.Program() failed: %v", err)
+			}
+		}
+	})
+
+	b.Run("OptimizeUnneeded", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := env.Program(astSimple, EvalOptions(OptOptimize))
+			if err != nil {
+				b.Fatalf("env.Program() failed: %v", err)
+			}
+		}
+	})
+
+	b.Run("OptimizeNeeded", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := env.Program(astOpt, EvalOptions(OptOptimize))
+			if err != nil {
+				b.Fatalf("env.Program() failed: %v", err)
+			}
+		}
+	})
+}
+
+
 func TestAstProgramNilValue(t *testing.T) {
 	var ast *Ast = nil
 	env := testEnv(t)

--- a/cel/cel_test.go
+++ b/cel/cel_test.go
@@ -4053,7 +4053,6 @@ func BenchmarkProgramPlan(b *testing.B) {
 	})
 }
 
-
 func TestAstProgramNilValue(t *testing.T) {
 	var ast *Ast = nil
 	env := testEnv(t)

--- a/cel/decls.go
+++ b/cel/decls.go
@@ -220,6 +220,10 @@ func ExcludeOverloads(overloadIDs ...string) OverloadSelector {
 // FunctionDecls provides one or more fully formed function declarations to be added to the environment.
 func FunctionDecls(funcs ...*decls.FunctionDecl) EnvOption {
 	return func(e *Env) (*Env, error) {
+		if len(funcs) == 0 {
+			return e, nil
+		}
+		e.ensureMutableFunctions()
 		var err error
 		for _, fn := range funcs {
 			if existing, found := e.functions[fn.Name()]; found {

--- a/cel/env.go
+++ b/cel/env.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/env"
+	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/stdlib"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -150,13 +151,23 @@ type Env struct {
 	validators      []ASTValidator
 	costOptions     []checker.CostOption
 
+	// Flags for copy-on-write behavior with env.Extend.
+	funcsShared           bool
+	featuresShared        bool
+	appliedFeaturesShared bool
+	limitsShared          bool
+	libsShared            bool
+
+	parent *Env
+
 	// sharedDispatcher caches a dispatcher populated with the env's function
 	// bindings, built once and reused across every Program() constructed from
 	// this env. It is read-only after construction; each Program layers a thin
-	// child over it for per-program Functions(). Zero in an extended env, so
-	// Extend() correctly rebuilds it.
-	dispOnce         sync.Once
+	// child over it for per-program Functions(). Extended envs reuse the parent's
+	// dispatcher if functions are unchanged.
 	sharedDispatcher interpreter.Dispatcher
+	dispOnce         sync.Once
+	hasAsync         bool
 	dispErr          error
 
 	// Internal parser representation
@@ -577,16 +588,6 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 		adapter = adapterReg.Copy()
 	}
 
-	featuresCopy := make(map[int]bool, len(e.features))
-	maps.Copy(featuresCopy, e.features)
-	appliedFeaturesCopy := make(map[int]bool, len(e.appliedFeatures))
-	maps.Copy(appliedFeaturesCopy, e.appliedFeatures)
-	limitsCopy := make(map[limitID]int, len(e.limits))
-	maps.Copy(limitsCopy, e.limits)
-	funcsCopy := make(map[string]*decls.FunctionDecl, len(e.functions))
-	maps.Copy(funcsCopy, e.functions)
-	libsCopy := make(map[string]SingletonLibrary, len(e.libraries))
-	maps.Copy(libsCopy, e.libraries)
 	validatorsCopy := make([]ASTValidator, len(e.validators))
 	copy(validatorsCopy, e.validators)
 
@@ -594,24 +595,66 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	copy(costOptsCopy, e.costOptions)
 
 	ext := &Env{
+		parent:          e,
 		Container:       e.Container,
 		variables:       varsCopy,
-		functions:       funcsCopy,
+		functions:       e.functions,
 		macros:          macsCopy,
 		contextProto:    e.contextProto,
 		progOpts:        progOptsCopy,
 		adapter:         adapter,
-		features:        featuresCopy,
-		limits:          limitsCopy,
-		appliedFeatures: appliedFeaturesCopy,
-		libraries:       libsCopy,
+		features:        e.features,
+		limits:          e.limits,
+		appliedFeatures: e.appliedFeatures,
+		libraries:       e.libraries,
 		validators:      validatorsCopy,
 		provider:        provider,
 		chkOpts:         chkOptsCopy,
 		prsrOpts:        prsrOptsCopy,
 		costOptions:     costOptsCopy,
+		// Copy-on-write flags.
+		funcsShared:           true,
+		featuresShared:        true,
+		limitsShared:          true,
+		appliedFeaturesShared: true,
+		libsShared:            true,
 	}
 	return ext.configure(opts)
+}
+
+func (e *Env) ensureMutableFunctions() {
+	if e.funcsShared {
+		e.functions = maps.Clone(e.functions)
+		e.funcsShared = false
+	}
+}
+
+func (e *Env) ensureMutableLibraries() {
+	if e.libsShared {
+		e.libraries = maps.Clone(e.libraries)
+		e.libsShared = false
+	}
+}
+
+func (e *Env) ensureMutableFeatures() {
+	if e.featuresShared {
+		e.features = maps.Clone(e.features)
+		e.featuresShared = false
+	}
+}
+
+func (e *Env) ensureMutableAppliedFeatures() {
+	if e.appliedFeaturesShared {
+		e.appliedFeatures = maps.Clone(e.appliedFeatures)
+		e.appliedFeaturesShared = false
+	}
+}
+
+func (e *Env) ensureMutableLimits() {
+	if e.limitsShared {
+		e.limits = maps.Clone(e.limits)
+		e.limitsShared = false
+	}
 }
 
 // HasFeature checks whether the environment enables the given feature
@@ -729,6 +772,41 @@ func (e *Env) PlanProgram(a *celast.AST, opts ...ProgramOption) (Program, error)
 		optSet = mergedOpts
 	}
 	return newProgram(e, a, optSet)
+}
+
+func (e *Env) initDispatcher() (interpreter.Dispatcher, bool, error) {
+	e.dispOnce.Do(func() {
+		if e.parent != nil && e.funcsShared {
+			// The dispatcher setup is skipped when the child has mutated the function set.
+			// As the child function set contains a copy of all parent function declarations
+			// by virtue of copy on write semantics.
+			d, hasAsync, err := e.parent.initDispatcher()
+			e.sharedDispatcher = d
+			e.hasAsync = hasAsync
+			e.dispErr = err
+			return
+		}
+		hasAsync := false
+		var bindings []*functions.Overload
+		for _, fn := range e.functions {
+			bs, err := fn.Bindings()
+			if err != nil {
+				e.dispErr = err
+				return
+			}
+			for _, b := range bs {
+				if b.Async != nil {
+					hasAsync = true
+				}
+			}
+			bindings = append(bindings, bs...)
+		}
+		d := interpreter.NewDispatcher()
+		e.dispErr = d.Add(bindings...)
+		e.sharedDispatcher = d
+		e.hasAsync = hasAsync
+	})
+	return e.sharedDispatcher, e.hasAsync, e.dispErr
 }
 
 // CELTypeAdapter returns the `types.Adapter` configured for the environment.
@@ -856,6 +934,7 @@ func (e *Env) configure(opts []EnvOption) (*Env, error) {
 	// If the default UTC timezone has been disabled, configure the legacy overloads
 	if utcTime, isSet := e.features[featureDefaultUTCTimeZone]; isSet && !utcTime {
 		if !e.appliedFeatures[featureDefaultUTCTimeZone] {
+			e.ensureMutableAppliedFeatures()
 			e.appliedFeatures[featureDefaultUTCTimeZone] = true
 			e, err = Lib(timeLegacyLibrary{})(e)
 			if err != nil {

--- a/cel/env.go
+++ b/cel/env.go
@@ -17,6 +17,7 @@ package cel
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"slices"
 	"strings"
@@ -29,7 +30,6 @@ import (
 	"github.com/google/cel-go/common/containers"
 	"github.com/google/cel-go/common/decls"
 	"github.com/google/cel-go/common/env"
-	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/stdlib"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
@@ -149,9 +149,6 @@ type Env struct {
 	libraries       map[string]SingletonLibrary
 	validators      []ASTValidator
 	costOptions     []checker.CostOption
-
-	funcBindOnce     sync.Once
-	functionBindings []*functions.Overload
 
 	// sharedDispatcher caches a dispatcher populated with the env's function
 	// bindings, built once and reused across every Program() constructed from
@@ -379,20 +376,19 @@ func NewCustomEnv(opts ...EnvOption) (*Env, error) {
 		return nil, err
 	}
 	return (&Env{
-		variables:        []*decls.VariableDecl{},
-		functions:        map[string]*decls.FunctionDecl{},
-		functionBindings: []*functions.Overload{},
-		macros:           []parser.Macro{},
-		Container:        containers.DefaultContainer,
-		adapter:          registry,
-		provider:         registry,
-		features:         map[int]bool{},
-		appliedFeatures:  map[int]bool{},
-		limits:           map[limitID]int{},
-		libraries:        map[string]SingletonLibrary{},
-		validators:       []ASTValidator{},
-		progOpts:         []ProgramOption{},
-		costOptions:      []checker.CostOption{},
+		variables:       []*decls.VariableDecl{},
+		functions:       map[string]*decls.FunctionDecl{},
+		macros:          []parser.Macro{},
+		Container:       containers.DefaultContainer,
+		adapter:         registry,
+		provider:        registry,
+		features:        map[int]bool{},
+		appliedFeatures: map[int]bool{},
+		limits:          map[limitID]int{},
+		libraries:       map[string]SingletonLibrary{},
+		validators:      []ASTValidator{},
+		progOpts:        []ProgramOption{},
+		costOptions:     []checker.CostOption{},
 	}).configure(opts)
 }
 
@@ -582,25 +578,15 @@ func (e *Env) Extend(opts ...EnvOption) (*Env, error) {
 	}
 
 	featuresCopy := make(map[int]bool, len(e.features))
-	for k, v := range e.features {
-		featuresCopy[k] = v
-	}
+	maps.Copy(featuresCopy, e.features)
 	appliedFeaturesCopy := make(map[int]bool, len(e.appliedFeatures))
-	for k, v := range e.appliedFeatures {
-		appliedFeaturesCopy[k] = v
-	}
+	maps.Copy(appliedFeaturesCopy, e.appliedFeatures)
 	limitsCopy := make(map[limitID]int, len(e.limits))
-	for k, v := range e.limits {
-		limitsCopy[k] = v
-	}
+	maps.Copy(limitsCopy, e.limits)
 	funcsCopy := make(map[string]*decls.FunctionDecl, len(e.functions))
-	for k, v := range e.functions {
-		funcsCopy[k] = v
-	}
+	maps.Copy(funcsCopy, e.functions)
 	libsCopy := make(map[string]SingletonLibrary, len(e.libraries))
-	for k, v := range e.libraries {
-		libsCopy[k] = v
-	}
+	maps.Copy(libsCopy, e.libraries)
 	validatorsCopy := make([]ASTValidator, len(e.validators))
 	copy(validatorsCopy, e.validators)
 

--- a/cel/env.go
+++ b/cel/env.go
@@ -153,6 +153,15 @@ type Env struct {
 	funcBindOnce     sync.Once
 	functionBindings []*functions.Overload
 
+	// sharedDispatcher caches a dispatcher populated with the env's function
+	// bindings, built once and reused across every Program() constructed from
+	// this env. It is read-only after construction; each Program layers a thin
+	// child over it for per-program Functions(). Zero in an extended env, so
+	// Extend() correctly rebuilds it.
+	dispOnce         sync.Once
+	sharedDispatcher interpreter.Dispatcher
+	dispErr          error
+
 	// Internal parser representation
 	prsr     *parser.Parser
 	prsrOpts []parser.Option

--- a/cel/library.go
+++ b/cel/library.go
@@ -98,6 +98,7 @@ func Lib(l Library) EnvOption {
 			if e.HasLibrary(singleton.LibraryName()) {
 				return e, nil
 			}
+			e.ensureMutableLibraries()
 			e.libraries[singleton.LibraryName()] = singleton
 		}
 		var err error

--- a/cel/options.go
+++ b/cel/options.go
@@ -977,6 +977,7 @@ func DefaultUTCTimeZone(enabled bool) EnvOption {
 // features sets the given feature flags.  See list of Feature constants above.
 func features(flag int, enabled bool) EnvOption {
 	return func(e *Env) (*Env, error) {
+		e.ensureMutableFeatures()
 		e.features[flag] = enabled
 		return e, nil
 	}
@@ -987,6 +988,7 @@ func setLimit(id limitID, limit int) EnvOption {
 		limit = -1
 	}
 	return func(e *Env) (*Env, error) {
+		e.ensureMutableLimits()
 		e.limits[id] = limit
 		return e, nil
 	}

--- a/cel/program.go
+++ b/cel/program.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/cel-go/cel/async"
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/functions"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
@@ -200,33 +202,39 @@ type prog struct {
 	asyncMaxConcurrency       int
 }
 
+// scanOptTargets walks the AST once and reports whether the Optimize()
+// decorator (needOpt) and the regex-constant compiler (needRegex) have any
+// target node present. The conditions are a superset of what each decorator
+// acts on, so a false negative — skipping a decorator that would have
+// optimized something — is impossible.
+func scanOptTargets(root ast.Expr) (needOpt, needRegex bool) {
+	ast.PostOrderVisit(root, ast.NewExprVisitor(func(e ast.Expr) {
+		switch e.Kind() {
+		case ast.ListKind, ast.MapKind:
+			needOpt = true // maybeBuildListLiteral / maybeBuildMapLiteral
+		case ast.CallKind:
+			switch fn := e.AsCall().FunctionName(); {
+			case fn == overloads.Matches:
+				needRegex = true
+			case fn == operators.In || fn == operators.OldIn:
+				needOpt = true // maybeOptimizeSetMembership
+			case overloads.IsTypeConversionFunction(fn):
+				needOpt = true // maybeOptimizeConstUnary
+			}
+		}
+	}))
+	return
+}
+
 // newProgram creates a program instance with an environment, an ast, and an optional list of
 // ProgramOption values.
 //
 // If the program cannot be configured the prog will be nil, with a non-nil error response.
 func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
-	// Build the dispatcher, interpreter, and default program value.
-	disp := interpreter.NewDispatcher()
-
-	// Ensure the default attribute factory is set after the adapter and provider are
-	// configured.
-	p := &prog{
-		Env:            e,
-		plannerOptions: []interpreter.PlannerOption{},
-		dispatcher:     disp,
-		costOptions:    []interpreter.CostTrackerOption{},
-		drainStrategy:  async.DrainReady(100 * time.Microsecond),
-	}
-
-	// Configure the program via the ProgramOption values.
+	// Build the env's function bindings once (a pure function of the env). This
+	// is moved ahead of the ProgramOption loop so the shared dispatcher can be
+	// assembled before per-program Functions() options add to its child.
 	var err error
-	for _, opt := range opts {
-		p, err = opt(p)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	e.funcBindOnce.Do(func() {
 		var bindings []*functions.Overload
 		e.functionBindings = []*functions.Overload{}
@@ -242,10 +250,38 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 		return nil, err
 	}
 
-	// Add the function bindings created via Function() options.
-	err = disp.Add(e.functionBindings...)
-	if err != nil {
-		return nil, err
+	// Build the dispatcher, interpreter, and default program value. The
+	// dispatcher holding the env's function bindings is a pure function of the
+	// env, identical across every Program() built from it, and read-only during
+	// planning — so assemble it once per env and layer a thin child over it here
+	// for per-program Functions() isolation, rather than re-indexing the ~100
+	// standard-library overloads on every Program() call.
+	e.dispOnce.Do(func() {
+		d := interpreter.NewDispatcher()
+		e.dispErr = d.Add(e.functionBindings...)
+		e.sharedDispatcher = d
+	})
+	if e.dispErr != nil {
+		return nil, e.dispErr
+	}
+	disp := interpreter.ExtendDispatcher(e.sharedDispatcher)
+
+	// Ensure the default attribute factory is set after the adapter and provider are
+	// configured.
+	p := &prog{
+		Env:            e,
+		plannerOptions: []interpreter.PlannerOption{},
+		dispatcher:     disp,
+		costOptions:    []interpreter.CostTrackerOption{},
+		drainStrategy:  async.DrainReady(100 * time.Microsecond),
+	}
+
+	// Configure the program via the ProgramOption values.
+	for _, opt := range opts {
+		p, err = opt(p)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Determine whether the environment declares any asynchronous function. Async is a property of
@@ -288,8 +324,21 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 	}
 	// Enable constant folding first.
 	if p.evalOpts&OptOptimize == OptOptimize {
-		plannerOptions = append(plannerOptions, interpreter.Optimize())
-		p.regexOptimizations = append(p.regexOptimizations, interpreter.MatchesRegexOptimization)
+		// The Optimize() decorator (set-membership, constant list/map literals,
+		// const type conversions) and the regex-constant compiler each walk
+		// every planned node. When the AST provably contains no node they can
+		// act on, adding them is pure overhead — so gate each on a single AST
+		// scan. The scan condition is a superset of what the decorators touch,
+		// so a decorator is only skipped when its target node is definitely
+		// absent and evaluation is never affected (an ungated regex would
+		// recompile per eval, etc.).
+		addOptimize, addRegex := scanOptTargets(a.Expr())
+		if addOptimize {
+			plannerOptions = append(plannerOptions, interpreter.Optimize())
+		}
+		if addRegex {
+			p.regexOptimizations = append(p.regexOptimizations, interpreter.MatchesRegexOptimization)
+		}
 	}
 	// Enable regex compilation of constants immediately after folding constants.
 	if len(p.regexOptimizations) > 0 {

--- a/cel/program.go
+++ b/cel/program.go
@@ -231,34 +231,33 @@ func scanOptTargets(root ast.Expr) (needOpt, needRegex bool) {
 //
 // If the program cannot be configured the prog will be nil, with a non-nil error response.
 func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
-	// Build the env's function bindings once (a pure function of the env). This
-	// is moved ahead of the ProgramOption loop so the shared dispatcher can be
-	// assembled before per-program Functions() options add to its child.
-	var err error
-	e.funcBindOnce.Do(func() {
+	// Build the env's function bindings and shared dispatcher once (pure functions of the
+	// env). The dispatcher holding the env's function bindings is identical across every
+	// Program() built from it and read-only during planning — so assemble it once per env
+	// and layer a thin child over it here for per-program Functions() isolation, rather than
+	// re-indexing overloads on every Program() call.
+	hasAsync := false
+	e.dispOnce.Do(func() {
 		var bindings []*functions.Overload
-		e.functionBindings = []*functions.Overload{}
 		for _, fn := range e.functions {
-			bindings, err = fn.Bindings()
+			bs, err := fn.Bindings()
 			if err != nil {
+				e.dispErr = err
 				return
 			}
-			e.functionBindings = append(e.functionBindings, bindings...)
+			// Determine whether the environment declares any asynchronous function. Async is a property of
+			// the binding, so its presence is known from the environment alone, without inspecting the
+			// program plan. The synchronous entry points (Eval, ContextEval) reject programs from an env
+			// with async functions; callers needing synchronous evaluation should use a non-async env.
+			for _, b := range bs {
+				if b.Async != nil {
+					hasAsync = true
+				}
+			}
+			bindings = append(bindings, bs...)
 		}
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Build the dispatcher, interpreter, and default program value. The
-	// dispatcher holding the env's function bindings is a pure function of the
-	// env, identical across every Program() built from it, and read-only during
-	// planning — so assemble it once per env and layer a thin child over it here
-	// for per-program Functions() isolation, rather than re-indexing the ~100
-	// standard-library overloads on every Program() call.
-	e.dispOnce.Do(func() {
 		d := interpreter.NewDispatcher()
-		e.dispErr = d.Add(e.functionBindings...)
+		e.dispErr = d.Add(bindings...)
 		e.sharedDispatcher = d
 	})
 	if e.dispErr != nil {
@@ -274,24 +273,15 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 		dispatcher:     disp,
 		costOptions:    []interpreter.CostTrackerOption{},
 		drainStrategy:  async.DrainReady(100 * time.Microsecond),
+		hasAsync:       hasAsync,
 	}
 
 	// Configure the program via the ProgramOption values.
+	var err error
 	for _, opt := range opts {
 		p, err = opt(p)
 		if err != nil {
 			return nil, err
-		}
-	}
-
-	// Determine whether the environment declares any asynchronous function. Async is a property of
-	// the binding, so its presence is known from the environment alone, without inspecting the
-	// program plan. The synchronous entry points (Eval, ContextEval) reject programs from an env
-	// with async functions; callers needing synchronous evaluation should use a non-async env.
-	for _, b := range e.functionBindings {
-		if b.Async != nil {
-			p.hasAsync = true
-			break
 		}
 	}
 

--- a/cel/program.go
+++ b/cel/program.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/cel-go/cel/async"
 	"github.com/google/cel-go/common/ast"
-	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/overloads"
 	"github.com/google/cel-go/common/types"
@@ -236,34 +235,11 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 	// Program() built from it and read-only during planning — so assemble it once per env
 	// and layer a thin child over it here for per-program Functions() isolation, rather than
 	// re-indexing overloads on every Program() call.
-	hasAsync := false
-	e.dispOnce.Do(func() {
-		var bindings []*functions.Overload
-		for _, fn := range e.functions {
-			bs, err := fn.Bindings()
-			if err != nil {
-				e.dispErr = err
-				return
-			}
-			// Determine whether the environment declares any asynchronous function. Async is a property of
-			// the binding, so its presence is known from the environment alone, without inspecting the
-			// program plan. The synchronous entry points (Eval, ContextEval) reject programs from an env
-			// with async functions; callers needing synchronous evaluation should use a non-async env.
-			for _, b := range bs {
-				if b.Async != nil {
-					hasAsync = true
-				}
-			}
-			bindings = append(bindings, bs...)
-		}
-		d := interpreter.NewDispatcher()
-		e.dispErr = d.Add(bindings...)
-		e.sharedDispatcher = d
-	})
-	if e.dispErr != nil {
-		return nil, e.dispErr
+	sharedDisp, hasAsync, err := e.initDispatcher()
+	if err != nil {
+		return nil, err
 	}
-	disp := interpreter.ExtendDispatcher(e.sharedDispatcher)
+	disp := interpreter.ExtendDispatcher(sharedDisp)
 
 	// Ensure the default attribute factory is set after the adapter and provider are
 	// configured.
@@ -277,7 +253,6 @@ func newProgram(e *Env, a *ast.AST, opts []ProgramOption) (Program, error) {
 	}
 
 	// Configure the program via the ProgramOption values.
-	var err error
 	for _, opt := range opts {
 		p, err = opt(p)
 		if err != nil {

--- a/common/decls/decls.go
+++ b/common/decls/decls.go
@@ -78,6 +78,9 @@ type FunctionDecl struct {
 
 	// overloadOrdinals indicates the order in which the overload was declared.
 	overloadOrdinals []string
+
+	// overloadDecls caches the slice of overloads in declaration order.
+	overloadDecls []*OverloadDecl
 }
 
 type declarationState int
@@ -151,7 +154,8 @@ func (f *FunctionDecl) Merge(other *FunctionDecl) (*FunctionDecl, error) {
 		name:             f.Name(),
 		overloads:        make(map[string]*OverloadDecl, len(f.overloads)),
 		singleton:        f.singleton,
-		overloadOrdinals: make([]string, len(f.overloads)),
+		overloadOrdinals: make([]string, len(f.overloadOrdinals)),
+		overloadDecls:    make([]*OverloadDecl, len(f.overloadDecls)),
 		// if one function is expecting type-guards and the other is not, then they
 		// must not be disabled.
 		disableTypeGuards: f.disableTypeGuards && other.disableTypeGuards,
@@ -170,6 +174,7 @@ func (f *FunctionDecl) Merge(other *FunctionDecl) (*FunctionDecl, error) {
 	}
 	// baseline copy of the overloads and their ordinals
 	copy(merged.overloadOrdinals, f.overloadOrdinals)
+	copy(merged.overloadDecls, f.overloadDecls)
 	for oID, o := range f.overloads {
 		merged.overloads[oID] = o
 	}
@@ -232,11 +237,13 @@ func (f *FunctionDecl) Subset(selector OverloadSelector) *FunctionDecl {
 	}
 	overloads := make(map[string]*OverloadDecl)
 	overloadOrdinals := make([]string, 0, len(f.overloadOrdinals))
+	overloadDecls := make([]*OverloadDecl, 0, len(f.overloadDecls))
 	for _, oID := range f.overloadOrdinals {
 		overload := f.overloads[oID]
 		if selector(overload) {
 			overloads[oID] = overload
 			overloadOrdinals = append(overloadOrdinals, oID)
+			overloadDecls = append(overloadDecls, overload)
 		}
 	}
 	if len(overloads) == 0 {
@@ -250,6 +257,7 @@ func (f *FunctionDecl) Subset(selector OverloadSelector) *FunctionDecl {
 		disableTypeGuards: f.disableTypeGuards,
 		state:             f.state,
 		overloadOrdinals:  overloadOrdinals,
+		overloadDecls:     overloadDecls,
 	}
 	return subset
 }
@@ -273,6 +281,12 @@ func (f *FunctionDecl) AddOverload(overload *OverloadDecl) error {
 				// Allow redefinition of an overload implementation so long as the signatures match.
 				if overload.HasBinding() {
 					f.overloads[oID] = overload
+					for i, decl := range f.overloadDecls {
+						if decl.ID() == oID {
+							f.overloadDecls[i] = overload
+							break
+						}
+					}
 				}
 				// Allow redefinition of the doc string.
 				if len(overload.doc) != 0 && o.doc != overload.doc {
@@ -288,20 +302,16 @@ func (f *FunctionDecl) AddOverload(overload *OverloadDecl) error {
 	}
 	f.overloadOrdinals = append(f.overloadOrdinals, overload.ID())
 	f.overloads[overload.ID()] = overload
+	f.overloadDecls = append(f.overloadDecls, overload)
 	return nil
 }
 
 // OverloadDecls returns the overload declarations in the order in which they were declared.
 func (f *FunctionDecl) OverloadDecls() []*OverloadDecl {
-	var emptySet []*OverloadDecl
 	if f == nil {
-		return emptySet
+		return nil
 	}
-	overloads := make([]*OverloadDecl, 0, len(f.overloads))
-	for _, oID := range f.overloadOrdinals {
-		overloads = append(overloads, f.overloads[oID])
-	}
-	return overloads
+	return f.overloadDecls
 }
 
 // HasSingletonBinding indicates whether the function has a singleton binding definition.


### PR DESCRIPTION
A significant amount of overhead comes from the instantiation of the dispatcher
with an immutable set of functions. Instead of recreating the dispatcher, create
a shared one across program instances.

Additionally, check whether optimizations are needed for an expression before
applying them as decorators.

| Benchmark Case | Before (ns/op) | After (ns/op) | Δ Time | Before (B/op) | After (B/op) | Δ Memory | Before (allocs) | After (allocs) | Δ Allocs | 
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | 
| BenchmarkProgramPlan/Default | 8,153 | 930 | **-88.6%** | 8,320 | 1,416 | **-83.0%** | 36 | 26 | **-27.8%** |
| BenchmarkProgramPlan/OptimizeUnneeded | 7,344 | 1,150 | **-84.3%** | 8,784 | 1,512 | **-82.8%** | 50 | 32 | **-36.0%** | 
| BenchmarkProgramPlan/OptimizeNeeded | 8,370 | 2,164 | **-74.1%** | 10,224 | 2,976 | **-70.9%** | 67 | 52 | **-22.4%** |

Addresses the dispatcher-sharing proposed in #1397, which is the first half of the optimizations suggested to minimize startup costs.